### PR TITLE
fix(docs): remove double base path in Get Started links

### DIFF
--- a/docs/.vitepress/theme/components/HeroSection.vue
+++ b/docs/.vitepress/theme/components/HeroSection.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { VPButton } from "vitepress/theme";
-import { withBase } from "vitepress";
 </script>
 
 <template>
@@ -20,7 +19,7 @@ import { withBase } from "vitepress";
 					tag="a"
 					size="medium"
 					theme="brand"
-					:href="withBase('/guide/quick-start')"
+					href="/guide/quick-start"
 					text="Get Started"
 				/>
 				<VPButton

--- a/docs/.vitepress/theme/components/QuickStart.vue
+++ b/docs/.vitepress/theme/components/QuickStart.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { VPButton } from "vitepress/theme";
-import { withBase } from "vitepress";
 
 interface Step {
 	number: number;
@@ -42,7 +41,7 @@ const steps: Step[] = [
 				tag="a"
 				size="medium"
 				theme="alt"
-				:href="withBase('/guide/quick-start')"
+				href="/guide/quick-start"
 				text="View Full Quick Start →"
 			/>
 		</div>


### PR DESCRIPTION
## Summary
- "Get Started" and "View Full Quick Start" buttons on the docs homepage used `withBase('/guide/quick-start')`, but `VPButton` already resolves the base path internally
- This caused a double base path: `/review-flow/review-flow/guide/quick-start` → 404
- Removed `withBase()` from `HeroSection.vue` and `QuickStart.vue`

## Test plan
- [ ] Visit https://dgouron.github.io/review-flow/ after deploy
- [ ] Click "Get Started" → should navigate to `/review-flow/guide/quick-start`
- [ ] Click "View Full Quick Start →" → same target, no 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)