### PR TITLE
fix(cli): resolve symlinks for global npm install detection

### DIFF
--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, realpathSync } from 'node:fs';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseCliArgs } from '../cli/parseCliArgs.js';
@@ -236,7 +236,7 @@ function createPidFileDeps() {
 
 const isDirectlyExecuted =
   process.argv[1] &&
-  resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  realpathSync(resolve(process.argv[1])) === fileURLToPath(import.meta.url);
 
 if (isDirectlyExecuted) {
   const args = parseCliArgs(process.argv.slice(2));


### PR DESCRIPTION
## Summary
- **Bug**: `reviewflow` CLI silently does nothing when installed globally via `npm install -g reviewflow`
- **Root cause**: `resolve()` doesn't follow symlinks — npm global bin creates a symlink, so `process.argv[1]` (symlink path) never matches `import.meta.url` (real file path)
- **Fix**: Use `realpathSync()` to resolve the symlink before comparing paths

## Test plan
- [ ] `npm install -g reviewflow` then run `reviewflow --help` — should print help
- [ ] `reviewflow --version` — should print version
- [ ] `reviewflow start` — should start the server
- [ ] `yarn dev` still works (no regression on local dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)