### PR TITLE
feat(cli): add reviewflow init wizard and validate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,37 +125,62 @@ Review behavior is defined by [Claude Code skills](https://docs.anthropic.com/en
 
 ## Quick Start
 
-### Install globally
+### 1. Install
 
 ```bash
 npm install -g reviewflow
-# or
-yarn global add reviewflow
 ```
 
-### Or run directly with npx
+### 2. Initialize
 
 ```bash
-npx reviewflow --help
-npx reviewflow start
+reviewflow init
 ```
 
-### Configure & run
+The interactive wizard will:
+- Configure server port and usernames
+- Generate webhook secrets
+- Scan your filesystem for git repositories
+- Set up MCP server integration with Claude Code
+
+For non-interactive setup: `reviewflow init --yes`
+
+### 3. Start
 
 ```bash
-# Configure
-cp .env.example .env
-cp config.example.json config.json
-# Edit config.json with your repositories
-
-# Start the server
 reviewflow start
 # Dashboard at http://localhost:3847
 ```
 
 Then [configure a webhook](https://dgouron.github.io/review-flow/guide/quick-start) on your GitLab/GitHub project pointing to your server.
 
+### Validate your setup
+
+```bash
+reviewflow validate
+```
+
 For detailed setup, see the **[Quick Start Guide](https://dgouron.github.io/review-flow/guide/quick-start)**.
+
+---
+
+## CLI Reference
+
+| Command | Description |
+|---------|-------------|
+| `reviewflow init` | Interactive setup wizard |
+| `reviewflow start` | Start the review server |
+| `reviewflow stop` | Stop the running daemon |
+| `reviewflow status` | Show server status |
+| `reviewflow logs` | Show daemon logs |
+| `reviewflow validate` | Validate configuration |
+
+| Init Flag | Description |
+|-----------|-------------|
+| `-y, --yes` | Accept all defaults (non-interactive) |
+| `--skip-mcp` | Skip MCP server configuration |
+| `--show-secrets` | Display full webhook secrets |
+| `--scan-path <path>` | Custom scan path (repeatable) |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "@fastify/static": "^8.0.0",
     "@fastify/websocket": "^11.0.0",
+    "@inquirer/prompts": "^8.2.0",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "dotenv": "^16.4.0",
     "fastify": "^5.0.0",

--- a/src/cli/formatters/initSummary.ts
+++ b/src/cli/formatters/initSummary.ts
@@ -1,0 +1,46 @@
+export interface InitSummaryInput {
+  configPath: string;
+  envPath: string;
+  port: number;
+  repositoryCount: number;
+  mcpStatus: 'configured' | 'already-configured' | 'claude-not-found' | 'skipped' | 'failed';
+  gitlabUsername: string;
+  githubUsername: string;
+}
+
+function mcpLine(status: InitSummaryInput['mcpStatus']): string {
+  switch (status) {
+    case 'configured':
+      return '  MCP server:    configured';
+    case 'already-configured':
+      return '  MCP server:    already configured';
+    case 'claude-not-found':
+      return '  MCP server:    skipped (Claude CLI not found)';
+    case 'skipped':
+      return '  MCP server:    skipped by user';
+    case 'failed':
+      return '  MCP server:    configuration failed';
+  }
+}
+
+export function formatInitSummary(input: InitSummaryInput): string {
+  const lines: string[] = [
+    '',
+    'ReviewFlow initialized successfully!',
+    '',
+    'Configuration:',
+    `  Config file:   ${input.configPath}`,
+    `  Env file:      ${input.envPath}`,
+    `  Port:          ${input.port}`,
+    `  Repositories:  ${input.repositoryCount}`,
+    mcpLine(input.mcpStatus),
+    '',
+    'Next steps:',
+    '  1. Configure webhook secrets on your GitLab/GitHub projects',
+    '  2. Start the server: reviewflow start',
+    '  3. Check status:     reviewflow validate',
+    '',
+  ];
+
+  return lines.join('\n');
+}

--- a/src/cli/parseCliArgs.ts
+++ b/src/cli/parseCliArgs.ts
@@ -22,6 +22,19 @@ interface LogsArgs {
   lines: number;
 }
 
+interface InitArgs {
+  command: 'init';
+  yes: boolean;
+  skipMcp: boolean;
+  showSecrets: boolean;
+  scanPaths: string[];
+}
+
+interface ValidateArgs {
+  command: 'validate';
+  fix: boolean;
+}
+
 interface VersionArgs {
   command: 'version';
 }
@@ -30,9 +43,9 @@ interface HelpArgs {
   command: 'help';
 }
 
-export type CliArgs = StartArgs | StopArgs | StatusArgs | LogsArgs | VersionArgs | HelpArgs;
+export type CliArgs = StartArgs | StopArgs | StatusArgs | LogsArgs | InitArgs | ValidateArgs | VersionArgs | HelpArgs;
 
-const KNOWN_COMMANDS = ['start', 'stop', 'status', 'logs'] as const;
+const KNOWN_COMMANDS = ['start', 'stop', 'status', 'logs', 'init', 'validate'] as const;
 type KnownCommand = (typeof KNOWN_COMMANDS)[number];
 
 function hasFlag(args: string[], long: string, short?: string): boolean {
@@ -90,6 +103,33 @@ function parseLogsArgs(args: string[]): LogsArgs {
   };
 }
 
+function getAllFlagValues(args: string[], long: string): string[] {
+  const values: string[] = [];
+  for (let index = 0; index < args.length; index++) {
+    if (args[index] === long && args[index + 1] !== undefined) {
+      values.push(args[index + 1]);
+    }
+  }
+  return values;
+}
+
+function parseInitArgs(args: string[]): InitArgs {
+  return {
+    command: 'init',
+    yes: hasFlag(args, '--yes', '-y'),
+    skipMcp: hasFlag(args, '--skip-mcp'),
+    showSecrets: hasFlag(args, '--show-secrets'),
+    scanPaths: getAllFlagValues(args, '--scan-path'),
+  };
+}
+
+function parseValidateArgs(args: string[]): ValidateArgs {
+  return {
+    command: 'validate',
+    fix: hasFlag(args, '--fix'),
+  };
+}
+
 export function parseCliArgs(args: string[]): CliArgs {
   if (hasFlag(args, '--version', '-v')) {
     return { command: 'version' };
@@ -110,5 +150,9 @@ export function parseCliArgs(args: string[]): CliArgs {
       return parseStatusArgs(args);
     case 'logs':
       return parseLogsArgs(args);
+    case 'init':
+      return parseInitArgs(args);
+    case 'validate':
+      return parseValidateArgs(args);
   }
 }

--- a/src/shared/services/configDir.ts
+++ b/src/shared/services/configDir.ts
@@ -1,0 +1,19 @@
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+export function getConfigDir(): string {
+  const platform = process.platform;
+
+  let base: string;
+  if (process.env.XDG_CONFIG_HOME) {
+    base = process.env.XDG_CONFIG_HOME;
+  } else if (platform === 'darwin') {
+    base = join(homedir(), 'Library', 'Application Support');
+  } else if (platform === 'win32') {
+    base = process.env.APPDATA || join(homedir(), 'AppData', 'Roaming');
+  } else {
+    base = join(homedir(), '.config');
+  }
+
+  return join(base, 'reviewflow');
+}

--- a/src/shared/services/secretGenerator.ts
+++ b/src/shared/services/secretGenerator.ts
@@ -1,0 +1,18 @@
+import { randomBytes as cryptoRandomBytes } from 'node:crypto';
+
+type RandomBytesFunction = (size: number) => Buffer;
+
+export function generateWebhookSecret(
+  randomBytes: RandomBytesFunction = cryptoRandomBytes,
+): string {
+  return randomBytes(32).toString('hex');
+}
+
+export function truncateSecret(secret: string, displayLength: number): string {
+  if (secret.length <= displayLength) return secret;
+  return `${secret.slice(0, displayLength)}...`;
+}
+
+export function isValidSecret(secret: string): boolean {
+  return /^[0-9a-f]{64}$/.test(secret);
+}

--- a/src/tests/units/cli/formatters/initSummary.test.ts
+++ b/src/tests/units/cli/formatters/initSummary.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { formatInitSummary, type InitSummaryInput } from '../../../../cli/formatters/initSummary.js';
+
+function createFakeSummary(overrides?: Partial<InitSummaryInput>): InitSummaryInput {
+  return {
+    configPath: '/home/user/.config/reviewflow/config.json',
+    envPath: '/home/user/.config/reviewflow/.env',
+    port: 3847,
+    repositoryCount: 2,
+    mcpStatus: 'configured',
+    gitlabUsername: 'damien',
+    githubUsername: 'DGouron',
+    ...overrides,
+  };
+}
+
+describe('formatInitSummary', () => {
+  it('should include config file path', () => {
+    const result = formatInitSummary(createFakeSummary());
+
+    expect(result).toContain('config.json');
+  });
+
+  it('should include .env file path', () => {
+    const result = formatInitSummary(createFakeSummary());
+
+    expect(result).toContain('.env');
+  });
+
+  it('should include port number', () => {
+    const result = formatInitSummary(createFakeSummary({ port: 4000 }));
+
+    expect(result).toContain('4000');
+  });
+
+  it('should include repository count', () => {
+    const result = formatInitSummary(createFakeSummary({ repositoryCount: 5 }));
+
+    expect(result).toContain('5');
+  });
+
+  it('should include next steps', () => {
+    const result = formatInitSummary(createFakeSummary());
+
+    expect(result).toContain('reviewflow start');
+  });
+
+  it('should show mcp warning when claude not found', () => {
+    const result = formatInitSummary(createFakeSummary({ mcpStatus: 'claude-not-found' }));
+
+    expect(result).toContain('Claude');
+  });
+
+  it('should show skipped when mcp was skipped', () => {
+    const result = formatInitSummary(createFakeSummary({ mcpStatus: 'skipped' }));
+
+    expect(result).toContain('skip');
+  });
+});

--- a/src/tests/units/cli/parseCliArgs.test.ts
+++ b/src/tests/units/cli/parseCliArgs.test.ts
@@ -162,6 +162,91 @@ describe('parseCliArgs', () => {
     });
   });
 
+  describe('init command', () => {
+    it('should detect init command', () => {
+      const result = parseCliArgs(['init']);
+
+      expect(result.command).toBe('init');
+    });
+
+    it('should detect --yes flag', () => {
+      const result = parseCliArgs(['init', '--yes']);
+
+      expect(result.command).toBe('init');
+      expect((result as CliArgs & { command: 'init' }).yes).toBe(true);
+    });
+
+    it('should detect -y short flag for yes', () => {
+      const result = parseCliArgs(['init', '-y']);
+
+      expect(result.command).toBe('init');
+      expect((result as CliArgs & { command: 'init' }).yes).toBe(true);
+    });
+
+    it('should detect --skip-mcp flag', () => {
+      const result = parseCliArgs(['init', '--skip-mcp']);
+
+      expect(result.command).toBe('init');
+      expect((result as CliArgs & { command: 'init' }).skipMcp).toBe(true);
+    });
+
+    it('should detect --show-secrets flag', () => {
+      const result = parseCliArgs(['init', '--show-secrets']);
+
+      expect(result.command).toBe('init');
+      expect((result as CliArgs & { command: 'init' }).showSecrets).toBe(true);
+    });
+
+    it('should detect --scan-path with value', () => {
+      const result = parseCliArgs(['init', '--scan-path', '/custom/path']);
+
+      expect(result.command).toBe('init');
+      expect((result as CliArgs & { command: 'init' }).scanPaths).toEqual(['/custom/path']);
+    });
+
+    it('should collect multiple --scan-path values', () => {
+      const result = parseCliArgs([
+        'init', '--scan-path', '/path/a', '--scan-path', '/path/b',
+      ]);
+
+      expect(result.command).toBe('init');
+      expect((result as CliArgs & { command: 'init' }).scanPaths).toEqual(['/path/a', '/path/b']);
+    });
+
+    it('should default flags to false', () => {
+      const result = parseCliArgs(['init']);
+
+      expect(result.command).toBe('init');
+      const initArgs = result as CliArgs & { command: 'init' };
+      expect(initArgs.yes).toBe(false);
+      expect(initArgs.skipMcp).toBe(false);
+      expect(initArgs.showSecrets).toBe(false);
+      expect(initArgs.scanPaths).toEqual([]);
+    });
+  });
+
+  describe('validate command', () => {
+    it('should detect validate command', () => {
+      const result = parseCliArgs(['validate']);
+
+      expect(result.command).toBe('validate');
+    });
+
+    it('should detect --fix flag', () => {
+      const result = parseCliArgs(['validate', '--fix']);
+
+      expect(result.command).toBe('validate');
+      expect((result as CliArgs & { command: 'validate' }).fix).toBe(true);
+    });
+
+    it('should default fix to false', () => {
+      const result = parseCliArgs(['validate']);
+
+      expect(result.command).toBe('validate');
+      expect((result as CliArgs & { command: 'validate' }).fix).toBe(false);
+    });
+  });
+
   describe('version and help flags', () => {
     it('should detect --version flag', () => {
       const result = parseCliArgs(['--version']);

--- a/src/tests/units/shared/services/configDir.test.ts
+++ b/src/tests/units/shared/services/configDir.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { getConfigDir } from '../../../../shared/services/configDir.js';
+
+describe('getConfigDir', () => {
+  it('should return a path ending with reviewflow', () => {
+    const result = getConfigDir();
+
+    expect(result).toMatch(/reviewflow$/);
+  });
+
+  it('should return an absolute path', () => {
+    const result = getConfigDir();
+
+    expect(result).toMatch(/^\//);
+  });
+
+  it('should use XDG_CONFIG_HOME when set', () => {
+    const original = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = '/custom/config';
+
+    try {
+      const result = getConfigDir();
+      expect(result).toBe('/custom/config/reviewflow');
+    } finally {
+      process.env.XDG_CONFIG_HOME = original ?? '';
+    }
+  });
+
+  it('should fallback to ~/.config on linux when XDG_CONFIG_HOME is not set', () => {
+    const originalXdg = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = '';
+
+    try {
+      const result = getConfigDir();
+      if (process.platform === 'linux') {
+        expect(result).toContain('.config/reviewflow');
+      }
+    } finally {
+      if (originalXdg !== undefined) {
+        process.env.XDG_CONFIG_HOME = originalXdg;
+      } else {
+        process.env.XDG_CONFIG_HOME = '';
+      }
+    }
+  });
+});

--- a/src/tests/units/shared/services/secretGenerator.test.ts
+++ b/src/tests/units/shared/services/secretGenerator.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateWebhookSecret,
+  truncateSecret,
+  isValidSecret,
+} from '../../../../shared/services/secretGenerator.js';
+
+describe('generateWebhookSecret', () => {
+  it('should generate a 64-character hex string', () => {
+    const secret = generateWebhookSecret();
+
+    expect(secret).toHaveLength(64);
+    expect(secret).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('should generate unique secrets on each call', () => {
+    const first = generateWebhookSecret();
+    const second = generateWebhookSecret();
+
+    expect(first).not.toBe(second);
+  });
+
+  it('should use injectable randomBytes for deterministic testing', () => {
+    const fakeRandomBytes = () => Buffer.from('a'.repeat(32));
+
+    const secret = generateWebhookSecret(fakeRandomBytes);
+
+    expect(secret).toBe('61'.repeat(32));
+  });
+});
+
+describe('truncateSecret', () => {
+  it('should truncate a secret and append ellipsis', () => {
+    const secret = 'abcdef1234567890abcdef1234567890';
+
+    const result = truncateSecret(secret, 8);
+
+    expect(result).toBe('abcdef12...');
+  });
+
+  it('should return the full secret if shorter than display length', () => {
+    const result = truncateSecret('abc', 10);
+
+    expect(result).toBe('abc');
+  });
+});
+
+describe('isValidSecret', () => {
+  it('should return true for a valid 64-char hex secret', () => {
+    const valid = 'a'.repeat(64);
+
+    expect(isValidSecret(valid)).toBe(true);
+  });
+
+  it('should return false for a secret that is too short', () => {
+    expect(isValidSecret('abc')).toBe(false);
+  });
+
+  it('should return false for non-hex characters', () => {
+    expect(isValidSecret('g'.repeat(64))).toBe(false);
+  });
+
+  it('should return false for empty string', () => {
+    expect(isValidSecret('')).toBe(false);
+  });
+});

--- a/src/tests/units/usecases/cli/configureMcp.usecase.test.ts
+++ b/src/tests/units/usecases/cli/configureMcp.usecase.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  ConfigureMcpUseCase,
+  type ConfigureMcpDependencies,
+} from '../../../../usecases/cli/configureMcp.usecase.js';
+
+function createFakeDeps(
+  overrides?: Partial<ConfigureMcpDependencies>,
+): ConfigureMcpDependencies {
+  return {
+    isClaudeInstalled: vi.fn(() => true),
+    readFileSync: vi.fn(() => '{}'),
+    writeFileSync: vi.fn(),
+    existsSync: vi.fn(() => true),
+    copyFileSync: vi.fn(),
+    resolveMcpServerPath: vi.fn(() => '/path/to/dist/mcpServer.js'),
+    settingsPath: '/home/user/.claude/settings.json',
+    ...overrides,
+  };
+}
+
+describe('ConfigureMcpUseCase', () => {
+  it('should return claude-not-found when claude is not installed', () => {
+    const deps = createFakeDeps({ isClaudeInstalled: vi.fn(() => false) });
+    const usecase = new ConfigureMcpUseCase(deps);
+
+    const result = usecase.execute();
+
+    expect(result).toBe('claude-not-found');
+    expect(deps.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('should configure mcp when settings file does not exist', () => {
+    const deps = createFakeDeps({
+      existsSync: vi.fn(() => false),
+      readFileSync: vi.fn(() => { throw new Error('ENOENT'); }),
+    });
+    const usecase = new ConfigureMcpUseCase(deps);
+
+    const result = usecase.execute();
+
+    expect(result).toBe('configured');
+    expect(deps.writeFileSync).toHaveBeenCalled();
+    const writtenContent = JSON.parse(
+      (deps.writeFileSync as ReturnType<typeof vi.fn>).mock.calls[0][1],
+    );
+    expect(writtenContent.mcpServers['review-progress']).toBeDefined();
+    expect(writtenContent.mcpServers['review-progress'].command).toBe('node');
+  });
+
+  it('should return already-configured when mcp is already set with correct path', () => {
+    const existingSettings = {
+      mcpServers: {
+        'review-progress': {
+          command: 'node',
+          args: ['/path/to/dist/mcpServer.js'],
+        },
+      },
+    };
+    const deps = createFakeDeps({
+      readFileSync: vi.fn(() => JSON.stringify(existingSettings)),
+    });
+    const usecase = new ConfigureMcpUseCase(deps);
+
+    const result = usecase.execute();
+
+    expect(result).toBe('already-configured');
+    expect(deps.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('should update mcp config when path has changed', () => {
+    const existingSettings = {
+      mcpServers: {
+        'review-progress': {
+          command: 'node',
+          args: ['/old/path/mcpServer.js'],
+        },
+      },
+    };
+    const deps = createFakeDeps({
+      readFileSync: vi.fn(() => JSON.stringify(existingSettings)),
+    });
+    const usecase = new ConfigureMcpUseCase(deps);
+
+    const result = usecase.execute();
+
+    expect(result).toBe('configured');
+    expect(deps.copyFileSync).toHaveBeenCalled();
+  });
+
+  it('should preserve existing mcp servers when adding review-progress', () => {
+    const existingSettings = {
+      mcpServers: {
+        'other-server': { command: 'python', args: ['server.py'] },
+      },
+    };
+    const deps = createFakeDeps({
+      readFileSync: vi.fn(() => JSON.stringify(existingSettings)),
+    });
+    const usecase = new ConfigureMcpUseCase(deps);
+
+    usecase.execute();
+
+    const writtenContent = JSON.parse(
+      (deps.writeFileSync as ReturnType<typeof vi.fn>).mock.calls[0][1],
+    );
+    expect(writtenContent.mcpServers['other-server']).toBeDefined();
+    expect(writtenContent.mcpServers['review-progress']).toBeDefined();
+  });
+
+  it('should backup settings before modifying', () => {
+    const deps = createFakeDeps({
+      readFileSync: vi.fn(() => '{}'),
+    });
+    const usecase = new ConfigureMcpUseCase(deps);
+
+    usecase.execute();
+
+    expect(deps.copyFileSync).toHaveBeenCalledWith(
+      '/home/user/.claude/settings.json',
+      '/home/user/.claude/settings.json.bak',
+    );
+  });
+});

--- a/src/tests/units/usecases/cli/discoverRepositories.usecase.test.ts
+++ b/src/tests/units/usecases/cli/discoverRepositories.usecase.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  DiscoverRepositoriesUseCase,
+  type DiscoverRepositoriesDependencies,
+  type DiscoverRepositoriesInput,
+} from '../../../../usecases/cli/discoverRepositories.usecase.js';
+
+function createFakeDeps(
+  overrides?: Partial<DiscoverRepositoriesDependencies>,
+): DiscoverRepositoriesDependencies {
+  return {
+    existsSync: vi.fn(() => false),
+    readdirSync: vi.fn(() => []),
+    getGitRemoteUrl: vi.fn(() => null),
+    ...overrides,
+  };
+}
+
+function createFakeInput(
+  overrides?: Partial<DiscoverRepositoriesInput>,
+): DiscoverRepositoriesInput {
+  return {
+    scanPaths: ['/home/user/projects'],
+    maxDepth: 3,
+    ...overrides,
+  };
+}
+
+describe('DiscoverRepositoriesUseCase', () => {
+  it('should return empty results when scan paths do not exist', () => {
+    const deps = createFakeDeps({ existsSync: vi.fn(() => false) });
+    const usecase = new DiscoverRepositoriesUseCase(deps);
+
+    const result = usecase.execute(createFakeInput());
+
+    expect(result.repositories).toEqual([]);
+    expect(result.skippedPaths).toContain('/home/user/projects');
+  });
+
+  it('should discover a repository with .git directory', () => {
+    const deps = createFakeDeps({
+      existsSync: vi.fn((path: string) => {
+        if (path === '/home/user/projects') return true;
+        if (path === '/home/user/projects/my-app/.git') return true;
+        return false;
+      }),
+      readdirSync: vi.fn((path: string) => {
+        if (path === '/home/user/projects') {
+          return [
+            { name: 'my-app', isDirectory: () => true },
+          ];
+        }
+        return [];
+      }),
+      getGitRemoteUrl: vi.fn(() => 'https://github.com/user/my-app'),
+    });
+    const usecase = new DiscoverRepositoriesUseCase(deps);
+
+    const result = usecase.execute(createFakeInput());
+
+    expect(result.repositories).toHaveLength(1);
+    expect(result.repositories[0]).toEqual({
+      name: 'my-app',
+      localPath: '/home/user/projects/my-app',
+      platform: 'github',
+      remoteUrl: 'https://github.com/user/my-app',
+      hasReviewConfig: false,
+    });
+  });
+
+  it('should detect gitlab platform from remote url', () => {
+    const deps = createFakeDeps({
+      existsSync: vi.fn((path: string) => {
+        if (path === '/projects') return true;
+        if (path === '/projects/repo/.git') return true;
+        return false;
+      }),
+      readdirSync: vi.fn((path: string) => {
+        if (path === '/projects') {
+          return [{ name: 'repo', isDirectory: () => true }];
+        }
+        return [];
+      }),
+      getGitRemoteUrl: vi.fn(() => 'https://gitlab.com/team/repo'),
+    });
+    const usecase = new DiscoverRepositoriesUseCase(deps);
+
+    const result = usecase.execute(createFakeInput({ scanPaths: ['/projects'] }));
+
+    expect(result.repositories[0].platform).toBe('gitlab');
+  });
+
+  it('should detect review config presence', () => {
+    const deps = createFakeDeps({
+      existsSync: vi.fn((path: string) => {
+        if (path === '/projects') return true;
+        if (path === '/projects/repo/.git') return true;
+        if (path === '/projects/repo/.claude/reviews/config.json') return true;
+        return false;
+      }),
+      readdirSync: vi.fn((path: string) => {
+        if (path === '/projects') {
+          return [{ name: 'repo', isDirectory: () => true }];
+        }
+        return [];
+      }),
+      getGitRemoteUrl: vi.fn(() => 'https://github.com/user/repo'),
+    });
+    const usecase = new DiscoverRepositoriesUseCase(deps);
+
+    const result = usecase.execute(createFakeInput({ scanPaths: ['/projects'] }));
+
+    expect(result.repositories[0].hasReviewConfig).toBe(true);
+  });
+
+  it('should skip hidden directories', () => {
+    const deps = createFakeDeps({
+      existsSync: vi.fn((path: string) => {
+        if (path === '/projects') return true;
+        return false;
+      }),
+      readdirSync: vi.fn((path: string) => {
+        if (path === '/projects') {
+          return [
+            { name: '.hidden', isDirectory: () => true },
+            { name: 'node_modules', isDirectory: () => true },
+          ];
+        }
+        return [];
+      }),
+    });
+    const usecase = new DiscoverRepositoriesUseCase(deps);
+
+    const result = usecase.execute(createFakeInput({ scanPaths: ['/projects'] }));
+
+    expect(result.repositories).toEqual([]);
+  });
+
+  it('should respect maxDepth limit', () => {
+    const deps = createFakeDeps({
+      existsSync: vi.fn((path: string) => {
+        if (path === '/projects') return true;
+        if (path === '/projects/level1/level2/level3/deep-repo/.git') return true;
+        return false;
+      }),
+      readdirSync: vi.fn((path: string) => {
+        if (path === '/projects') {
+          return [{ name: 'level1', isDirectory: () => true }];
+        }
+        if (path === '/projects/level1') {
+          return [{ name: 'level2', isDirectory: () => true }];
+        }
+        return [];
+      }),
+    });
+    const usecase = new DiscoverRepositoriesUseCase(deps);
+
+    const result = usecase.execute(createFakeInput({ maxDepth: 1 }));
+
+    expect(result.repositories).toEqual([]);
+  });
+
+  it('should handle repos without remote url', () => {
+    const deps = createFakeDeps({
+      existsSync: vi.fn((path: string) => {
+        if (path === '/projects') return true;
+        if (path === '/projects/local-only/.git') return true;
+        return false;
+      }),
+      readdirSync: vi.fn((path: string) => {
+        if (path === '/projects') {
+          return [{ name: 'local-only', isDirectory: () => true }];
+        }
+        return [];
+      }),
+      getGitRemoteUrl: vi.fn(() => null),
+    });
+    const usecase = new DiscoverRepositoriesUseCase(deps);
+
+    const result = usecase.execute(createFakeInput({ scanPaths: ['/projects'] }));
+
+    expect(result.repositories).toHaveLength(1);
+    expect(result.repositories[0].platform).toBeNull();
+    expect(result.repositories[0].remoteUrl).toBeNull();
+  });
+
+  it('should scan multiple paths', () => {
+    const deps = createFakeDeps({
+      existsSync: vi.fn((path: string) => {
+        if (path === '/path-a' || path === '/path-b') return true;
+        if (path === '/path-a/repo1/.git') return true;
+        if (path === '/path-b/repo2/.git') return true;
+        return false;
+      }),
+      readdirSync: vi.fn((path: string) => {
+        if (path === '/path-a') return [{ name: 'repo1', isDirectory: () => true }];
+        if (path === '/path-b') return [{ name: 'repo2', isDirectory: () => true }];
+        return [];
+      }),
+      getGitRemoteUrl: vi.fn(() => 'https://github.com/user/repo'),
+    });
+    const usecase = new DiscoverRepositoriesUseCase(deps);
+
+    const result = usecase.execute(
+      createFakeInput({ scanPaths: ['/path-a', '/path-b'] }),
+    );
+
+    expect(result.repositories).toHaveLength(2);
+    expect(result.scannedPaths).toEqual(['/path-a', '/path-b']);
+  });
+});

--- a/src/tests/units/usecases/cli/validateConfig.usecase.test.ts
+++ b/src/tests/units/usecases/cli/validateConfig.usecase.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  ValidateConfigUseCase,
+  type ValidateConfigDependencies,
+} from '../../../../usecases/cli/validateConfig.usecase.js';
+
+function createFakeDeps(
+  overrides?: Partial<ValidateConfigDependencies>,
+): ValidateConfigDependencies {
+  return {
+    existsSync: vi.fn(() => true),
+    readFileSync: vi.fn(() =>
+      JSON.stringify({
+        server: { port: 3847 },
+        user: { gitlabUsername: 'user', githubUsername: 'user' },
+        queue: { maxConcurrent: 2, deduplicationWindowMs: 300000 },
+        repositories: [],
+      }),
+    ),
+    ...overrides,
+  };
+}
+
+describe('ValidateConfigUseCase', () => {
+  it('should return not-found when config file does not exist', () => {
+    const deps = createFakeDeps({ existsSync: vi.fn(() => false) });
+    const usecase = new ValidateConfigUseCase(deps);
+
+    const result = usecase.execute({ configPath: '/missing/config.json', envPath: '/missing/.env' });
+
+    expect(result.status).toBe('not-found');
+  });
+
+  it('should return valid for correct config', () => {
+    const deps = createFakeDeps();
+    const usecase = new ValidateConfigUseCase(deps);
+
+    const result = usecase.execute({
+      configPath: '/home/user/.config/reviewflow/config.json',
+      envPath: '/home/user/.config/reviewflow/.env',
+    });
+
+    expect(result.status).toBe('valid');
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('should detect invalid JSON', () => {
+    const deps = createFakeDeps({
+      readFileSync: vi.fn((path: string) => {
+        if (path.endsWith('config.json')) return 'not json{';
+        return 'GITLAB_WEBHOOK_TOKEN=abc\nGITHUB_WEBHOOK_SECRET=def';
+      }),
+    });
+    const usecase = new ValidateConfigUseCase(deps);
+
+    const result = usecase.execute({
+      configPath: '/config.json',
+      envPath: '/.env',
+    });
+
+    expect(result.status).toBe('invalid');
+    expect(result.issues.some(i => i.field === 'config.json')).toBe(true);
+  });
+
+  it('should detect invalid port', () => {
+    const deps = createFakeDeps({
+      readFileSync: vi.fn((path: string) => {
+        if (path.endsWith('config.json')) {
+          return JSON.stringify({
+            server: { port: 99999 },
+            user: { gitlabUsername: 'u', githubUsername: 'u' },
+            queue: { maxConcurrent: 2, deduplicationWindowMs: 300000 },
+            repositories: [],
+          });
+        }
+        return 'GITLAB_WEBHOOK_TOKEN=abc\nGITHUB_WEBHOOK_SECRET=def';
+      }),
+    });
+    const usecase = new ValidateConfigUseCase(deps);
+
+    const result = usecase.execute({ configPath: '/config.json', envPath: '/.env' });
+
+    expect(result.status).toBe('invalid');
+    expect(result.issues.some(i => i.field === 'server.port')).toBe(true);
+  });
+
+  it('should detect missing .env file', () => {
+    const deps = createFakeDeps({
+      existsSync: vi.fn((path: string) => !path.endsWith('.env')),
+      readFileSync: vi.fn(() =>
+        JSON.stringify({
+          server: { port: 3847 },
+          user: { gitlabUsername: 'u', githubUsername: 'u' },
+          queue: { maxConcurrent: 2, deduplicationWindowMs: 300000 },
+          repositories: [],
+        }),
+      ),
+    });
+    const usecase = new ValidateConfigUseCase(deps);
+
+    const result = usecase.execute({ configPath: '/config.json', envPath: '/.env' });
+
+    expect(result.status).toBe('invalid');
+    expect(result.issues.some(i => i.field === '.env')).toBe(true);
+  });
+
+  it('should detect missing required fields', () => {
+    const deps = createFakeDeps({
+      readFileSync: vi.fn((path: string) => {
+        if (path.endsWith('config.json')) {
+          return JSON.stringify({ server: { port: 3847 } });
+        }
+        return 'GITLAB_WEBHOOK_TOKEN=abc\nGITHUB_WEBHOOK_SECRET=def';
+      }),
+    });
+    const usecase = new ValidateConfigUseCase(deps);
+
+    const result = usecase.execute({ configPath: '/config.json', envPath: '/.env' });
+
+    expect(result.status).toBe('invalid');
+    expect(result.issues.some(i => i.field === 'user')).toBe(true);
+  });
+
+  it('should detect non-existent repository paths', () => {
+    const deps = createFakeDeps({
+      existsSync: vi.fn((path: string) => !path.startsWith('/nonexistent')),
+      readFileSync: vi.fn((path: string) => {
+        if (path.endsWith('config.json')) {
+          return JSON.stringify({
+            server: { port: 3847 },
+            user: { gitlabUsername: 'u', githubUsername: 'u' },
+            queue: { maxConcurrent: 2, deduplicationWindowMs: 300000 },
+            repositories: [
+              { name: 'repo', localPath: '/nonexistent/repo', enabled: true },
+            ],
+          });
+        }
+        return 'GITLAB_WEBHOOK_TOKEN=abc\nGITHUB_WEBHOOK_SECRET=def';
+      }),
+    });
+    const usecase = new ValidateConfigUseCase(deps);
+
+    const result = usecase.execute({ configPath: '/config.json', envPath: '/.env' });
+
+    expect(result.status).toBe('invalid');
+    expect(result.issues.some(i => i.field === 'repositories')).toBe(true);
+  });
+});

--- a/src/tests/units/usecases/cli/writeInitConfig.usecase.test.ts
+++ b/src/tests/units/usecases/cli/writeInitConfig.usecase.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  WriteInitConfigUseCase,
+  type WriteInitConfigDependencies,
+  type WriteInitConfigInput,
+} from '../../../../usecases/cli/writeInitConfig.usecase.js';
+
+function createFakeDeps(
+  overrides?: Partial<WriteInitConfigDependencies>,
+): WriteInitConfigDependencies {
+  return {
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    ...overrides,
+  };
+}
+
+function createFakeInput(
+  overrides?: Partial<WriteInitConfigInput>,
+): WriteInitConfigInput {
+  return {
+    configDir: '/home/user/.config/reviewflow',
+    port: 3847,
+    gitlabUsername: 'damien',
+    githubUsername: 'DGouron',
+    repositories: [
+      { name: 'my-app', localPath: '/home/user/projects/my-app', enabled: true },
+    ],
+    gitlabWebhookSecret: 'abc123',
+    githubWebhookSecret: 'def456',
+    ...overrides,
+  };
+}
+
+describe('WriteInitConfigUseCase', () => {
+  it('should create config directory recursively', () => {
+    const deps = createFakeDeps();
+    const usecase = new WriteInitConfigUseCase(deps);
+
+    usecase.execute(createFakeInput());
+
+    expect(deps.mkdirSync).toHaveBeenCalledWith(
+      '/home/user/.config/reviewflow',
+      { recursive: true },
+    );
+  });
+
+  it('should write config.json with correct structure', () => {
+    const deps = createFakeDeps();
+    const usecase = new WriteInitConfigUseCase(deps);
+
+    const result = usecase.execute(createFakeInput());
+
+    const writeCall = (deps.writeFileSync as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call: unknown[]) => (call[0] as string).endsWith('config.json'),
+    );
+    expect(writeCall).toBeDefined();
+
+    const config = JSON.parse(writeCall![1] as string);
+    expect(config.server.port).toBe(3847);
+    expect(config.user.gitlabUsername).toBe('damien');
+    expect(config.user.githubUsername).toBe('DGouron');
+    expect(config.queue.maxConcurrent).toBe(2);
+    expect(config.repositories).toHaveLength(1);
+    expect(result.configPath).toContain('config.json');
+  });
+
+  it('should write .env file with webhook secrets', () => {
+    const deps = createFakeDeps();
+    const usecase = new WriteInitConfigUseCase(deps);
+
+    const result = usecase.execute(createFakeInput());
+
+    const writeCall = (deps.writeFileSync as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call: unknown[]) => (call[0] as string).endsWith('.env'),
+    );
+    expect(writeCall).toBeDefined();
+
+    const envContent = writeCall![1] as string;
+    expect(envContent).toContain('GITLAB_WEBHOOK_TOKEN=abc123');
+    expect(envContent).toContain('GITHUB_WEBHOOK_SECRET=def456');
+    expect(result.envPath).toContain('.env');
+  });
+
+  it('should handle empty repositories', () => {
+    const deps = createFakeDeps();
+    const usecase = new WriteInitConfigUseCase(deps);
+
+    const result = usecase.execute(createFakeInput({ repositories: [] }));
+
+    const writeCall = (deps.writeFileSync as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call: unknown[]) => (call[0] as string).endsWith('config.json'),
+    );
+    const config = JSON.parse(writeCall![1] as string);
+    expect(config.repositories).toEqual([]);
+    expect(result.configPath).toBeDefined();
+  });
+
+  it('should use empty string for omitted usernames', () => {
+    const deps = createFakeDeps();
+    const usecase = new WriteInitConfigUseCase(deps);
+
+    usecase.execute(
+      createFakeInput({ gitlabUsername: '', githubUsername: '' }),
+    );
+
+    const writeCall = (deps.writeFileSync as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call: unknown[]) => (call[0] as string).endsWith('config.json'),
+    );
+    const config = JSON.parse(writeCall![1] as string);
+    expect(config.user.gitlabUsername).toBe('');
+    expect(config.user.githubUsername).toBe('');
+  });
+});

--- a/src/usecases/cli/configureMcp.usecase.ts
+++ b/src/usecases/cli/configureMcp.usecase.ts
@@ -1,0 +1,60 @@
+export type ConfigureMcpResult = 'configured' | 'already-configured' | 'claude-not-found' | 'failed';
+
+export interface ConfigureMcpDependencies {
+  isClaudeInstalled: () => boolean;
+  readFileSync: (path: string, encoding: string) => string;
+  writeFileSync: (path: string, content: string) => void;
+  existsSync: (path: string) => boolean;
+  copyFileSync: (src: string, dest: string) => void;
+  resolveMcpServerPath: () => string;
+  settingsPath: string;
+}
+
+export class ConfigureMcpUseCase {
+  constructor(private readonly deps: ConfigureMcpDependencies) {}
+
+  execute(): ConfigureMcpResult {
+    if (!this.deps.isClaudeInstalled()) {
+      return 'claude-not-found';
+    }
+
+    const mcpServerPath = this.deps.resolveMcpServerPath();
+    let settings: Record<string, unknown>;
+
+    try {
+      const content = this.deps.readFileSync(this.deps.settingsPath, 'utf-8');
+      settings = JSON.parse(content);
+    } catch {
+      settings = {};
+    }
+
+    const mcpServers = (settings.mcpServers ?? {}) as Record<string, unknown>;
+    const existing = mcpServers['review-progress'] as
+      | { command: string; args: string[] }
+      | undefined;
+
+    if (existing?.args?.[0] === mcpServerPath) {
+      return 'already-configured';
+    }
+
+    if (this.deps.existsSync(this.deps.settingsPath)) {
+      this.deps.copyFileSync(
+        this.deps.settingsPath,
+        `${this.deps.settingsPath}.bak`,
+      );
+    }
+
+    mcpServers['review-progress'] = {
+      command: 'node',
+      args: [mcpServerPath],
+    };
+    settings.mcpServers = mcpServers;
+
+    this.deps.writeFileSync(
+      this.deps.settingsPath,
+      JSON.stringify(settings, null, 2),
+    );
+
+    return 'configured';
+  }
+}

--- a/src/usecases/cli/discoverRepositories.usecase.ts
+++ b/src/usecases/cli/discoverRepositories.usecase.ts
@@ -1,0 +1,104 @@
+import type { UseCase } from '../../shared/foundation/usecase.base.js';
+
+interface DirEntry {
+  name: string;
+  isDirectory: () => boolean;
+}
+
+export interface DiscoverRepositoriesDependencies {
+  existsSync: (path: string) => boolean;
+  readdirSync: (path: string) => DirEntry[];
+  getGitRemoteUrl: (localPath: string) => string | null;
+}
+
+export interface DiscoverRepositoriesInput {
+  scanPaths: string[];
+  maxDepth: number;
+}
+
+export interface DiscoveredRepository {
+  name: string;
+  localPath: string;
+  platform: 'gitlab' | 'github' | null;
+  remoteUrl: string | null;
+  hasReviewConfig: boolean;
+}
+
+export interface DiscoverRepositoriesResult {
+  repositories: DiscoveredRepository[];
+  scannedPaths: string[];
+  skippedPaths: string[];
+}
+
+const IGNORED_DIRS = new Set([
+  'node_modules', '.git', '.vscode', '.idea', 'dist', 'build', '.cache',
+]);
+
+function detectPlatform(remoteUrl: string | null): 'gitlab' | 'github' | null {
+  if (!remoteUrl) return null;
+  const lower = remoteUrl.toLowerCase();
+  if (lower.includes('gitlab')) return 'gitlab';
+  if (lower.includes('github')) return 'github';
+  return null;
+}
+
+export class DiscoverRepositoriesUseCase
+  implements UseCase<DiscoverRepositoriesInput, DiscoverRepositoriesResult>
+{
+  constructor(private readonly deps: DiscoverRepositoriesDependencies) {}
+
+  execute(input: DiscoverRepositoriesInput): DiscoverRepositoriesResult {
+    const repositories: DiscoveredRepository[] = [];
+    const scannedPaths: string[] = [];
+    const skippedPaths: string[] = [];
+
+    for (const scanPath of input.scanPaths) {
+      if (!this.deps.existsSync(scanPath)) {
+        skippedPaths.push(scanPath);
+        continue;
+      }
+      scannedPaths.push(scanPath);
+      this.scan(scanPath, 0, input.maxDepth, repositories);
+    }
+
+    return { repositories, scannedPaths, skippedPaths };
+  }
+
+  private scan(
+    dirPath: string,
+    currentDepth: number,
+    maxDepth: number,
+    results: DiscoveredRepository[],
+  ): void {
+    if (currentDepth >= maxDepth) return;
+
+    let entries: DirEntry[];
+    try {
+      entries = this.deps.readdirSync(dirPath);
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name.startsWith('.') || IGNORED_DIRS.has(entry.name)) continue;
+
+      const fullPath = `${dirPath}/${entry.name}`;
+      const gitPath = `${fullPath}/.git`;
+
+      if (this.deps.existsSync(gitPath)) {
+        const remoteUrl = this.deps.getGitRemoteUrl(fullPath);
+        const reviewConfigPath = `${fullPath}/.claude/reviews/config.json`;
+        results.push({
+          name: entry.name,
+          localPath: fullPath,
+          platform: detectPlatform(remoteUrl),
+          remoteUrl,
+          hasReviewConfig: this.deps.existsSync(reviewConfigPath),
+        });
+      } else {
+        this.scan(fullPath, currentDepth + 1, maxDepth, results);
+      }
+    }
+  }
+}

--- a/src/usecases/cli/validateConfig.usecase.ts
+++ b/src/usecases/cli/validateConfig.usecase.ts
@@ -1,0 +1,100 @@
+export interface ValidateConfigDependencies {
+  existsSync: (path: string) => boolean;
+  readFileSync: (path: string, encoding: string) => string;
+}
+
+export interface ValidateConfigInput {
+  configPath: string;
+  envPath: string;
+}
+
+export interface ValidationIssue {
+  field: string;
+  message: string;
+  severity: 'error' | 'warning';
+}
+
+export interface ValidateConfigResult {
+  status: 'valid' | 'invalid' | 'not-found';
+  issues: ValidationIssue[];
+}
+
+export class ValidateConfigUseCase {
+  constructor(private readonly deps: ValidateConfigDependencies) {}
+
+  execute(input: ValidateConfigInput): ValidateConfigResult {
+    const issues: ValidationIssue[] = [];
+
+    if (!this.deps.existsSync(input.configPath)) {
+      return { status: 'not-found', issues: [] };
+    }
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = this.deps.readFileSync(input.configPath, 'utf-8');
+      config = JSON.parse(raw);
+    } catch {
+      issues.push({
+        field: 'config.json',
+        message: 'Invalid JSON format',
+        severity: 'error',
+      });
+      return { status: 'invalid', issues };
+    }
+
+    this.validateServer(config, issues);
+    this.validateUser(config, issues);
+    this.validateQueue(config, issues);
+    this.validateRepositories(config, issues);
+    this.validateEnv(input.envPath, issues);
+
+    return {
+      status: issues.length > 0 ? 'invalid' : 'valid',
+      issues,
+    };
+  }
+
+  private validateServer(config: Record<string, unknown>, issues: ValidationIssue[]): void {
+    const server = config.server as Record<string, unknown> | undefined;
+    if (!server) {
+      issues.push({ field: 'server', message: 'Missing server section', severity: 'error' });
+      return;
+    }
+    if (typeof server.port !== 'number' || server.port < 1 || server.port > 65535) {
+      issues.push({ field: 'server.port', message: 'Port must be between 1 and 65535', severity: 'error' });
+    }
+  }
+
+  private validateUser(config: Record<string, unknown>, issues: ValidationIssue[]): void {
+    if (!config.user || typeof config.user !== 'object') {
+      issues.push({ field: 'user', message: 'Missing user section', severity: 'error' });
+    }
+  }
+
+  private validateQueue(config: Record<string, unknown>, issues: ValidationIssue[]): void {
+    if (!config.queue || typeof config.queue !== 'object') {
+      issues.push({ field: 'queue', message: 'Missing queue section', severity: 'error' });
+    }
+  }
+
+  private validateRepositories(config: Record<string, unknown>, issues: ValidationIssue[]): void {
+    if (!Array.isArray(config.repositories)) return;
+
+    for (const repo of config.repositories) {
+      const entry = repo as Record<string, unknown>;
+      if (typeof entry.localPath === 'string' && !this.deps.existsSync(entry.localPath)) {
+        issues.push({
+          field: 'repositories',
+          message: `Path does not exist: ${entry.localPath}`,
+          severity: 'error',
+        });
+      }
+    }
+  }
+
+  private validateEnv(envPath: string, issues: ValidationIssue[]): void {
+    if (!this.deps.existsSync(envPath)) {
+      issues.push({ field: '.env', message: 'Missing .env file', severity: 'error' });
+    }
+  }
+}

--- a/src/usecases/cli/writeInitConfig.usecase.ts
+++ b/src/usecases/cli/writeInitConfig.usecase.ts
@@ -1,0 +1,67 @@
+import { join } from 'node:path';
+
+export interface WriteInitConfigDependencies {
+  mkdirSync: (path: string, options: { recursive: boolean }) => void;
+  writeFileSync: (path: string, content: string) => void;
+}
+
+interface RepositoryEntry {
+  name: string;
+  localPath: string;
+  enabled: boolean;
+}
+
+export interface WriteInitConfigInput {
+  configDir: string;
+  port: number;
+  gitlabUsername: string;
+  githubUsername: string;
+  repositories: RepositoryEntry[];
+  gitlabWebhookSecret: string;
+  githubWebhookSecret: string;
+}
+
+export interface WriteInitConfigResult {
+  configPath: string;
+  envPath: string;
+}
+
+export class WriteInitConfigUseCase {
+  constructor(private readonly deps: WriteInitConfigDependencies) {}
+
+  execute(input: WriteInitConfigInput): WriteInitConfigResult {
+    this.deps.mkdirSync(input.configDir, { recursive: true });
+
+    const configPath = join(input.configDir, 'config.json');
+    const envPath = join(input.configDir, '.env');
+
+    const config = {
+      server: { port: input.port },
+      user: {
+        gitlabUsername: input.gitlabUsername,
+        githubUsername: input.githubUsername,
+      },
+      queue: {
+        maxConcurrent: 2,
+        deduplicationWindowMs: 300000,
+      },
+      repositories: input.repositories.map(repo => ({
+        name: repo.name,
+        localPath: repo.localPath,
+        enabled: repo.enabled,
+      })),
+    };
+
+    this.deps.writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+    const envContent = [
+      `GITLAB_WEBHOOK_TOKEN=${input.gitlabWebhookSecret}`,
+      `GITHUB_WEBHOOK_SECRET=${input.githubWebhookSecret}`,
+      '',
+    ].join('\n');
+
+    this.deps.writeFileSync(envPath, envContent);
+
+    return { configPath, envPath };
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -602,6 +602,145 @@
   resolved "https://registry.yarnpkg.com/@iconify/types/-/types-2.0.0.tgz#ab0e9ea681d6c8a1214f30cd741fe3a20cc57f57"
   integrity sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==
 
+"@inquirer/ansi@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@inquirer/ansi/-/ansi-2.0.3.tgz#3c4c5b587894278996c2750db83d89fb547b796b"
+  integrity sha512-g44zhR3NIKVs0zUesa4iMzExmZpLUdTLRMCStqX3GE5NT6VkPcxQGJ+uC8tDgBUC/vB1rUhUd55cOf++4NZcmw==
+
+"@inquirer/checkbox@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/checkbox/-/checkbox-5.0.4.tgz#813e8fd64c5f9ce064e4a6517a1fcc4524d2cf05"
+  integrity sha512-DrAMU3YBGMUAp6ArwTIp/25CNDtDbxk7UjIrrtM25JVVrlVYlVzHh5HR1BDFu9JMyUoZ4ZanzeaHqNDttf3gVg==
+  dependencies:
+    "@inquirer/ansi" "^2.0.3"
+    "@inquirer/core" "^11.1.1"
+    "@inquirer/figures" "^2.0.3"
+    "@inquirer/type" "^4.0.3"
+
+"@inquirer/confirm@^6.0.4":
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/confirm/-/confirm-6.0.4.tgz#548d63981f3bc189ee0773015fbe4625e7a204a0"
+  integrity sha512-WdaPe7foUnoGYvXzH4jp4wH/3l+dBhZ3uwhKjXjwdrq5tEIFaANxj6zrGHxLdsIA0yKM0kFPVcEalOZXBB5ISA==
+  dependencies:
+    "@inquirer/core" "^11.1.1"
+    "@inquirer/type" "^4.0.3"
+
+"@inquirer/core@^11.1.1":
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/@inquirer/core/-/core-11.1.1.tgz#7cf708b350f9e73b01ccb4b61ecf3016d3de1b0d"
+  integrity sha512-hV9o15UxX46OyQAtaoMqAOxGR8RVl1aZtDx1jHbCtSJy1tBdTfKxLPKf7utsE4cRy4tcmCQ4+vdV+ca+oNxqNA==
+  dependencies:
+    "@inquirer/ansi" "^2.0.3"
+    "@inquirer/figures" "^2.0.3"
+    "@inquirer/type" "^4.0.3"
+    cli-width "^4.1.0"
+    mute-stream "^3.0.0"
+    signal-exit "^4.1.0"
+    wrap-ansi "^9.0.2"
+
+"@inquirer/editor@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/editor/-/editor-5.0.4.tgz#8dda8bc92ca5a7f7326b4508f8da90358fbedfc5"
+  integrity sha512-QI3Jfqcv6UO2/VJaEFONH8Im1ll++Xn/AJTBn9Xf+qx2M+H8KZAdQ5sAe2vtYlo+mLW+d7JaMJB4qWtK4BG3pw==
+  dependencies:
+    "@inquirer/core" "^11.1.1"
+    "@inquirer/external-editor" "^2.0.3"
+    "@inquirer/type" "^4.0.3"
+
+"@inquirer/expand@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/expand/-/expand-5.0.4.tgz#72adbd795c451deb6e74d04d5da91e41a45372d3"
+  integrity sha512-0I/16YwPPP0Co7a5MsomlZLpch48NzYfToyqYAOWtBmaXSB80RiNQ1J+0xx2eG+Wfxt0nHtpEWSRr6CzNVnOGg==
+  dependencies:
+    "@inquirer/core" "^11.1.1"
+    "@inquirer/type" "^4.0.3"
+
+"@inquirer/external-editor@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@inquirer/external-editor/-/external-editor-2.0.3.tgz#c9e84d8d6040968bee33232683b05642001a4731"
+  integrity sha512-LgyI7Agbda74/cL5MvA88iDpvdXI2KuMBCGRkbCl2Dg1vzHeOgs+s0SDcXV7b+WZJrv2+ERpWSM65Fpi9VfY3w==
+  dependencies:
+    chardet "^2.1.1"
+    iconv-lite "^0.7.2"
+
+"@inquirer/figures@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@inquirer/figures/-/figures-2.0.3.tgz#9d0cd242fbdb4ed8f1f52836a977eb7071e6c512"
+  integrity sha512-y09iGt3JKoOCBQ3w4YrSJdokcD8ciSlMIWsD+auPu+OZpfxLuyz+gICAQ6GCBOmJJt4KEQGHuZSVff2jiNOy7g==
+
+"@inquirer/input@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/input/-/input-5.0.4.tgz#56a839a27ed091972f0eb6be1ed6ede2f7f4223f"
+  integrity sha512-4B3s3jvTREDFvXWit92Yc6jF1RJMDy2VpSqKtm4We2oVU65YOh2szY5/G14h4fHlyQdpUmazU5MPCFZPRJ0AOw==
+  dependencies:
+    "@inquirer/core" "^11.1.1"
+    "@inquirer/type" "^4.0.3"
+
+"@inquirer/number@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/number/-/number-4.0.4.tgz#c0ea5cd3a3f5e15ea1e90d6144abfd338a07f4f7"
+  integrity sha512-CmMp9LF5HwE+G/xWsC333TlCzYYbXMkcADkKzcawh49fg2a1ryLc7JL1NJYYt1lJ+8f4slikNjJM9TEL/AljYQ==
+  dependencies:
+    "@inquirer/core" "^11.1.1"
+    "@inquirer/type" "^4.0.3"
+
+"@inquirer/password@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/password/-/password-5.0.4.tgz#d691b1e9f4cc323ffff94579db040c751140c4fa"
+  integrity sha512-ZCEPyVYvHK4W4p2Gy6sTp9nqsdHQCfiPXIP9LbJVW4yCinnxL/dDDmPaEZVysGrj8vxVReRnpfS2fOeODe9zjg==
+  dependencies:
+    "@inquirer/ansi" "^2.0.3"
+    "@inquirer/core" "^11.1.1"
+    "@inquirer/type" "^4.0.3"
+
+"@inquirer/prompts@^8.2.0":
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/@inquirer/prompts/-/prompts-8.2.0.tgz#864494037fe3d456a829198a0563b17492b95a77"
+  integrity sha512-rqTzOprAj55a27jctS3vhvDDJzYXsr33WXTjODgVOru21NvBo9yIgLIAf7SBdSV0WERVly3dR6TWyp7ZHkvKFA==
+  dependencies:
+    "@inquirer/checkbox" "^5.0.4"
+    "@inquirer/confirm" "^6.0.4"
+    "@inquirer/editor" "^5.0.4"
+    "@inquirer/expand" "^5.0.4"
+    "@inquirer/input" "^5.0.4"
+    "@inquirer/number" "^4.0.4"
+    "@inquirer/password" "^5.0.4"
+    "@inquirer/rawlist" "^5.2.0"
+    "@inquirer/search" "^4.1.0"
+    "@inquirer/select" "^5.0.4"
+
+"@inquirer/rawlist@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@inquirer/rawlist/-/rawlist-5.2.0.tgz#fee7d58867508781ff96483f5894bfdd551a1ec2"
+  integrity sha512-CciqGoOUMrFo6HxvOtU5uL8fkjCmzyeB6fG7O1vdVAZVSopUBYECOwevDBlqNLyyYmzpm2Gsn/7nLrpruy9RFg==
+  dependencies:
+    "@inquirer/core" "^11.1.1"
+    "@inquirer/type" "^4.0.3"
+
+"@inquirer/search@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@inquirer/search/-/search-4.1.0.tgz#5e17b5787975b8b4df182ca969e525c01c98dc4f"
+  integrity sha512-EAzemfiP4IFvIuWnrHpgZs9lAhWDA0GM3l9F4t4mTQ22IFtzfrk8xbkMLcAN7gmVML9O/i+Hzu8yOUyAaL6BKA==
+  dependencies:
+    "@inquirer/core" "^11.1.1"
+    "@inquirer/figures" "^2.0.3"
+    "@inquirer/type" "^4.0.3"
+
+"@inquirer/select@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/select/-/select-5.0.4.tgz#11249c7091946681d394f649b00844f8fda38d7a"
+  integrity sha512-s8KoGpPYMEQ6WXc0dT9blX2NtIulMdLOO3LA1UKOiv7KFWzlJ6eLkEYTDBIi+JkyKXyn8t/CD6TinxGjyLt57g==
+  dependencies:
+    "@inquirer/ansi" "^2.0.3"
+    "@inquirer/core" "^11.1.1"
+    "@inquirer/figures" "^2.0.3"
+    "@inquirer/type" "^4.0.3"
+
+"@inquirer/type@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@inquirer/type/-/type-4.0.3.tgz#219b8c29afe366067f90705d156d1b395c9e2af0"
+  integrity sha512-cKZN7qcXOpj1h+1eTTcGDVLaBIHNMT1Rz9JqJP5MnEJ0JhgVWllx7H/tahUp5YEK1qaByH2Itb8wLG/iScD5kw==
+
 "@isaacs/balanced-match@^4.0.1":
   version "4.0.1"
   resolved "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz"
@@ -1259,7 +1398,7 @@ ansi-styles@^4.0.0:
   dependencies:
     color-convert "^2.0.1"
 
-ansi-styles@^6.1.0:
+ansi-styles@^6.1.0, ansi-styles@^6.2.1:
   version "6.2.3"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz"
   integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
@@ -1364,6 +1503,16 @@ character-entities-legacy@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz#76bc83a90738901d7bc223a9e93759fdd560125b"
   integrity sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==
+
+chardet@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-2.1.1.tgz#5c75593704a642f71ee53717df234031e65373c8"
+  integrity sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==
+
+cli-width@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-4.1.0.tgz#42daac41d3c254ef38ad8ac037672130173691c5"
+  integrity sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==
 
 color-convert@^2.0.1:
   version "2.0.1"
@@ -1515,6 +1664,11 @@ emoji-regex-xs@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz#e8af22e5d9dbd7f7f22d280af3d19d2aab5b0724"
   integrity sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==
+
+emoji-regex@^10.3.0:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.6.0.tgz#bf3d6e8f7f8fd22a65d9703475bc0147357a6b0d"
+  integrity sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -1874,6 +2028,11 @@ function-bind@^1.1.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
+get-east-asian-width@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz#9bc4caa131702b4b61729cb7e42735bc550c9ee6"
+  integrity sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==
+
 get-intrinsic@^1.2.5, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
@@ -1999,7 +2158,7 @@ http-errors@^2.0.0, http-errors@^2.0.1, http-errors@~2.0.1:
     statuses "~2.0.2"
     toidentifier "~1.0.1"
 
-iconv-lite@^0.7.0, iconv-lite@~0.7.0:
+iconv-lite@^0.7.0, iconv-lite@^0.7.2, iconv-lite@~0.7.0:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.7.2.tgz#d0bdeac3f12b4835b7359c2ad89c422a4d1cc72e"
   integrity sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==
@@ -2269,6 +2428,11 @@ ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+mute-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-3.0.0.tgz#cd8014dd2acb72e1e91bb67c74f0019e620ba2d1"
+  integrity sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==
 
 nanoid@^3.3.11:
   version "3.3.11"
@@ -2809,7 +2973,7 @@ siginfo@^2.0.0:
   resolved "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz"
   integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
 
-signal-exit@^4.0.1:
+signal-exit@^4.0.1, signal-exit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
@@ -2904,6 +3068,15 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
+string-width@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-7.2.0.tgz#b5bb8e2165ce275d4d43476dd2700ad9091db6dc"
+  integrity sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==
+  dependencies:
+    emoji-regex "^10.3.0"
+    get-east-asian-width "^1.0.0"
+    strip-ansi "^7.1.0"
+
 string_decoder@^1.1.1, string_decoder@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
@@ -2933,7 +3106,7 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-strip-ansi@^7.0.1:
+strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.2"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz"
   integrity sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==
@@ -3237,6 +3410,15 @@ wrap-ansi@^8.1.0:
     ansi-styles "^6.1.0"
     string-width "^5.0.1"
     strip-ansi "^7.0.1"
+
+wrap-ansi@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-9.0.2.tgz#956832dea9494306e6d209eb871643bb873d7c98"
+  integrity sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==
+  dependencies:
+    ansi-styles "^6.2.1"
+    string-width "^7.0.0"
+    strip-ansi "^7.1.0"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
## Summary

- Add `reviewflow init` interactive setup wizard: configures port, usernames, generates webhook secrets, scans filesystem for git repos, auto-configures MCP server, writes `config.json` + `.env` to XDG config dir
- Add `reviewflow validate` command for post-setup configuration health checks
- Add XDG config dir fallback to config loader (`~/.config/reviewflow/` on Linux)
- 4 new use cases (discoverRepositories, configureMcp, writeInitConfig, validateConfig), 2 new services (configDir, secretGenerator), 1 formatter (initSummary)
- 56 new tests covering all use cases and services
- Update README with new quick-start flow (install → init → start)

## Test plan

- [x] `yarn typecheck` — zero type errors
- [x] `yarn lint` — zero lint errors
- [x] `yarn test:ci` — 736 tests pass (2 pre-existing integration failures)
- [x] `yarn build` — clean build
- [x] `reviewflow init --yes --skip-mcp` — non-interactive mode works
- [x] `reviewflow validate` — validates existing config
- [x] `reviewflow --help` — shows new commands
- [ ] `reviewflow init` — full interactive wizard flow
- [ ] Backward compat: existing `config.json` in cwd still works without `init`

🤖 Generated with [Claude Code](https://claude.com/claude-code)