### PR TITLE
fix(docs): replace broken README links with VitePress URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Node.js](https://img.shields.io/badge/Node.js-%3E%3D20-green.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.8-blue.svg)](https://www.typescriptlang.org/)
+[![Documentation](https://img.shields.io/badge/Docs-VitePress-646cff.svg)](https://dgouron.github.io/review-flow/)
 
 Automated AI code reviews powered by [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Assign a reviewer on your merge request — Claude reviews the code, tracks progress in real time, and follows up when you push fixes.
 
@@ -152,9 +153,9 @@ reviewflow start
 # Dashboard at http://localhost:3847
 ```
 
-Then [configure a webhook](docs/QUICKSTART.md) on your GitLab/GitHub project pointing to your server.
+Then [configure a webhook](https://dgouron.github.io/review-flow/guide/quick-start) on your GitLab/GitHub project pointing to your server.
 
-For detailed setup, see the **[Quick Start Guide](docs/QUICKSTART.md)**.
+For detailed setup, see the **[Quick Start Guide](https://dgouron.github.io/review-flow/guide/quick-start)**.
 
 ---
 
@@ -162,15 +163,14 @@ For detailed setup, see the **[Quick Start Guide](docs/QUICKSTART.md)**.
 
 | Topic | Link |
 |-------|------|
-| Quick Start | [docs/QUICKSTART.md](docs/QUICKSTART.md) |
-| Configuration Reference | [docs/CONFIG-REFERENCE.md](docs/CONFIG-REFERENCE.md) |
-| Project Configuration | [docs/PROJECT_CONFIG.md](docs/PROJECT_CONFIG.md) |
-| Review Skills Guide | [docs/REVIEW-SKILLS-GUIDE.md](docs/REVIEW-SKILLS-GUIDE.md) |
-| MCP Tools Reference | [docs/MCP-TOOLS-REFERENCE.md](docs/MCP-TOOLS-REFERENCE.md) |
-| Architecture | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) |
-| Deployment | [docs/deployment/README.md](docs/deployment/README.md) |
-| Troubleshooting | [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) |
-| Full Documentation Index | [docs/INDEX.md](docs/INDEX.md) |
+| Quick Start | [guide/quick-start](https://dgouron.github.io/review-flow/guide/quick-start) |
+| Configuration Reference | [reference/config](https://dgouron.github.io/review-flow/reference/config) |
+| Project Configuration | [guide/project-config](https://dgouron.github.io/review-flow/guide/project-config) |
+| Review Skills Guide | [guide/review-skills](https://dgouron.github.io/review-flow/guide/review-skills) |
+| MCP Tools Reference | [reference/mcp-tools](https://dgouron.github.io/review-flow/reference/mcp-tools) |
+| Architecture | [architecture](https://dgouron.github.io/review-flow/architecture/) |
+| Deployment | [deployment](https://dgouron.github.io/review-flow/deployment/) |
+| Troubleshooting | [guide/troubleshooting](https://dgouron.github.io/review-flow/guide/troubleshooting) |
 
 ---
 

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -14,15 +14,26 @@ Get Reviewflow running in 5 minutes.
 
 ## 1. Installation
 
+### As a user (recommended)
+
 ```bash
-# Clone the repository
-git clone https://github.com/YOUR_USERNAME/reviewflow.git
-cd reviewflow
+npm install -g reviewflow
+# or
+yarn global add reviewflow
+```
 
-# Install dependencies
+You can also run it without installing:
+
+```bash
+npx reviewflow start
+```
+
+### As a contributor
+
+```bash
+git clone https://github.com/DGouron/review-flow.git
+cd review-flow
 yarn install
-
-# Build
 yarn build
 ```
 
@@ -31,8 +42,9 @@ yarn build
 ### Environment variables
 
 ```bash
-# Copy the example
-cp .env.example .env
+# Create your .env from the bundled template
+cp node_modules/reviewflow/templates/.env.example .env 2>/dev/null \
+  || cp .env.example .env
 
 # Edit with your webhook secrets
 # Generate tokens with: openssl rand -hex 32
@@ -48,8 +60,9 @@ GITHUB_WEBHOOK_SECRET=your_generated_token_here
 ### Application config
 
 ```bash
-# Copy the example
-cp config.example.json config.json
+# Create your config from the bundled template
+cp node_modules/reviewflow/templates/config.json.template config.json 2>/dev/null \
+  || cp config.example.json config.json
 
 # Edit with your settings
 nano config.json
@@ -75,6 +88,14 @@ nano config.json
 ```
 
 ## 3. Start the server
+
+### Global install
+
+```bash
+reviewflow start
+```
+
+### Contributor mode
 
 ```bash
 # Development mode (with hot reload)
@@ -130,7 +151,7 @@ ngrok http 3000
 1. Create or open a Merge Request / Pull Request
 2. Assign yourself as **Reviewer**
 3. Open `http://localhost:3000/dashboard/`
-4. Watch the review appear! 🎉
+4. Watch the review appear!
 
 ## Next steps
 


### PR DESCRIPTION
## Summary

- **Fixed 9 broken documentation links** in README.md — all pointed to non-existent `docs/*.md` files, now point to the deployed VitePress site at `https://dgouron.github.io/review-flow/`
- **Added Documentation badge** to README header
- **Updated Quick Start guide** (`docs/guide/quick-start.md`) to show `npm install -g reviewflow` as primary install path, with `git clone` as contributor alternative
- **Removed "Full Documentation Index" row** from README table (redundant with VitePress nav)

## Test plan

- [ ] Verify all 10 VitePress URLs in README resolve (badge + 2 inline + 8 table)
- [ ] Verify `yarn docs:build` passes
- [ ] Check quick-start renders correctly on VitePress site

🤖 Generated with [Claude Code](https://claude.com/claude-code)