### PR TITLE
feat(followup): re-verify Important issues on pending-approval MRs

### DIFF
--- a/src/cli/parseCliArgs.ts
+++ b/src/cli/parseCliArgs.ts
@@ -39,13 +39,19 @@ interface VersionArgs {
   command: 'version';
 }
 
+interface FollowupImportantsArgs {
+  command: 'followup-importants';
+  project: string | undefined;
+  yes: boolean;
+}
+
 interface HelpArgs {
   command: 'help';
 }
 
-export type CliArgs = StartArgs | StopArgs | StatusArgs | LogsArgs | InitArgs | ValidateArgs | VersionArgs | HelpArgs;
+export type CliArgs = StartArgs | StopArgs | StatusArgs | LogsArgs | InitArgs | ValidateArgs | FollowupImportantsArgs | VersionArgs | HelpArgs;
 
-const KNOWN_COMMANDS = ['start', 'stop', 'status', 'logs', 'init', 'validate'] as const;
+const KNOWN_COMMANDS = ['start', 'stop', 'status', 'logs', 'init', 'validate', 'followup-importants'] as const;
 type KnownCommand = (typeof KNOWN_COMMANDS)[number];
 
 function hasFlag(args: string[], long: string, short?: string): boolean {
@@ -91,6 +97,14 @@ function parseStatusArgs(args: string[]): StatusArgs {
   return {
     command: 'status',
     json: hasFlag(args, '--json'),
+  };
+}
+
+function parseFollowupImportantsArgs(args: string[]): FollowupImportantsArgs {
+  return {
+    command: 'followup-importants',
+    project: getFlagValue(args, '--project', '-p'),
+    yes: hasFlag(args, '--yes', '-y'),
   };
 }
 
@@ -154,5 +168,7 @@ export function parseCliArgs(args: string[]): CliArgs {
       return parseInitArgs(args);
     case 'validate':
       return parseValidateArgs(args);
+    case 'followup-importants':
+      return parseFollowupImportantsArgs(args);
   }
 }

--- a/src/interface-adapters/views/dashboard/index.html
+++ b/src/interface-adapters/views/dashboard/index.html
@@ -822,11 +822,16 @@
       const mrPrefix = mr.platform === 'github' ? '#' : '!';
       const threadInfo = type === 'pending-fix'
         ? `<span class="mr-threads has-open"><i data-lucide="message-circle"></i> ${mr.openThreads} ouvert${mr.openThreads > 1 ? 's' : ''}</span>`
-        : `<span class="mr-threads all-resolved"><i data-lucide="check-circle"></i> Résolus</span>`;
+        : (type === 'pending-approval' && mr.totalWarnings > 0)
+          ? `<span class="mr-threads has-warnings"><i data-lucide="alert-triangle"></i> ${mr.totalWarnings} important${mr.totalWarnings > 1 ? 's' : ''}</span>`
+          : `<span class="mr-threads all-resolved"><i data-lucide="check-circle"></i> Résolus</span>`;
 
       const openBtn = `<a href="${mr.url}" target="_blank" class="btn-action open"><i data-lucide="external-link"></i> Ouvrir</a>`;
       const autoFollowupChecked = mr.autoFollowup !== false ? 'checked' : '';
-      const actions = type === 'pending-fix'
+      const showFollowupActions = type === 'pending-fix' ||
+        (type === 'pending-approval' && mr.totalWarnings > 0);
+
+      const actions = showFollowupActions
         ? `<label class="auto-followup-toggle" onclick="event.stopPropagation()" title="Active/désactive le followup automatique après un push">
              <input type="checkbox" ${autoFollowupChecked} onchange="toggleAutoFollowup('${mr.id}', this.checked)">
              Auto follow-up
@@ -855,7 +860,7 @@
       return `
         <div class="mr-item-accordion" data-mr-id="${mr.id}">
           <div class="mr-item-header" onclick="toggleMrAccordion('${accordionId}')">
-            <div class="review-status ${type === 'pending-fix' ? 'running' : 'completed'}"></div>
+            <div class="review-status ${type === 'pending-fix' ? 'running' : (type === 'pending-approval' && mr.totalWarnings > 0) ? 'warnings' : 'completed'}"></div>
             <div class="mr-info">
               <div class="mr-title">
                 <a href="${mr.url}" target="_blank" onclick="event.stopPropagation()">${mrPrefix}${mr.mrNumber}</a> - ${mr.title}

--- a/src/interface-adapters/views/dashboard/styles.css
+++ b/src/interface-adapters/views/dashboard/styles.css
@@ -276,6 +276,7 @@ h1 { font-size: 1.75rem; font-weight: 600; }
 .review-status.queued { background: #3b82f6; }
 .review-status.completed { background: #22c55e; }
 .review-status.failed { background: #ef4444; }
+.review-status.warnings { background: #f59e0b; }
 
 .review-info { flex: 1; min-width: 0; }
 .review-title { font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
@@ -762,6 +763,7 @@ h1 { font-size: 1.75rem; font-weight: 600; }
 }
 .mr-threads.has-open { color: #ef4444; }
 .mr-threads.all-resolved { color: #22c55e; }
+.mr-threads.has-warnings { color: #f59e0b; }
 .mr-actions {
   display: flex;
   gap: 0.5rem;

--- a/src/tests/units/cli/parseCliArgs.test.ts
+++ b/src/tests/units/cli/parseCliArgs.test.ts
@@ -247,6 +247,60 @@ describe('parseCliArgs', () => {
     });
   });
 
+  describe('followup-importants command', () => {
+    it('should detect followup-importants command', () => {
+      const result = parseCliArgs(['followup-importants']);
+
+      expect(result.command).toBe('followup-importants');
+    });
+
+    it('should detect --project flag with value', () => {
+      const result = parseCliArgs(['followup-importants', '--project', '/path/to/repo']);
+
+      expect(result).toEqual(expect.objectContaining({
+        command: 'followup-importants',
+        project: '/path/to/repo',
+      }));
+    });
+
+    it('should detect -p short flag for project', () => {
+      const result = parseCliArgs(['followup-importants', '-p', '/path/to/repo']);
+
+      expect(result).toEqual(expect.objectContaining({
+        command: 'followup-importants',
+        project: '/path/to/repo',
+      }));
+    });
+
+    it('should detect --yes flag', () => {
+      const result = parseCliArgs(['followup-importants', '--yes']);
+
+      expect(result).toEqual(expect.objectContaining({
+        command: 'followup-importants',
+        yes: true,
+      }));
+    });
+
+    it('should detect -y short flag for yes', () => {
+      const result = parseCliArgs(['followup-importants', '-y']);
+
+      expect(result).toEqual(expect.objectContaining({
+        command: 'followup-importants',
+        yes: true,
+      }));
+    });
+
+    it('should default project to undefined and yes to false', () => {
+      const result = parseCliArgs(['followup-importants']);
+
+      expect(result).toEqual(expect.objectContaining({
+        command: 'followup-importants',
+        project: undefined,
+        yes: false,
+      }));
+    });
+  });
+
   describe('version and help flags', () => {
     it('should detect --version flag', () => {
       const result = parseCliArgs(['--version']);

--- a/src/tests/units/usecases/cli/followupImportants.usecase.test.ts
+++ b/src/tests/units/usecases/cli/followupImportants.usecase.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import { FollowupImportantsUseCase } from '../../../../usecases/cli/followupImportants.usecase.js';
+
+function createMockFetch(response: object) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(response),
+  });
+}
+
+function createDeps(overrides: Partial<Parameters<typeof FollowupImportantsUseCase.prototype.execute>[1]> = {}) {
+  return {
+    serverPort: 3000,
+    log: vi.fn(),
+    error: vi.fn(),
+    fetch: createMockFetch({ success: true, triggered: 0, candidates: [], failed: [] }),
+    ...overrides,
+  };
+}
+
+describe('FollowupImportantsUseCase', () => {
+  it('should call the batch API endpoint', async () => {
+    const fetch = createMockFetch({ success: true, triggered: 0, candidates: [], failed: [] });
+    const deps = createDeps({ fetch });
+    const usecase = new FollowupImportantsUseCase(deps);
+
+    await usecase.execute({});
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:3000/api/mr-tracking/followup-importants',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('should pass projectPath when provided', async () => {
+    const fetch = createMockFetch({ success: true, triggered: 0, candidates: [], failed: [] });
+    const deps = createDeps({ fetch });
+    const usecase = new FollowupImportantsUseCase(deps);
+
+    await usecase.execute({ project: '/path/to/repo' });
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: JSON.stringify({ projectPath: '/path/to/repo' }),
+      }),
+    );
+  });
+
+  it('should log message when no candidates found', async () => {
+    const deps = createDeps();
+    const usecase = new FollowupImportantsUseCase(deps);
+
+    await usecase.execute({});
+
+    expect(deps.log).toHaveBeenCalledWith(expect.stringContaining('No pending-approval'));
+  });
+
+  it('should log triggered count and candidate details', async () => {
+    const fetch = createMockFetch({
+      success: true,
+      triggered: 2,
+      candidates: [
+        { mrId: 'gitlab-proj-10', mrNumber: 10, title: 'Fix auth' },
+        { mrId: 'gitlab-proj-11', mrNumber: 11, title: 'Add tests' },
+      ],
+      failed: [],
+    });
+    const deps = createDeps({ fetch });
+    const usecase = new FollowupImportantsUseCase(deps);
+
+    await usecase.execute({});
+
+    expect(deps.log).toHaveBeenCalledWith(expect.stringContaining('2'));
+    expect(deps.log).toHaveBeenCalledWith(expect.stringContaining('!10'));
+    expect(deps.log).toHaveBeenCalledWith(expect.stringContaining('!11'));
+  });
+
+  it('should log failures when some followups fail', async () => {
+    const fetch = createMockFetch({
+      success: true,
+      triggered: 1,
+      candidates: [
+        { mrId: 'gitlab-proj-10', mrNumber: 10, title: 'Fix auth' },
+      ],
+      failed: [{ mrId: 'gitlab-proj-11', error: 'timeout' }],
+    });
+    const deps = createDeps({ fetch });
+    const usecase = new FollowupImportantsUseCase(deps);
+
+    await usecase.execute({});
+
+    expect(deps.error).toHaveBeenCalledWith(expect.stringContaining('1 failed'));
+  });
+});

--- a/src/usecases/cli/followupImportants.usecase.ts
+++ b/src/usecases/cli/followupImportants.usecase.ts
@@ -1,0 +1,53 @@
+interface FollowupImportantsDependencies {
+  serverPort: number;
+  log: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+  fetch: typeof globalThis.fetch;
+}
+
+interface FollowupImportantsInput {
+  project?: string;
+}
+
+interface FollowupImportantsCandidate {
+  mrId: string;
+  mrNumber: number;
+  title: string;
+}
+
+interface FollowupImportantsResponse {
+  success: boolean;
+  triggered: number;
+  candidates: FollowupImportantsCandidate[];
+  failed: Array<{ mrId: string; error: string }>;
+}
+
+export class FollowupImportantsUseCase {
+  constructor(private readonly deps: FollowupImportantsDependencies) {}
+
+  async execute(input: FollowupImportantsInput, _deps?: unknown): Promise<void> {
+    const baseUrl = `http://localhost:${this.deps.serverPort}`;
+
+    const response = await this.deps.fetch(`${baseUrl}/api/mr-tracking/followup-importants`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectPath: input.project }),
+    });
+
+    const data = (await response.json()) as FollowupImportantsResponse;
+
+    if (!data.candidates || data.candidates.length === 0) {
+      this.deps.log('No pending-approval MRs with Important issues found.');
+      return;
+    }
+
+    this.deps.log(`Triggered ${data.triggered} followup(s):`);
+    for (const candidate of data.candidates) {
+      this.deps.log(`  - !${candidate.mrNumber}: ${candidate.title}`);
+    }
+
+    if (data.failed && data.failed.length > 0) {
+      this.deps.error(`${data.failed.length} failed.`);
+    }
+  }
+}

--- a/src/usecases/tracking/checkFollowupNeeded.usecase.ts
+++ b/src/usecases/tracking/checkFollowupNeeded.usecase.ts
@@ -14,7 +14,12 @@ export class CheckFollowupNeededUseCase implements UseCase<CheckFollowupNeededIn
     const mr = this.trackingGateway.getByNumber(input.projectPath, input.mrNumber, input.platform);
 
     if (!mr) return false;
-    if (mr.state !== 'pending-fix') return false;
+
+    const eligibleForFollowup =
+      mr.state === 'pending-fix' ||
+      (mr.state === 'pending-approval' && mr.totalWarnings > 0);
+
+    if (!eligibleForFollowup) return false;
     if (!mr.lastPushAt || !mr.lastReviewAt) return false;
 
     return new Date(mr.lastPushAt).getTime() > new Date(mr.lastReviewAt).getTime();


### PR DESCRIPTION
## Summary

- **Extend auto-followup eligibility** to `pending-approval` MRs that have unresolved Important (⚠️) issues (`totalWarnings > 0`)
- **Dashboard**: show followup button + auto-followup toggle for qualifying pending-approval MRs, with amber warning indicator
- **Batch API route**: `POST /api/mr-tracking/followup-importants` to trigger followups across all repos (uses `fastify.inject()` to reuse existing handler)
- **CLI command**: `reviewflow followup-importants` with `--project` and `--yes` flags
- **Webhook auto-followup**: automatically triggers on push events for pending-approval MRs with warnings (no controller changes needed - propagates from usecase)

## Test plan

- [x] 7 unit tests for `CheckFollowupNeededUseCase` (4 new: pending-approval with/without warnings)
- [x] 35 unit tests for `parseCliArgs` (6 new: followup-importants command)
- [x] 5 unit tests for `FollowupImportantsUseCase` (new file)
- [x] TypeScript typecheck passes
- [x] Biome lint passes
- [ ] Manual: open dashboard, verify pending-approval MRs with warnings show followup button
- [ ] Manual: click followup button on a qualifying MR
- [ ] Manual: `reviewflow followup-importants` CLI command

🤖 Generated with [Claude Code](https://claude.com/claude-code)