### PR TITLE
fix(config): allow empty usernames for single-platform users

### DIFF
--- a/src/frameworks/config/configLoader.ts
+++ b/src/frameworks/config/configLoader.ts
@@ -115,7 +115,7 @@ function enrichRepository(input: RepositoryInput): RepositoryConfig | null {
   };
 }
 
-function validateAndEnrichConfig(data: unknown): Config {
+export function validateAndEnrichConfig(data: unknown): Config {
   if (!data || typeof data !== 'object') {
     throw new Error('Configuration invalide : objet attendu');
   }
@@ -136,11 +136,11 @@ function validateAndEnrichConfig(data: unknown): Config {
     throw new Error('Configuration invalide : section "user" manquante');
   }
   const user = config.user as Record<string, unknown>;
-  if (typeof user.gitlabUsername !== 'string' || !user.gitlabUsername) {
-    throw new Error('Configuration invalide : gitlabUsername manquant');
+  if (typeof user.gitlabUsername !== 'string') {
+    throw new Error('Invalid configuration: gitlabUsername must be a string');
   }
-  if (typeof user.githubUsername !== 'string' || !user.githubUsername) {
-    throw new Error('Configuration invalide : githubUsername manquant');
+  if (typeof user.githubUsername !== 'string') {
+    throw new Error('Invalid configuration: githubUsername must be a string');
   }
 
   // Validate queue

--- a/src/tests/units/frameworks/config/configLoader.test.ts
+++ b/src/tests/units/frameworks/config/configLoader.test.ts
@@ -1,0 +1,97 @@
+import { validateAndEnrichConfig } from '../../../../frameworks/config/configLoader.js'
+
+function createValidConfig(userOverrides: Record<string, unknown> = {}) {
+  return {
+    server: { port: 3000 },
+    user: {
+      gitlabUsername: 'my-gitlab-user',
+      githubUsername: 'my-github-user',
+      ...userOverrides,
+    },
+    queue: { maxConcurrent: 2, deduplicationWindowMs: 5000 },
+    repositories: [],
+  }
+}
+
+describe('validateAndEnrichConfig', () => {
+  describe('username validation', () => {
+    it('should accept both non-empty usernames', () => {
+      const config = createValidConfig()
+
+      const result = validateAndEnrichConfig(config)
+
+      expect(result.user.gitlabUsername).toBe('my-gitlab-user')
+      expect(result.user.githubUsername).toBe('my-github-user')
+    })
+
+    it('should accept empty gitlabUsername with non-empty githubUsername', () => {
+      const config = createValidConfig({
+        gitlabUsername: '',
+        githubUsername: 'my-github-user',
+      })
+
+      const result = validateAndEnrichConfig(config)
+
+      expect(result.user.gitlabUsername).toBe('')
+      expect(result.user.githubUsername).toBe('my-github-user')
+    })
+
+    it('should accept empty githubUsername with non-empty gitlabUsername', () => {
+      const config = createValidConfig({
+        gitlabUsername: 'my-gitlab-user',
+        githubUsername: '',
+      })
+
+      const result = validateAndEnrichConfig(config)
+
+      expect(result.user.gitlabUsername).toBe('my-gitlab-user')
+      expect(result.user.githubUsername).toBe('')
+    })
+
+    it('should accept both usernames empty', () => {
+      const config = createValidConfig({
+        gitlabUsername: '',
+        githubUsername: '',
+      })
+
+      const result = validateAndEnrichConfig(config)
+
+      expect(result.user.gitlabUsername).toBe('')
+      expect(result.user.githubUsername).toBe('')
+    })
+
+    it('should reject non-string gitlabUsername', () => {
+      const config = createValidConfig({ gitlabUsername: 123 })
+
+      expect(() => validateAndEnrichConfig(config)).toThrow(
+        'gitlabUsername',
+      )
+    })
+
+    it('should reject missing gitlabUsername field', () => {
+      const config = createValidConfig()
+      ;(config.user as Record<string, unknown>).gitlabUsername = undefined
+
+      expect(() => validateAndEnrichConfig(config)).toThrow(
+        'gitlabUsername',
+      )
+    })
+
+    it('should reject non-string githubUsername', () => {
+      const config = createValidConfig({ githubUsername: true })
+
+      expect(() => validateAndEnrichConfig(config)).toThrow(
+        'githubUsername',
+      )
+    })
+
+    it('should reject missing githubUsername field', () => {
+      const config = createValidConfig()
+      ;(config.user as Record<string, unknown>).githubUsername = undefined
+
+      expect(() => validateAndEnrichConfig(config)).toThrow(
+        'githubUsername',
+      )
+    })
+  })
+})

--- a/src/tests/units/interface-adapters/controllers/webhook/eventFilter.test.ts
+++ b/src/tests/units/interface-adapters/controllers/webhook/eventFilter.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../../../../config/loader.js', () => ({
   })),
 }))
 
+import { loadConfig } from '../../../../../config/loader.js'
 import {
   filterGitLabEvent,
   filterGitLabMrUpdate,
@@ -482,6 +483,32 @@ describe('filterGitHubLabelEvent', () => {
       expect(result.shouldProcess).toBe(false)
       expect(result.reason).toContain('closed')
     })
+  })
+})
+
+describe('filterGitLabEvent with empty gitlabUsername', () => {
+  it('should not process when gitlabUsername is empty', () => {
+    vi.mocked(loadConfig).mockReturnValueOnce({
+      user: { gitlabUsername: '', githubUsername: 'claude-reviewer' },
+    } as ReturnType<typeof loadConfig>)
+    const event = GitLabEventFactory.createWithReviewerAdded('claude-reviewer')
+
+    const result = filterGitLabEvent(event)
+
+    expect(result.shouldProcess).toBe(false)
+  })
+})
+
+describe('filterGitHubEvent with empty githubUsername', () => {
+  it('should not process when githubUsername is empty', () => {
+    vi.mocked(loadConfig).mockReturnValueOnce({
+      user: { gitlabUsername: 'claude-reviewer', githubUsername: '' },
+    } as ReturnType<typeof loadConfig>)
+    const event = GitHubEventFactory.createReviewRequestedPr('claude-reviewer')
+
+    const result = filterGitHubEvent(event)
+
+    expect(result.shouldProcess).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary

- **Fix config validation**: `validateAndEnrichConfig` now accepts empty strings for `gitlabUsername`/`githubUsername`, enabling GitHub-only (or GitLab-only) users to start the server without filling in the other platform's username
- **Export `validateAndEnrichConfig`** for direct unit testing without filesystem mocking
- **10 new tests**: 8 for username validation in `configLoader`, 2 for empty-username event filtering behavior

## Context

`reviewflow init` marks platform usernames as optional, but the validation layer rejected empty strings (`""`) with a hard error. This blocked GitHub-only npm users from starting the server.

## Test plan

- [x] `yarn test:ci` — 763/763 tests pass
- [x] `yarn typecheck` — clean
- [x] `yarn lint` — clean
- [x] New tests cover: empty strings accepted, non-string rejected, missing field rejected, both empty accepted
- [x] Event filter tests confirm empty username → `shouldProcess: false` (events silently ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)