### PR TITLE
feat(ci): auto-publish to npm on release + fix docs links

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,29 @@ jobs:
   release:
     name: Release Please
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - id: release
+        uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Publish to npm
+    needs: release
+    if: needs.release.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+          registry-url: https://registry.npmjs.org
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+      - run: yarn test:ci
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/.vitepress/theme/components/HeroSection.vue
+++ b/docs/.vitepress/theme/components/HeroSection.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { VPButton } from "vitepress/theme";
+import { withBase } from "vitepress";
 </script>
 
 <template>
@@ -19,7 +20,7 @@ import { VPButton } from "vitepress/theme";
 					tag="a"
 					size="medium"
 					theme="brand"
-					href="/review-flow/guide/quick-start"
+					:href="withBase('/guide/quick-start')"
 					text="Get Started"
 				/>
 				<VPButton

--- a/docs/.vitepress/theme/components/QuickStart.vue
+++ b/docs/.vitepress/theme/components/QuickStart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { VPButton } from "vitepress/theme";
+import { withBase } from "vitepress";
 
 interface Step {
 	number: number;
@@ -41,7 +42,7 @@ const steps: Step[] = [
 				tag="a"
 				size="medium"
 				theme="alt"
-				href="/review-flow/guide/quick-start"
+				:href="withBase('/guide/quick-start')"
 				text="View Full Quick Start →"
 			/>
 		</div>


### PR DESCRIPTION
## Summary
- Add `publish` job to release workflow that auto-publishes to npm when release-please creates a new release
- Fix hardcoded `/review-flow/` prefix in docs Vue components (HeroSection, QuickStart) — use `withBase()` to prevent double-prefix 404s

## Setup required
Add `NPM_TOKEN` secret in **Settings → Secrets → Actions** with a granular npm access token.

## Test plan
- [ ] Verify CI passes on this PR
- [ ] After merge, confirm release-please PR does not trigger npm publish (no release created)
- [ ] On next release, confirm npm publish job runs
- [ ] Verify docs links resolve correctly after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)