### PR TITLE
feat(dashboard): extract utility modules and add i18n support

### DIFF
--- a/src/interface-adapters/views/dashboard/index.html
+++ b/src/interface-adapters/views/dashboard/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -14,56 +14,56 @@
       <h1>Reviewflow</h1>
       <div class="header-actions">
         <button id="check-claude-btn" class="btn btn-primary" onclick="checkClaudeStatus()">
-          <i data-lucide="search"></i> Vérifier Claude
+          <i data-lucide="search"></i> <span id="i18n-check-claude"></span>
         </button>
         <button id="toggle-logs-btn" class="btn btn-secondary" onclick="toggleLogs()">
-          <i data-lucide="scroll-text"></i> Logs
+          <i data-lucide="scroll-text"></i> <span id="i18n-logs-btn"></span>
         </button>
         <div id="server-status" class="status-indicator connecting">
           <span class="status-dot"></span>
-          <span>Connexion...</span>
+          <span id="i18n-server-status"></span>
         </div>
       </div>
     </header>
 
     <div class="cards">
       <div class="card">
-        <div class="card-label">En cours</div>
+        <div class="card-label" id="i18n-card-running"></div>
         <div id="running-count" class="card-value running">-</div>
       </div>
       <div class="card">
-        <div class="card-label">En attente</div>
+        <div class="card-label" id="i18n-card-queued"></div>
         <div id="queued-count" class="card-value queued">-</div>
       </div>
       <div class="card">
-        <div class="card-label">Terminées</div>
+        <div class="card-label" id="i18n-card-completed"></div>
         <div id="completed-count" class="card-value">-</div>
       </div>
       <div class="card">
-        <div class="card-label">Claude CLI</div>
+        <div class="card-label" id="i18n-card-claude-cli"></div>
         <div id="claude-status" class="card-claude checking">
-          <span class="status">Vérification...</span>
+          <span class="status" id="i18n-claude-checking"></span>
           <span class="version"></span>
         </div>
       </div>
       <div class="card" id="git-cli-card">
-        <div class="card-label" id="git-cli-label">Git CLI</div>
+        <div class="card-label" id="git-cli-label"></div>
         <div id="git-cli-status" class="card-claude checking">
-          <span class="status">Charger un projet...</span>
+          <span class="status" id="i18n-git-load-project"></span>
           <span class="version"></span>
         </div>
       </div>
       <div class="card">
-        <div class="card-label">Modèle</div>
+        <div class="card-label" id="i18n-card-model"></div>
         <div class="card-model">
           <select id="model-select" class="model-select" onchange="changeModel(this.value)">
-            <option value="opus">Opus (puissant)</option>
-            <option value="sonnet">Sonnet (rapide)</option>
+            <option value="opus" id="i18n-model-opus"></option>
+            <option value="sonnet" id="i18n-model-sonnet"></option>
           </select>
         </div>
       </div>
       <div class="card">
-        <div class="card-label">Langue</div>
+        <div class="card-label" id="i18n-card-language"></div>
         <div class="card-model">
           <select id="language-select" class="model-select" onchange="changeLanguage(this.value)">
             <option value="en">English</option>
@@ -75,15 +75,14 @@
 
     <div class="project-loader">
       <select id="project-select" class="project-input" style="min-width: 350px;" onchange="onProjectSelect(this.value)">
-        <option value="">-- Sélectionner un projet --</option>
+        <option value="" id="i18n-project-placeholder"></option>
       </select>
       <input type="text" id="project-path-input" class="project-input" style="min-width: 250px;"
-             placeholder="Ou entrer un nouveau chemin..."
              value="">
       <button class="btn btn-primary" onclick="loadProjectConfig()">
-        <i data-lucide="folder-open"></i> Charger
+        <i data-lucide="folder-open"></i> <span id="i18n-project-load"></span>
       </button>
-      <button class="btn btn-secondary" onclick="removeCurrentProject()" title="Retirer de la liste">
+      <button id="remove-project-btn" class="btn btn-secondary" onclick="removeCurrentProject()">
         <i data-lucide="trash-2"></i>
       </button>
       <span id="config-status" class="config-status hidden"></span>
@@ -91,108 +90,114 @@
     <div id="config-info" class="config-info hidden"></div>
 
     <div id="claude-login-section" class="login-instructions hidden">
-      <strong><i data-lucide="alert-triangle"></i> Claude n'est pas authentifié</strong>
-      <p style="margin-top: 0.5rem;">Exécutez cette commande dans un terminal :</p>
+      <strong><i data-lucide="alert-triangle"></i> <span id="i18n-claude-login-title"></span></strong>
+      <p style="margin-top: 0.5rem;" id="i18n-claude-login-instruction"></p>
       <p style="margin-top: 0.5rem;"><code>claude login</code></p>
-      <p style="margin-top: 0.5rem; font-size: 0.875rem; color: #a1a1aa;">Puis rechargez cette page.</p>
+      <p style="margin-top: 0.5rem; font-size: 0.875rem; color: #a1a1aa;" id="i18n-claude-login-reload"></p>
     </div>
 
     <div id="git-login-section" class="login-instructions hidden">
-      <strong id="git-login-title"><i data-lucide="alert-triangle"></i> CLI non authentifié</strong>
+      <strong id="git-login-title"><i data-lucide="alert-triangle"></i> <span id="i18n-git-login-title"></span></strong>
       <div style="margin-top: 0.75rem;" id="git-login-instructions"></div>
     </div>
 
     <div id="logs-section" class="section hidden">
       <div class="section-header">
-        <i data-lucide="scroll-text"></i> Logs récents
-        <span id="error-count" class="badge-count hidden">0 erreurs</span>
+        <i data-lucide="scroll-text"></i> <span id="i18n-section-logs"></span>
+        <span id="error-count" class="badge-count hidden"></span>
       </div>
       <div id="logs-content" class="section-content logs">
-        <div class="empty-state">Aucun log</div>
+        <div class="empty-state" id="i18n-empty-logs"></div>
       </div>
     </div>
 
     <div id="stats-section" class="section hidden">
       <div class="section-header clickable" onclick="toggleStats()">
-        <i data-lucide="bar-chart-3"></i> Statistiques du projet
+        <i data-lucide="bar-chart-3"></i> <span id="i18n-section-stats"></span>
         <span id="stats-toggle" class="toggle-icon collapsed"><i data-lucide="chevron-down"></i></span>
       </div>
       <div id="project-stats" class="section-content stats-grid hidden">
-        <div class="empty-state">Charger un projet pour voir les stats</div>
+        <div class="empty-state" id="i18n-empty-stats"></div>
       </div>
     </div>
 
     <div class="section" id="active-reviews-section">
       <div class="section-header">
-        <i data-lucide="file-search"></i> Reviews actives
+        <i data-lucide="file-search"></i> <span id="i18n-section-active-reviews"></span>
         <span id="active-reviews-count" class="badge-count hidden">0</span>
       </div>
       <div id="active-reviews" class="section-content">
-        <div class="empty-state">Aucune review en cours</div>
+        <div class="empty-state" id="i18n-empty-active-reviews"></div>
       </div>
     </div>
 
     <div class="section hidden" id="active-followups-section">
       <div class="section-header">
-        <i data-lucide="refresh-cw"></i> Followups actifs
+        <i data-lucide="refresh-cw"></i> <span id="i18n-section-active-followups"></span>
         <span id="active-followups-count" class="badge-count hidden">0</span>
       </div>
       <div id="active-followups" class="section-content">
-        <div class="empty-state">Aucun followup en cours</div>
+        <div class="empty-state" id="i18n-empty-active-followups"></div>
       </div>
     </div>
 
     <div class="section hidden" id="pending-fix-section">
       <div class="section-header">
-        <i data-lucide="wrench"></i> En attente de correctif
+        <i data-lucide="wrench"></i> <span id="i18n-section-pending-fix"></span>
         <span id="pending-fix-count" class="badge-count hidden">0</span>
-        <button id="sync-threads-btn" class="btn-icon btn-sync" title="Synchroniser les threads GitLab" onclick="syncGitLabThreads()">
+        <button id="sync-threads-btn" class="btn-icon btn-sync" onclick="syncGitLabThreads()">
           <i data-lucide="refresh-cw"></i>
         </button>
       </div>
       <div id="pending-fix-reviews" class="section-content">
-        <div class="empty-state">Aucune MR en attente de correctif</div>
+        <div class="empty-state" id="i18n-empty-pending-fix"></div>
       </div>
     </div>
 
     <div class="section hidden" id="pending-approval-section">
       <div class="section-header">
-        <i data-lucide="circle-check"></i> En attente d'approbation
+        <i data-lucide="circle-check"></i> <span id="i18n-section-pending-approval"></span>
         <span id="pending-approval-count" class="badge-count hidden">0</span>
       </div>
       <div id="pending-approval-reviews" class="section-content">
-        <div class="empty-state">Aucune MR en attente d'approbation</div>
+        <div class="empty-state" id="i18n-empty-pending-approval"></div>
       </div>
     </div>
 
     <div class="section">
       <div class="section-header">
-        <i data-lucide="file-check"></i> Reviews terminées
+        <i data-lucide="file-check"></i> <span id="i18n-section-completed-reviews"></span>
       </div>
       <div id="recent-reviews" class="section-content">
-        <div class="empty-state">Chargement...</div>
+        <div class="empty-state" id="i18n-empty-loading"></div>
       </div>
     </div>
 
     <div class="refresh-info">
-      <span id="connection-mode">WebSocket temps réel</span> • Fallback polling 5s
+      <span id="connection-mode"></span> • <span id="i18n-connection-fallback"></span>
     </div>
   </div>
 
   <div id="cancel-modal" class="modal-overlay hidden" onclick="closeCancelModal(event)">
     <div class="modal-content" onclick="event.stopPropagation()">
       <div class="modal-title" id="cancel-modal-title"></div>
-      <div class="modal-message">Cette action est irréversible. La review sera arrêtée immédiatement.</div>
+      <div class="modal-message" id="i18n-modal-message"></div>
       <div class="modal-actions">
-        <button class="btn-modal-back" onclick="closeCancelModal()">Revenir</button>
-        <button class="btn-modal-confirm" id="cancel-modal-confirm" onclick="confirmCancelReview()">Confirmer</button>
+        <button class="btn-modal-back" onclick="closeCancelModal()" id="i18n-modal-back"></button>
+        <button class="btn-modal-confirm" id="cancel-modal-confirm" onclick="confirmCancelReview()"></button>
       </div>
     </div>
   </div>
 
   <div id="toast-container" class="toast-container"></div>
 
-  <script>
+  <script type="module">
+    import { t, setLanguage, getLanguage } from './modules/i18n.js';
+    import { formatTime, formatDuration, formatPhase, formatLogTime } from './modules/formatting.js';
+    import { escapeHtml, markdownToHtml } from './modules/html.js';
+    import { getAgentIcon, icon, refreshIcons } from './modules/icons.js';
+    import { MAX_RECONNECT_ATTEMPTS, RECONNECT_DELAY, STORAGE_KEY_PROJECTS, STORAGE_KEY_CURRENT } from './modules/constants.js';
+
     const API_URL = window.location.origin;
     const WS_URL = `ws://${window.location.host}/ws`;
 
@@ -200,59 +205,10 @@
     let wsConnected = false;
     let reconnectAttempts = 0;
     let logsVisible = false;
-    const MAX_RECONNECT_ATTEMPTS = 10;
-    const RECONNECT_DELAY = 3000;
 
     let currentData = { activeReviews: [], recentReviews: [], logs: [], reviewFiles: [], pendingFix: [], pendingApproval: [] };
-    let loadedReviews = {}; // Cache for loaded review content
-    let statsCollapsed = true; // Track stats section state (collapsed by default)
-
-    // Agent status icons (will be replaced with Lucide icons after render)
-    const agentIconNames = { pending: 'clock', running: 'loader', completed: 'check', failed: 'x' };
-    const getAgentIcon = (status) => `<i data-lucide="${agentIconNames[status] || 'help-circle'}"></i>`;
-
-    function formatTime(dateStr) {
-      if (!dateStr) return '-';
-      const date = new Date(dateStr);
-      const now = new Date();
-      const diff = now - date;
-      if (diff < 60000) return "À l'instant";
-      if (diff < 3600000) return `Il y a ${Math.floor(diff / 60000)} min`;
-      if (diff < 86400000) return `Il y a ${Math.floor(diff / 3600000)}h`;
-      return date.toLocaleDateString('fr-FR');
-    }
-
-    function formatDuration(startStr, endStr, totalMs) {
-      let diff;
-      if (totalMs !== undefined && totalMs !== null) {
-        diff = Math.floor(totalMs / 1000);
-      } else if (startStr) {
-        const start = new Date(startStr);
-        const end = endStr ? new Date(endStr) : new Date();
-        diff = Math.floor((end - start) / 1000);
-      } else {
-        return '';
-      }
-      if (diff < 60) return `${diff}s`;
-      if (diff < 3600) return `${Math.floor(diff / 60)}m ${diff % 60}s`;
-      return `${Math.floor(diff / 3600)}h ${Math.floor((diff % 3600) / 60)}m`;
-    }
-
-    function formatPhase(phase) {
-      const labels = {
-        'initializing': 'Initialisation',
-        'agents-running': 'Agents en cours',
-        'synthesizing': 'Synthèse',
-        'publishing': 'Publication',
-        'completed': 'Terminé'
-      };
-      return labels[phase] || phase;
-    }
-
-    function formatLogTime(timestamp) {
-      const date = new Date(timestamp);
-      return date.toLocaleTimeString('fr-FR');
-    }
+    let loadedReviews = {};
+    let statsCollapsed = true;
 
     function renderAgentTimeline(progress) {
       if (!progress?.agents?.length) return '';
@@ -292,16 +248,14 @@
         ${renderProgressBar(review.progress)}
       ` : '';
 
-      // Assignee info with avatar
       const assignerUsername = review.assignedBy?.username || 'unknown';
       const assignerDisplay = review.assignedBy?.displayName || assignerUsername;
       const assignerInitial = assignerDisplay.charAt(0).toUpperCase();
 
-      // Description accordion (for active reviews)
       const descriptionHtml = isActive && review.description ? `
         <div class="review-description-accordion">
           <div class="review-description-toggle" onclick="toggleReviewDescription('${review.id}')">
-            <i data-lucide="chevron-right"></i> Description
+            <i data-lucide="chevron-right"></i> ${t('review.description')}
           </div>
           <div class="review-description-content" id="review-desc-${review.id.replace(/[^a-zA-Z0-9-]/g, '-')}">
             <div class="review-description-text">${escapeHtml(review.description)}</div>
@@ -309,7 +263,6 @@
         </div>
       ` : '';
 
-      // Title: use MR title if available, else fallback to project name
       const displayTitle = review.title || project;
 
       return `
@@ -326,7 +279,7 @@
               </div>
               ${review.error ? `<div class="error-message">${review.error}</div>` : ''}
             </div>
-            ${isActive ? `<button class="btn-cancel-review" onclick="event.stopPropagation(); showCancelModal('${review.id}', ${mrNumber}, '${review.jobType || 'review'}')" title="Annuler"><i data-lucide="x"></i> Annuler</button>` : ''}
+            ${isActive ? `<button class="btn-cancel-review" onclick="event.stopPropagation(); showCancelModal('${review.id}', ${mrNumber}, '${review.jobType || 'review'}')" title="${t('button.cancel')}"><i data-lucide="x"></i> ${t('button.cancel')}</button>` : ''}
             <div class="review-assigner">
               <div class="review-assigner-info">
                 <span class="review-assigner-name">${assignerDisplay}</span>
@@ -358,13 +311,6 @@
       }
     }
 
-    function escapeHtml(text) {
-      if (!text) return '';
-      const div = document.createElement('div');
-      div.textContent = text;
-      return div.innerHTML;
-    }
-
     function renderLog(log) {
       const dataStr = log.data ? JSON.stringify(log.data, null, 2) : '';
       return `
@@ -380,7 +326,6 @@
     }
 
     function updateUI() {
-      // Separate reviews and followups
       const reviews = currentData.activeReviews.filter(r => r.jobType !== 'followup');
       const followups = currentData.activeReviews.filter(r => r.jobType === 'followup');
 
@@ -390,7 +335,6 @@
       document.getElementById('queued-count').textContent = queued;
       document.getElementById('completed-count').textContent = currentData.reviewFiles.length;
 
-      // Update Reviews section
       const activeReviewsSection = document.getElementById('active-reviews-section');
       const activeReviewsEl = document.getElementById('active-reviews');
       const activeReviewsCount = document.getElementById('active-reviews-count');
@@ -404,7 +348,6 @@
         activeReviewsCount.classList.remove('hidden');
       }
 
-      // Update Followups section
       const activeFollowupsSection = document.getElementById('active-followups-section');
       const activeFollowupsEl = document.getElementById('active-followups');
       const activeFollowupsCount = document.getElementById('active-followups-count');
@@ -419,7 +362,6 @@
       }
 
       refreshIcons();
-      // Note: recent-reviews is managed by updateReviewFilesUI() - don't overwrite here
     }
 
     function updateLogs() {
@@ -428,80 +370,34 @@
       const errorBadge = document.getElementById('error-count');
 
       if (errorCount > 0) {
-        errorBadge.textContent = `${errorCount} erreurs`;
+        errorBadge.textContent = t('logs.errorCount', { count: errorCount });
         errorBadge.classList.remove('hidden');
       } else {
         errorBadge.classList.add('hidden');
       }
 
       if (currentData.logs.length === 0) {
-        logsEl.innerHTML = '<div class="empty-state">Aucun log</div>';
+        logsEl.innerHTML = `<div class="empty-state">${t('empty.logs')}</div>`;
       } else {
         logsEl.innerHTML = currentData.logs.slice().reverse().map(renderLog).join('');
       }
     }
 
-    function updateConnectionStatus(status, text) {
+    function updateConnectionStatus(status, textKey, textFallback) {
       const statusEl = document.getElementById('server-status');
       statusEl.className = `status-indicator ${status}`;
-      statusEl.innerHTML = `<span class="status-dot"></span><span>${text}</span>`;
+      const displayText = textKey ? t(textKey) : textFallback;
+      statusEl.innerHTML = `<span class="status-dot"></span><span>${displayText}</span>`;
 
       const modeEl = document.getElementById('connection-mode');
       modeEl.textContent = status === 'online' && wsConnected
-        ? 'WebSocket temps réel'
-        : status === 'online' ? 'Mode polling' : 'Déconnecté';
-    }
-
-    // Simple markdown to HTML converter
-    function markdownToHtml(md) {
-      let html = md
-        // Escape HTML
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        // Code blocks
-        .replace(/```(\w*)\n([\s\S]*?)```/g, '<pre><code>$2</code></pre>')
-        // Inline code
-        .replace(/`([^`]+)`/g, '<code>$1</code>')
-        // Headers
-        .replace(/^### (.+)$/gm, '<h3>$1</h3>')
-        .replace(/^## (.+)$/gm, '<h2>$1</h2>')
-        .replace(/^# (.+)$/gm, '<h1>$1</h1>')
-        // Bold
-        .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
-        // Italic
-        .replace(/\*([^*]+)\*/g, '<em>$1</em>')
-        // Links
-        .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank">$1</a>')
-        // Blockquotes
-        .replace(/^> (.+)$/gm, '<blockquote>$1</blockquote>')
-        // Unordered lists
-        .replace(/^- (.+)$/gm, '<li>$1</li>')
-        // Ordered lists
-        .replace(/^\d+\. (.+)$/gm, '<li>$1</li>')
-        // Horizontal rules
-        .replace(/^---$/gm, '<hr>')
-        // Tables (simple)
-        .replace(/^\|(.+)\|$/gm, (match, content) => {
-          const cells = content.split('|').map(c => c.trim());
-          if (cells.every(c => c.match(/^-+$/))) return '';
-          const cellTag = match.includes('---') ? 'th' : 'td';
-          return '<tr>' + cells.map(c => `<${cellTag}>${c}</${cellTag}>`).join('') + '</tr>';
-        })
-        // Wrap consecutive table rows
-        .replace(/(<tr>[\s\S]*?<\/tr>)+/g, '<table>$&</table>')
-        // Wrap consecutive list items
-        .replace(/(<li>[\s\S]*?<\/li>)+/g, '<ul>$&</ul>')
-        // Paragraphs
-        .replace(/\n\n/g, '</p><p>')
-        .replace(/\n/g, '<br>');
-
-      return '<p>' + html + '</p>';
+        ? t('connection.websocket')
+        : status === 'online' ? t('connection.polling') : t('connection.disconnected');
     }
 
     function renderReviewFile(review) {
       const typeIcon = review.type === 'review' ? 'file-text' : review.type === 'followup' ? 'refresh-cw' : 'file';
-      const typeLabel = review.type === 'review' ? 'Review' : review.type === 'followup' ? 'Followup' : review.type;
+      const typeLabel = review.type === 'review' ? t('review.type.review') : review.type === 'followup' ? t('review.type.followup') : review.type;
       const sizeKb = (review.size / 1024).toFixed(1);
       const mrLabel = getMrLabel();
 
@@ -518,11 +414,11 @@
               </div>
             </div>
             <div class="review-time" onclick="toggleReviewAccordion('${review.filename}')" style="cursor: pointer;">${review.date}</div>
-            <button class="btn-delete" onclick="deleteReviewFile('${review.filename}')" title="Supprimer"><i data-lucide="trash-2"></i></button>
+            <button class="btn-delete" onclick="deleteReviewFile('${review.filename}')" title="${t('button.delete')}"><i data-lucide="trash-2"></i></button>
           </div>
           <div class="review-accordion-content">
             <div class="markdown-content" id="review-content-${review.filename.replace(/\./g, '-')}">
-              <div class="empty-state">Chargement...</div>
+              <div class="empty-state">${t('status.loading')}</div>
             </div>
           </div>
         </div>
@@ -533,7 +429,6 @@
       const accordion = document.querySelector(`.review-accordion[data-filename="${filename}"]`);
       const isOpen = accordion.classList.contains('open');
 
-      // Close all other accordions
       document.querySelectorAll('.review-accordion.open').forEach(el => {
         if (el !== accordion) el.classList.remove('open');
       });
@@ -547,14 +442,13 @@
       const contentId = `review-content-${filename.replace(/\./g, '-')}`;
       const contentEl = document.getElementById(contentId);
 
-      // Load content if not cached
       if (!loadedReviews[filename]) {
         try {
           const response = await fetch(`${API_URL}/api/reviews/${filename}`);
           const data = await response.json();
           loadedReviews[filename] = data.content;
         } catch (error) {
-          contentEl.innerHTML = '<div class="empty-state">Erreur de chargement</div>';
+          contentEl.innerHTML = `<div class="empty-state">${t('error.loading')}</div>`;
           return;
         }
       }
@@ -564,7 +458,6 @@
 
     async function fetchReviewFiles() {
       try {
-        // Fetch reviews for current project if loaded, otherwise all
         const url = currentProjectPath
           ? `${API_URL}/api/reviews?path=${encodeURIComponent(currentProjectPath)}`
           : `${API_URL}/api/reviews`;
@@ -581,7 +474,7 @@
       const statsEl = document.getElementById('project-stats');
 
       if (!currentProjectPath) {
-        statsEl.innerHTML = '<div class="empty-state">Charger un projet pour voir les stats</div>';
+        statsEl.innerHTML = `<div class="empty-state">${t('empty.statsNoProject')}</div>`;
         return;
       }
 
@@ -591,41 +484,41 @@
 
         if (data.summary) {
           const s = data.summary;
-          const trendIcon = (t) => t === 'up' ? '<i data-lucide="trending-up"></i>' : t === 'down' ? '<i data-lucide="trending-down"></i>' : '<i data-lucide="minus"></i>';
+          const trendIcon = (trend) => trend === 'up' ? '<i data-lucide="trending-up"></i>' : trend === 'down' ? '<i data-lucide="trending-down"></i>' : '<i data-lucide="minus"></i>';
 
           statsEl.innerHTML = `
             <div class="stat-card">
               <div class="stat-value">${s.totalReviews}</div>
-              <div class="stat-label"><i data-lucide="file-search"></i> Reviews</div>
+              <div class="stat-label"><i data-lucide="file-search"></i> ${t('stats.reviews')}</div>
             </div>
             <div class="stat-card">
               <div class="stat-value">${s.averageScore}/10 ${trendIcon(s.trend.score)}</div>
-              <div class="stat-label"><i data-lucide="star"></i> Score moyen</div>
+              <div class="stat-label"><i data-lucide="star"></i> ${t('stats.averageScore')}</div>
             </div>
             <div class="stat-card">
               <div class="stat-value">${s.totalTime}</div>
-              <div class="stat-label"><i data-lucide="timer"></i> Temps total</div>
+              <div class="stat-label"><i data-lucide="timer"></i> ${t('stats.totalTime')}</div>
             </div>
             <div class="stat-card">
               <div class="stat-value">${s.averageTime}</div>
-              <div class="stat-label"><i data-lucide="clock"></i> Durée moyenne</div>
+              <div class="stat-label"><i data-lucide="clock"></i> ${t('stats.averageTime')}</div>
             </div>
             <div class="stat-card warning">
               <div class="stat-value">${s.totalBlocking} ${trendIcon(s.trend.blocking)}</div>
-              <div class="stat-label"><i data-lucide="octagon-alert"></i> Bloquants</div>
+              <div class="stat-label"><i data-lucide="octagon-alert"></i> ${t('stats.blocking')}</div>
             </div>
             <div class="stat-card">
               <div class="stat-value">${s.totalWarnings}</div>
-              <div class="stat-label"><i data-lucide="alert-triangle"></i> Importants</div>
+              <div class="stat-label"><i data-lucide="alert-triangle"></i> ${t('stats.warnings')}</div>
             </div>
           `;
           refreshIcons();
         } else {
-          statsEl.innerHTML = '<div class="empty-state">Aucune statistique disponible</div>';
+          statsEl.innerHTML = `<div class="empty-state">${t('empty.statsNoData')}</div>`;
         }
       } catch (error) {
         console.error('Error fetching stats:', error);
-        statsEl.innerHTML = '<div class="empty-state">Erreur de chargement des stats</div>';
+        statsEl.innerHTML = `<div class="empty-state">${t('error.loadingStats')}</div>`;
       }
     }
 
@@ -633,7 +526,7 @@
       const recentEl = document.getElementById('recent-reviews');
 
       if (currentData.reviewFiles.length === 0) {
-        recentEl.innerHTML = '<div class="empty-state">Aucun fichier de review</div>';
+        recentEl.innerHTML = `<div class="empty-state">${t('empty.reviewFiles')}</div>`;
         return;
       }
 
@@ -642,7 +535,7 @@
     }
 
     async function deleteReviewFile(filename) {
-      if (!confirm(`Supprimer ${filename} ?`)) return;
+      if (!confirm(t('confirm.deleteReview', { filename }))) return;
 
       try {
         const response = await fetch(`${API_URL}/api/reviews/${filename}`, {
@@ -651,18 +544,16 @@
         const data = await response.json();
 
         if (data.success) {
-          // Remove from cache
           delete loadedReviews[filename];
-          // Remove from list and update UI
           currentData.reviewFiles = currentData.reviewFiles.filter(r => r.filename !== filename);
           updateReviewFilesUI();
-          updateUI(); // Update count
+          updateUI();
         } else {
-          alert('Erreur: ' + data.error);
+          alert(t('error.deleteReview') + ': ' + data.error);
         }
       } catch (error) {
         console.error('Error deleting review:', error);
-        alert('Erreur lors de la suppression');
+        alert(t('error.deleteReview'));
       }
     }
 
@@ -671,7 +562,7 @@
       const loginSection = document.getElementById('claude-login-section');
 
       claudeEl.className = 'card-claude checking';
-      claudeEl.innerHTML = '<span class="status">Vérification...</span>';
+      claudeEl.innerHTML = `<span class="status">${t('status.checking')}</span>`;
 
       try {
         const response = await fetch(`${API_URL}/api/claude/status`);
@@ -680,7 +571,7 @@
         if (data.available) {
           claudeEl.className = 'card-claude available';
           claudeEl.innerHTML = `
-            <span class="status"><i data-lucide="check-circle"></i> Opérationnel</span>
+            <span class="status"><i data-lucide="check-circle"></i> ${t('status.operational')}</span>
             <span class="version">${data.version}</span>
           `;
           loginSection.classList.add('hidden');
@@ -691,18 +582,17 @@
             <span class="status"><i data-lucide="x-circle"></i> ${data.message}</span>
           `;
           refreshIcons();
-          if (data.message.includes('authentifié') || data.message.includes('login')) {
+          if (data.message.includes('authentifié') || data.message.includes('login') || data.message.includes('authenticated')) {
             loginSection.classList.remove('hidden');
           }
         }
       } catch (error) {
         claudeEl.className = 'card-claude unavailable';
-        claudeEl.innerHTML = '<span class="status"><i data-lucide="x-circle"></i> Erreur de vérification</span>';
+        claudeEl.innerHTML = `<span class="status"><i data-lucide="x-circle"></i> ${t('error.checkStatus')}</span>`;
         refreshIcons();
       }
     }
 
-    // Active platform from config (gitlab or github)
     let activePlatform = null;
 
     function updateGitCliUI() {
@@ -711,44 +601,43 @@
       const loginSection = document.getElementById('git-login-section');
 
       if (!activePlatform) {
-        labelEl.textContent = 'Git CLI';
+        labelEl.textContent = t('card.gitCli');
         statusEl.className = 'card-claude checking';
-        statusEl.innerHTML = '<span class="status">Charger un projet...</span>';
+        statusEl.innerHTML = `<span class="status">${t('status.loadProject')}</span>`;
         loginSection.classList.add('hidden');
         return;
       }
 
       const isGitlab = activePlatform === 'gitlab';
-      labelEl.textContent = isGitlab ? 'GitLab CLI' : 'GitHub CLI';
+      labelEl.textContent = isGitlab ? t('card.gitlabCli') : t('card.githubCli');
 
-      // Update login section with CLI + Webhook instructions
       const titleEl = document.getElementById('git-login-title');
       const instructionsEl = document.getElementById('git-login-instructions');
 
       if (isGitlab) {
-        titleEl.innerHTML = '<i data-lucide="alert-triangle"></i> GitLab CLI non authentifié';
+        titleEl.innerHTML = `<i data-lucide="alert-triangle"></i> ${t('login.gitlab.title')}`;
         instructionsEl.innerHTML = `
-          <p><strong>1. Installer et authentifier glab :</strong></p>
+          <p><strong>${t('setup.installAndAuth', { cli: 'glab' })}</strong></p>
           <p style="margin: 0.5rem 0;"><code>sudo apt install glab</code></p>
           <p style="margin: 0.5rem 0;"><code>glab auth login</code></p>
-          <p style="margin-top: 1rem;"><strong>2. Configurer le webhook GitLab :</strong></p>
-          <p style="margin: 0.5rem 0; font-size: 0.8rem;">Settings → Webhooks → Add webhook</p>
+          <p style="margin-top: 1rem;"><strong>${t('setup.configureWebhook', { platform: 'GitLab' })}</strong></p>
+          <p style="margin: 0.5rem 0; font-size: 0.8rem;">${t('setup.webhookPath')}</p>
           <p style="margin: 0.25rem 0; font-size: 0.8rem;">URL: <code>http://&lt;your-server&gt;:3847/webhooks/gitlab</code></p>
-          <p style="margin: 0.25rem 0; font-size: 0.8rem;">Trigger: Merge request events</p>
-          <p style="margin-top: 0.75rem; font-size: 0.75rem; color: #a1a1aa;">Puis rechargez cette page.</p>
+          <p style="margin: 0.25rem 0; font-size: 0.8rem;">${t('setup.gitlab.trigger')}</p>
+          <p style="margin-top: 0.75rem; font-size: 0.75rem; color: #a1a1aa;">${t('setup.reload')}</p>
         `;
       } else {
-        titleEl.innerHTML = '<i data-lucide="alert-triangle"></i> GitHub CLI non authentifié';
+        titleEl.innerHTML = `<i data-lucide="alert-triangle"></i> ${t('login.github.title')}`;
         instructionsEl.innerHTML = `
-          <p><strong>1. Installer et authentifier gh :</strong></p>
+          <p><strong>${t('setup.installAndAuth', { cli: 'gh' })}</strong></p>
           <p style="margin: 0.5rem 0;"><code>sudo apt install gh</code></p>
           <p style="margin: 0.5rem 0;"><code>gh auth login</code></p>
-          <p style="margin-top: 1rem;"><strong>2. Configurer le webhook GitHub :</strong></p>
-          <p style="margin: 0.5rem 0; font-size: 0.8rem;">Settings → Webhooks → Add webhook</p>
+          <p style="margin-top: 1rem;"><strong>${t('setup.configureWebhook', { platform: 'GitHub' })}</strong></p>
+          <p style="margin: 0.5rem 0; font-size: 0.8rem;">${t('setup.webhookPath')}</p>
           <p style="margin: 0.25rem 0; font-size: 0.8rem;">Payload URL: <code>http://&lt;your-server&gt;:3847/webhooks/github</code></p>
-          <p style="margin: 0.25rem 0; font-size: 0.8rem;">Content type: application/json</p>
-          <p style="margin: 0.25rem 0; font-size: 0.8rem;">Events: Pull requests</p>
-          <p style="margin-top: 0.75rem; font-size: 0.75rem; color: #a1a1aa;">Puis rechargez cette page.</p>
+          <p style="margin: 0.25rem 0; font-size: 0.8rem;">${t('setup.github.contentType')}</p>
+          <p style="margin: 0.25rem 0; font-size: 0.8rem;">${t('setup.github.events')}</p>
+          <p style="margin-top: 0.75rem; font-size: 0.75rem; color: #a1a1aa;">${t('setup.reload')}</p>
         `;
       }
 
@@ -765,7 +654,7 @@
       const endpoint = isGitlab ? '/api/gitlab/status' : '/api/github/status';
 
       statusEl.className = 'card-claude checking';
-      statusEl.innerHTML = '<span class="status">Vérification...</span>';
+      statusEl.innerHTML = `<span class="status">${t('status.checking')}</span>`;
 
       try {
         const response = await fetch(`${API_URL}${endpoint}`);
@@ -774,7 +663,7 @@
         if (data.available && data.authenticated) {
           statusEl.className = 'card-claude available';
           statusEl.innerHTML = `
-            <span class="status"><i data-lucide="check-circle"></i> Opérationnel</span>
+            <span class="status"><i data-lucide="check-circle"></i> ${t('status.operational')}</span>
             <span class="version">@${data.username}</span>
           `;
           loginSection.classList.add('hidden');
@@ -792,7 +681,7 @@
         }
       } catch (error) {
         statusEl.className = 'card-claude unavailable';
-        statusEl.innerHTML = '<span class="status"><i data-lucide="x-circle"></i> Erreur de vérification</span>';
+        statusEl.innerHTML = `<span class="status"><i data-lucide="x-circle"></i> ${t('error.checkStatus')}</span>`;
         refreshIcons();
       }
     }
@@ -804,11 +693,11 @@
 
       if (logsVisible) {
         logsSection.classList.remove('hidden');
-        btn.innerHTML = '<i data-lucide="scroll-text"></i> Masquer Logs';
+        btn.innerHTML = `<i data-lucide="scroll-text"></i> ${t('header.hideLogs')}`;
         fetchLogs();
       } else {
         logsSection.classList.add('hidden');
-        btn.innerHTML = '<i data-lucide="scroll-text"></i> Logs';
+        btn.innerHTML = `<i data-lucide="scroll-text"></i> ${t('header.logs')}`;
       }
       refreshIcons();
     }
@@ -830,25 +719,24 @@
     function renderMrItem(mr, type) {
       const mrPrefix = mr.platform === 'github' ? '#' : '!';
       const threadInfo = type === 'pending-fix'
-        ? `<span class="mr-threads has-open"><i data-lucide="message-circle"></i> ${mr.openThreads} ouvert${mr.openThreads > 1 ? 's' : ''}</span>`
+        ? `<span class="mr-threads has-open"><i data-lucide="message-circle"></i> ${t('mr.threads.open', { count: mr.openThreads })}</span>`
         : (type === 'pending-approval' && mr.totalWarnings > 0)
-          ? `<span class="mr-threads has-warnings"><i data-lucide="alert-triangle"></i> ${mr.totalWarnings} important${mr.totalWarnings > 1 ? 's' : ''}</span>`
-          : `<span class="mr-threads all-resolved"><i data-lucide="check-circle"></i> Résolus</span>`;
+          ? `<span class="mr-threads has-warnings"><i data-lucide="alert-triangle"></i> ${mr.totalWarnings} ${t('stats.warnings').toLowerCase()}</span>`
+          : `<span class="mr-threads all-resolved"><i data-lucide="check-circle"></i> ${t('mr.threads.resolved')}</span>`;
 
-      const openBtn = `<a href="${mr.url}" target="_blank" class="btn-action open"><i data-lucide="external-link"></i> Ouvrir</a>`;
+      const openBtn = `<a href="${mr.url}" target="_blank" class="btn-action open"><i data-lucide="external-link"></i> ${t('button.open')}</a>`;
       const autoFollowupChecked = mr.autoFollowup !== false ? 'checked' : '';
       const showFollowupActions = type === 'pending-fix' ||
         (type === 'pending-approval' && mr.totalWarnings > 0);
 
       const actions = showFollowupActions
-        ? `<label class="auto-followup-toggle" onclick="event.stopPropagation()" title="Active/désactive le followup automatique après un push">
+        ? `<label class="auto-followup-toggle" onclick="event.stopPropagation()" title="${t('button.autoFollowup')}">
              <input type="checkbox" ${autoFollowupChecked} onchange="toggleAutoFollowup('${mr.id}', this.checked)">
-             Auto follow-up
+             ${t('button.autoFollowup')}
            </label>
-           <button class="btn-action" onclick="triggerFollowup('${mr.id}')"><i data-lucide="refresh-cw"></i> Followup</button>${openBtn}`
+           <button class="btn-action" onclick="triggerFollowup('${mr.id}')"><i data-lucide="refresh-cw"></i> ${t('button.followup')}</button>${openBtn}`
         : openBtn;
 
-      // Stats badges
       const statsBadges = [];
       if (mr.totalBlocking > 0) statsBadges.push(`<span class="stat-badge blocking"><i data-lucide="octagon-alert"></i> ${mr.totalBlocking}</span>`);
       if (mr.totalWarnings > 0) statsBadges.push(`<span class="stat-badge warning"><i data-lucide="alert-triangle"></i> ${mr.totalWarnings}</span>`);
@@ -857,13 +745,11 @@
 
       const durationFormatted = mr.totalDurationMs ? formatDuration(null, null, mr.totalDurationMs) : '';
 
-      // Assigner info with avatar
       const assignerUsername = mr.assignment?.username || 'unknown';
       const assignerDisplay = mr.assignment?.displayName || assignerUsername;
       const assignerInitial = assignerDisplay.charAt(0).toUpperCase();
       const assignedAt = mr.assignment?.assignedAt ? formatTime(mr.assignment.assignedAt) : '';
 
-      // Sanitize ID for accordion toggle
       const accordionId = mr.id.replace(/[^a-zA-Z0-9-]/g, '-');
 
       return `
@@ -892,33 +778,33 @@
           <div class="mr-item-content" id="mr-content-${accordionId}">
             <div class="mr-details">
               <div class="mr-detail-row">
-                <span class="mr-detail-label"><i data-lucide="git-branch"></i> Source:</span>
+                <span class="mr-detail-label"><i data-lucide="git-branch"></i> ${t('mr.detail.source')}</span>
                 <span class="mr-detail-value">${mr.sourceBranch}</span>
               </div>
               <div class="mr-detail-row">
-                <span class="mr-detail-label"><i data-lucide="git-merge"></i> Target:</span>
+                <span class="mr-detail-label"><i data-lucide="git-merge"></i> ${t('mr.detail.target')}</span>
                 <span class="mr-detail-value">${mr.targetBranch}</span>
               </div>
               <div class="mr-detail-row">
-                <span class="mr-detail-label"><i data-lucide="calendar"></i> Créée:</span>
+                <span class="mr-detail-label"><i data-lucide="calendar"></i> ${t('mr.detail.created')}</span>
                 <span class="mr-detail-value">${formatTime(mr.createdAt)}</span>
               </div>
               ${mr.lastReviewAt ? `
               <div class="mr-detail-row">
-                <span class="mr-detail-label"><i data-lucide="file-search"></i> Dernière review:</span>
+                <span class="mr-detail-label"><i data-lucide="file-search"></i> ${t('mr.detail.lastReview')}</span>
                 <span class="mr-detail-value">${formatTime(mr.lastReviewAt)}</span>
               </div>
               ` : ''}
               ${mr.reviews?.length ? `
               <div class="mr-reviews-history">
-                <div class="mr-detail-label"><i data-lucide="history"></i> Historique (${mr.reviews.length}):</div>
+                <div class="mr-detail-label"><i data-lucide="history"></i> ${t('mr.detail.history', { count: mr.reviews.length })}</div>
                 <div class="mr-reviews-list">
                   ${mr.reviews.slice(-5).reverse().map(r => `
                     <div class="mr-review-event ${r.type}">
-                      <span class="review-event-type">${r.type === 'review' ? 'Review' : 'Followup'}</span>
+                      <span class="review-event-type">${r.type === 'review' ? t('review.type.review') : t('review.type.followup')}</span>
                       <span class="review-event-time">${formatTime(r.timestamp)}</span>
                       ${r.score !== null ? `<span class="review-event-score">${r.score}/10</span>` : ''}
-                      ${r.blocking > 0 ? `<span class="review-event-blocking">${r.blocking} bloquant${r.blocking > 1 ? 's' : ''}</span>` : ''}
+                      ${r.blocking > 0 ? `<span class="review-event-blocking">${t('mr.review.blocking', { count: r.blocking })}</span>` : ''}
                     </div>
                   `).join('')}
                 </div>
@@ -940,7 +826,6 @@
 
       const isOpen = accordion.classList.contains('open');
 
-      // Close all other MR accordions
       document.querySelectorAll('.mr-item-accordion.open').forEach(el => {
         if (el !== accordion) {
           el.classList.remove('open');
@@ -962,9 +847,7 @@
       const pendingApprovalEl = document.getElementById('pending-approval-reviews');
       const pendingFixCount = document.getElementById('pending-fix-count');
       const pendingApprovalCount = document.getElementById('pending-approval-count');
-      const mrLabel = getMrLabel();
 
-      // Pending fix - show/hide section dynamically
       if (currentData.pendingFix.length === 0) {
         pendingFixSection.classList.add('hidden');
         pendingFixCount.classList.add('hidden');
@@ -975,7 +858,6 @@
         pendingFixCount.classList.remove('hidden');
       }
 
-      // Pending approval - show/hide section dynamically
       if (currentData.pendingApproval.length === 0) {
         pendingApprovalSection.classList.add('hidden');
         pendingApprovalCount.classList.add('hidden');
@@ -993,7 +875,6 @@
       if (!currentProjectPath) {
         currentData.pendingFix = [];
         currentData.pendingApproval = [];
-        // Hide sections when no project loaded
         document.getElementById('pending-fix-section').classList.add('hidden');
         document.getElementById('pending-approval-section').classList.add('hidden');
         return;
@@ -1023,11 +904,11 @@
         if (data.success) {
           console.log('Followup triggered for MR:', mrId);
         } else {
-          alert('Erreur: ' + data.error);
+          alert(t('error.triggerFollowup') + ': ' + data.error);
         }
       } catch (error) {
         console.error('Error triggering followup:', error);
-        alert('Erreur lors du déclenchement du followup');
+        alert(t('error.triggerFollowup'));
       }
     }
 
@@ -1040,16 +921,16 @@
         });
         const data = await response.json();
         if (!data.success) {
-          alert('Erreur: ' + data.error);
+          alert(t('error.toggleAutoFollowup') + ': ' + data.error);
         }
       } catch (error) {
         console.error('Error toggling auto-followup:', error);
-        alert('Erreur lors du changement de auto follow-up');
+        alert(t('error.toggleAutoFollowup'));
       }
     }
 
     async function approveMr(mrId) {
-      if (!confirm(`Marquer cette ${getMrLabel()} comme approuvée ?`)) return;
+      if (!confirm(t('confirm.approveMr', { label: getMrLabel() }))) return;
 
       try {
         const response = await fetch(`${API_URL}/api/mr-tracking/approve`, {
@@ -1059,30 +940,28 @@
         });
         const data = await response.json();
         if (data.success) {
-          // Remove from pending approval list
           currentData.pendingApproval = currentData.pendingApproval.filter(mr => mr.id !== mrId);
           updateMrTrackingUI();
         } else {
-          alert('Erreur: ' + data.error);
+          alert(t('error.approveMr') + ': ' + data.error);
         }
       } catch (error) {
         console.error('Error approving MR:', error);
-        alert('Erreur lors de l\'approbation');
+        alert(t('error.approveMr'));
       }
     }
 
     async function syncGitLabThreads() {
       if (!currentProjectPath) {
-        alert('Charger un projet d\'abord');
+        alert(t('error.projectNotLoaded'));
         return;
       }
 
       const btn = document.getElementById('sync-threads-btn');
-      const icon = btn.querySelector('i');
+      const iconEl = btn.querySelector('i');
 
-      // Add spinning animation
       btn.disabled = true;
-      icon.classList.add('spinning');
+      iconEl.classList.add('spinning');
 
       try {
         const response = await fetch(`${API_URL}/api/mr-tracking/sync`, {
@@ -1092,18 +971,17 @@
         });
         const data = await response.json();
         if (data.success) {
-          // Refresh MR tracking data
           await fetchMrTracking();
           console.log('Threads synchronized successfully');
         } else {
-          alert('Erreur: ' + data.error);
+          alert(t('error.syncThreads') + ': ' + data.error);
         }
       } catch (error) {
         console.error('Error syncing threads:', error);
-        alert('Erreur lors de la synchronisation des threads');
+        alert(t('error.syncThreads'));
       } finally {
         btn.disabled = false;
-        icon.classList.remove('spinning');
+        iconEl.classList.remove('spinning');
       }
     }
 
@@ -1136,7 +1014,7 @@
     function connectWebSocket() {
       if (ws?.readyState === WebSocket.OPEN) return;
 
-      updateConnectionStatus('connecting', 'Connexion...');
+      updateConnectionStatus('connecting', 'status.connecting');
 
       try {
         ws = new WebSocket(WS_URL);
@@ -1144,7 +1022,7 @@
         ws.onopen = () => {
           wsConnected = true;
           reconnectAttempts = 0;
-          updateConnectionStatus('online', 'En ligne');
+          updateConnectionStatus('online', 'connection.online');
         };
 
         ws.onmessage = (event) => {
@@ -1157,7 +1035,6 @@
                 currentData.activeReviews = message.activeReviews || [];
                 currentData.recentReviews = message.recentReviews || [];
                 updateUI();
-                // Also refresh MR tracking when state changes
                 if (message.type === 'state') {
                   fetchMrTracking();
                 }
@@ -1179,7 +1056,7 @@
         ws.onclose = () => {
           wsConnected = false;
           ws = null;
-          updateConnectionStatus('offline', 'Hors ligne');
+          updateConnectionStatus('offline', 'connection.offline');
           if (reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
             reconnectAttempts++;
             setTimeout(connectWebSocket, RECONNECT_DELAY);
@@ -1206,16 +1083,16 @@
         const data = await response.json();
         currentData.activeReviews = data.jobs?.active || [];
         currentData.recentReviews = data.jobs?.recent || [];
-        if (!wsConnected) updateConnectionStatus('online', 'En ligne (polling)');
+        if (!wsConnected) updateConnectionStatus('online', 'connection.onlinePolling');
         updateUI();
       } catch (error) {
         if (!wsConnected) {
-          updateConnectionStatus('offline', 'Hors ligne');
+          updateConnectionStatus('offline', 'connection.offline');
           document.getElementById('running-count').textContent = '-';
           document.getElementById('queued-count').textContent = '-';
           document.getElementById('completed-count').textContent = '-';
-          document.getElementById('active-reviews').innerHTML = '<div class="empty-state">Serveur non accessible</div>';
-          document.getElementById('recent-reviews').innerHTML = '<div class="empty-state">Serveur non accessible</div>';
+          document.getElementById('active-reviews').innerHTML = `<div class="empty-state">${t('empty.serverNotAccessible')}</div>`;
+          document.getElementById('recent-reviews').innerHTML = `<div class="empty-state">${t('empty.serverNotAccessible')}</div>`;
         }
       }
     }
@@ -1256,6 +1133,8 @@
         const select = document.getElementById('language-select');
         if (select && data.language) {
           select.value = data.language;
+          setLanguage(data.language);
+          renderStaticLabels();
         }
       } catch (error) {
         console.error('Error loading language setting:', error);
@@ -1263,6 +1142,15 @@
     }
 
     async function changeLanguage(language) {
+      setLanguage(language);
+      renderStaticLabels();
+      // Re-render all dynamic content
+      updateUI();
+      updateLogs();
+      updateReviewFilesUI();
+      updateMrTrackingUI();
+      updateGitCliUI();
+      // Also persist on server
       try {
         const response = await fetch(`${API_URL}/api/settings/language`, {
           method: 'POST',
@@ -1278,9 +1166,6 @@
       }
     }
 
-    // Project config loader with persistence
-    const STORAGE_KEY_PROJECTS = 'review-flow-projects';
-    const STORAGE_KEY_CURRENT = 'review-flow-current-project';
     let currentProjectConfig = null;
     let currentProjectPath = null;
 
@@ -1298,11 +1183,8 @@
 
     function addProjectToHistory(path) {
       const projects = getStoredProjects();
-      // Remove if already exists (to move to top)
       const filtered = projects.filter(p => p !== path);
-      // Add to beginning
       filtered.unshift(path);
-      // Keep max 10 projects
       saveProjects(filtered.slice(0, 10));
       updateProjectSelect();
     }
@@ -1318,7 +1200,7 @@
       const projects = getStoredProjects();
       const current = localStorage.getItem(STORAGE_KEY_CURRENT) || '';
 
-      select.innerHTML = '<option value="">-- Sélectionner un projet --</option>';
+      select.innerHTML = `<option value="">${t('project.selectPlaceholder')}</option>`;
       for (const path of projects) {
         const shortName = path.split('/').slice(-2).join('/');
         const option = document.createElement('option');
@@ -1340,11 +1222,10 @@
     async function loadProjectConfig() {
       const input = document.getElementById('project-path-input');
       const select = document.getElementById('project-select');
-      // Prioritize input field, fallback to select
       const projectPath = input.value.trim() || select.value;
 
       if (!projectPath) {
-        showConfigStatus('Sélectionnez ou entrez un chemin', 'error');
+        showConfigStatus(t('error.selectOrEnterPath'), 'error');
         return;
       }
 
@@ -1355,7 +1236,7 @@
       const status = document.getElementById('config-status');
       const info = document.getElementById('config-info');
 
-      showConfigStatus('Chargement...', 'loading');
+      showConfigStatus(t('status.loading'), 'loading');
       info.classList.add('hidden');
 
       try {
@@ -1366,11 +1247,9 @@
           currentProjectConfig = data.config;
           currentProjectPath = projectPath;
 
-          // Save to history and set as current
           addProjectToHistory(projectPath);
           localStorage.setItem(STORAGE_KEY_CURRENT, projectPath);
 
-          // Update select to show current project
           document.getElementById('project-select').value = projectPath;
           document.getElementById('project-path-input').value = '';
 
@@ -1378,7 +1257,6 @@
           showConfigStatus(`<i data-lucide="check-circle"></i> ${shortName}`, 'success');
           refreshIcons();
 
-          // Update model selector if defaultModel is set
           if (data.config.defaultModel) {
             const modelSelect = document.getElementById('model-select');
             if (modelSelect) {
@@ -1387,23 +1265,19 @@
             }
           }
 
-          // Update active platform and check CLI
           activePlatform = data.config.gitlab ? 'gitlab' : (data.config.github ? 'github' : null);
           updateGitCliUI();
 
-          // Reload reviews, stats, and MR tracking for this project
           fetchReviewFiles();
           fetchProjectStats();
           fetchMrTracking();
 
-          // Show stats section when project is loaded
           document.getElementById('stats-section').classList.remove('hidden');
 
-          // Display config info (only show active platform)
           const platformIcon = activePlatform === 'gitlab' ? '<i data-lucide="gitlab"></i> GitLab' : '<i data-lucide="github"></i> GitHub';
           info.innerHTML = `
             <span>${platformIcon}</span>
-            <span><i data-lucide="bot"></i> ${data.config.defaultModel || 'non défini'}</span>
+            <span><i data-lucide="bot"></i> ${data.config.defaultModel || t('status.undefined')}</span>
             <span><i data-lucide="file-text"></i> ${data.config.reviewSkill}</span>
             <span><i data-lucide="refresh-cw"></i> ${data.config.reviewFollowupSkill}</span>
           `;
@@ -1414,7 +1288,7 @@
           refreshIcons();
         }
       } catch (error) {
-        showConfigStatus('<i data-lucide="x-circle"></i> Erreur de chargement', 'error');
+        showConfigStatus(`<i data-lucide="x-circle"></i> ${t('error.loadingConfig')}`, 'error');
         refreshIcons();
         console.error('Error loading project config:', error);
       }
@@ -1432,56 +1306,43 @@
       const select = document.getElementById('project-select');
       const path = select.value;
       if (!path) {
-        showConfigStatus('Aucun projet sélectionné', 'error');
+        showConfigStatus(t('project.noProjectSelected'), 'error');
         return;
       }
-      if (confirm(`Retirer "${path.split('/').slice(-2).join('/')}" de la liste ?`)) {
+      const shortName = path.split('/').slice(-2).join('/');
+      if (confirm(t('confirm.removeProject', { name: shortName }))) {
         removeProjectFromHistory(path);
         localStorage.removeItem(STORAGE_KEY_CURRENT);
         currentProjectPath = null;
         currentProjectConfig = null;
         document.getElementById('config-info').classList.add('hidden');
-        showConfigStatus('Projet retiré', 'success');
+        showConfigStatus(t('project.removed'), 'success');
       }
     }
 
     function initProjectLoader() {
       updateProjectSelect();
-      // Auto-load last project
       const lastProject = localStorage.getItem(STORAGE_KEY_CURRENT);
       if (lastProject) {
         loadProjectConfigFromPath(lastProject);
       } else {
-        // No project loaded - show empty state
         document.getElementById('recent-reviews').innerHTML =
-          '<div class="empty-state">Charger un projet pour voir les reviews</div>';
+          `<div class="empty-state">${t('empty.reviewsNoProject')}</div>`;
         document.getElementById('project-stats').innerHTML =
-          '<div class="empty-state">Charger un projet pour voir les stats</div>';
+          `<div class="empty-state">${t('empty.statsNoProject')}</div>`;
       }
     }
 
-    // Lucide icon helper - call after dynamic content is added
-    function refreshIcons() {
-      lucide.createIcons();
-    }
-
-    // Icon helper for dynamic HTML
-    function icon(name, className = '') {
-      return `<i data-lucide="${name}" class="${className}"></i>`;
-    }
-
-    // Platform-aware MR/PR label
     function getMrLabel(platform = activePlatform) {
       return platform === 'github' ? 'PR' : 'MR';
     }
 
-    // Cancel review modal state
     let cancelModalJobId = null;
 
     function showCancelModal(jobId, mrNumber, jobType) {
       cancelModalJobId = jobId;
-      const typeLabel = jobType === 'followup' ? 'followup' : 'review';
-      document.getElementById('cancel-modal-title').textContent = `Annuler la ${typeLabel} de la ${getMrLabel()} !${mrNumber} (${typeLabel}) ?`;
+      const typeLabel = jobType === 'followup' ? t('review.type.followup').toLowerCase() : t('review.type.review').toLowerCase();
+      document.getElementById('cancel-modal-title').textContent = t('modal.cancel.title', { type: typeLabel, label: getMrLabel(), number: mrNumber });
       const modal = document.getElementById('cancel-modal');
       modal.classList.remove('hidden');
       requestAnimationFrame(() => modal.classList.add('visible'));
@@ -1515,17 +1376,17 @@
         if (data.success) {
           const card = document.querySelector(`.review-item[data-job-id="${jobId}"]`);
           if (card) card.remove();
-          showToast('Review annulée', 'success');
+          showToast(t('success.reviewCancelled'), 'success');
           fetchStatus();
         } else if (data.status === 'already-completed') {
-          showToast('Cette review est déjà terminée', 'info');
+          showToast(t('success.reviewAlreadyCompleted'), 'info');
           fetchStatus();
         } else {
-          showToast(data.error || 'Erreur lors de l\'annulation', 'error');
+          showToast(data.error || t('error.cancelReview'), 'error');
         }
       } catch (error) {
         console.error('Error cancelling review:', error);
-        showToast('Erreur lors de l\'annulation', 'error');
+        showToast(t('error.cancelReview'), 'error');
       }
     }
 
@@ -1544,13 +1405,173 @@
       }, 3000);
     }
 
+    function renderStaticLabels() {
+      // Header buttons
+      const checkClaudeSpan = document.getElementById('i18n-check-claude');
+      if (checkClaudeSpan) checkClaudeSpan.textContent = t('header.checkClaude');
+
+      const logsBtnSpan = document.getElementById('i18n-logs-btn');
+      if (logsBtnSpan) logsBtnSpan.textContent = logsVisible ? t('header.hideLogs') : t('header.logs');
+
+      const serverStatusSpan = document.getElementById('i18n-server-status');
+      if (serverStatusSpan) serverStatusSpan.textContent = t('status.connecting');
+
+      // Cards
+      const cardRunning = document.getElementById('i18n-card-running');
+      if (cardRunning) cardRunning.textContent = t('card.running');
+
+      const cardQueued = document.getElementById('i18n-card-queued');
+      if (cardQueued) cardQueued.textContent = t('card.queued');
+
+      const cardCompleted = document.getElementById('i18n-card-completed');
+      if (cardCompleted) cardCompleted.textContent = t('card.completed');
+
+      const cardClaudeCli = document.getElementById('i18n-card-claude-cli');
+      if (cardClaudeCli) cardClaudeCli.textContent = t('card.claudeCli');
+
+      const claudeChecking = document.getElementById('i18n-claude-checking');
+      if (claudeChecking) claudeChecking.textContent = t('status.checking');
+
+      const gitLoadProject = document.getElementById('i18n-git-load-project');
+      if (gitLoadProject) gitLoadProject.textContent = t('status.loadProject');
+
+      const gitCliLabel = document.getElementById('git-cli-label');
+      if (gitCliLabel && !activePlatform) gitCliLabel.textContent = t('card.gitCli');
+
+      const cardModel = document.getElementById('i18n-card-model');
+      if (cardModel) cardModel.textContent = t('card.model');
+
+      const cardLanguage = document.getElementById('i18n-card-language');
+      if (cardLanguage) cardLanguage.textContent = t('card.language');
+
+      // Model options
+      const modelOpus = document.getElementById('i18n-model-opus');
+      if (modelOpus) modelOpus.textContent = t('model.opus');
+
+      const modelSonnet = document.getElementById('i18n-model-sonnet');
+      if (modelSonnet) modelSonnet.textContent = t('model.sonnet');
+
+      // Project loader
+      const projectPlaceholder = document.getElementById('i18n-project-placeholder');
+      if (projectPlaceholder) projectPlaceholder.textContent = t('project.selectPlaceholder');
+
+      const projectPathInput = document.getElementById('project-path-input');
+      if (projectPathInput) projectPathInput.placeholder = t('project.inputPlaceholder');
+
+      const projectLoad = document.getElementById('i18n-project-load');
+      if (projectLoad) projectLoad.textContent = t('project.load');
+
+      const removeProjectBtn = document.getElementById('remove-project-btn');
+      if (removeProjectBtn) removeProjectBtn.title = t('project.removeTooltip');
+
+      // Login sections
+      const claudeLoginTitle = document.getElementById('i18n-claude-login-title');
+      if (claudeLoginTitle) claudeLoginTitle.textContent = t('login.claude.title');
+
+      const claudeLoginInstruction = document.getElementById('i18n-claude-login-instruction');
+      if (claudeLoginInstruction) claudeLoginInstruction.textContent = t('login.claude.instruction');
+
+      const claudeLoginReload = document.getElementById('i18n-claude-login-reload');
+      if (claudeLoginReload) claudeLoginReload.textContent = t('login.claude.reload');
+
+      const gitLoginTitle = document.getElementById('i18n-git-login-title');
+      if (gitLoginTitle) gitLoginTitle.textContent = t('login.git.title');
+
+      // Section headers
+      const sectionLogs = document.getElementById('i18n-section-logs');
+      if (sectionLogs) sectionLogs.textContent = t('section.logs');
+
+      const sectionStats = document.getElementById('i18n-section-stats');
+      if (sectionStats) sectionStats.textContent = t('section.stats');
+
+      const sectionActiveReviews = document.getElementById('i18n-section-active-reviews');
+      if (sectionActiveReviews) sectionActiveReviews.textContent = t('section.activeReviews');
+
+      const sectionActiveFollowups = document.getElementById('i18n-section-active-followups');
+      if (sectionActiveFollowups) sectionActiveFollowups.textContent = t('section.activeFollowups');
+
+      const sectionPendingFix = document.getElementById('i18n-section-pending-fix');
+      if (sectionPendingFix) sectionPendingFix.textContent = t('section.pendingFix');
+
+      const sectionPendingApproval = document.getElementById('i18n-section-pending-approval');
+      if (sectionPendingApproval) sectionPendingApproval.textContent = t('section.pendingApproval');
+
+      const sectionCompletedReviews = document.getElementById('i18n-section-completed-reviews');
+      if (sectionCompletedReviews) sectionCompletedReviews.textContent = t('section.completedReviews');
+
+      // Empty states
+      const emptyLogs = document.getElementById('i18n-empty-logs');
+      if (emptyLogs) emptyLogs.textContent = t('empty.logs');
+
+      const emptyStats = document.getElementById('i18n-empty-stats');
+      if (emptyStats) emptyStats.textContent = t('empty.stats');
+
+      const emptyActiveReviews = document.getElementById('i18n-empty-active-reviews');
+      if (emptyActiveReviews) emptyActiveReviews.textContent = t('empty.activeReviews');
+
+      const emptyActiveFollowups = document.getElementById('i18n-empty-active-followups');
+      if (emptyActiveFollowups) emptyActiveFollowups.textContent = t('empty.activeFollowups');
+
+      const emptyPendingFix = document.getElementById('i18n-empty-pending-fix');
+      if (emptyPendingFix) emptyPendingFix.textContent = t('empty.pendingFix');
+
+      const emptyPendingApproval = document.getElementById('i18n-empty-pending-approval');
+      if (emptyPendingApproval) emptyPendingApproval.textContent = t('empty.pendingApproval');
+
+      const emptyLoading = document.getElementById('i18n-empty-loading');
+      if (emptyLoading) emptyLoading.textContent = t('status.loading');
+
+      // Sync threads button
+      const syncThreadsBtn = document.getElementById('sync-threads-btn');
+      if (syncThreadsBtn) syncThreadsBtn.title = t('button.syncThreads');
+
+      // Connection footer
+      const connectionFallback = document.getElementById('i18n-connection-fallback');
+      if (connectionFallback) connectionFallback.textContent = t('connection.fallback');
+
+      // Modal
+      const modalMessage = document.getElementById('i18n-modal-message');
+      if (modalMessage) modalMessage.textContent = t('modal.cancel.message');
+
+      const modalBack = document.getElementById('i18n-modal-back');
+      if (modalBack) modalBack.textContent = t('modal.back');
+
+      const modalConfirm = document.getElementById('cancel-modal-confirm');
+      if (modalConfirm) modalConfirm.textContent = t('modal.confirm');
+
+      // Update project select placeholder (re-render the select)
+      updateProjectSelect();
+    }
+
+    // Expose functions to HTML onclick handlers
+    window.checkClaudeStatus = checkClaudeStatus;
+    window.toggleLogs = toggleLogs;
+    window.toggleStats = toggleStats;
+    window.changeModel = changeModel;
+    window.changeLanguage = changeLanguage;
+    window.onProjectSelect = onProjectSelect;
+    window.loadProjectConfig = loadProjectConfig;
+    window.removeCurrentProject = removeCurrentProject;
+    window.toggleReviewAccordion = toggleReviewAccordion;
+    window.toggleReviewDescription = toggleReviewDescription;
+    window.deleteReviewFile = deleteReviewFile;
+    window.toggleMrAccordion = toggleMrAccordion;
+    window.triggerFollowup = triggerFollowup;
+    window.toggleAutoFollowup = toggleAutoFollowup;
+    window.approveMr = approveMr;
+    window.syncGitLabThreads = syncGitLabThreads;
+    window.showCancelModal = showCancelModal;
+    window.closeCancelModal = closeCancelModal;
+    window.confirmCancelReview = confirmCancelReview;
+
     // Init
+    renderStaticLabels();
     connectWebSocket();
     fetchStatus();
     checkClaudeStatus();
     loadModelSetting();
     loadLanguageSetting();
-    initProjectLoader(); // Will check git CLI and load reviews/stats after loading project config
+    initProjectLoader();
 
     // Initialize Lucide icons
     refreshIcons();
@@ -1560,7 +1581,7 @@
       fetchReviewFiles();
       fetchProjectStats();
       fetchMrTracking();
-    }, 30000); // Refresh review files, stats and MR tracking every 30s
+    }, 30000);
 
     setInterval(() => {
       document.querySelectorAll('.review-item').forEach(el => {

--- a/src/interface-adapters/views/dashboard/modules/constants.js
+++ b/src/interface-adapters/views/dashboard/modules/constants.js
@@ -1,0 +1,4 @@
+export const MAX_RECONNECT_ATTEMPTS = 10;
+export const RECONNECT_DELAY = 3000;
+export const STORAGE_KEY_PROJECTS = 'review-flow-projects';
+export const STORAGE_KEY_CURRENT = 'review-flow-current-project';

--- a/src/interface-adapters/views/dashboard/modules/formatting.js
+++ b/src/interface-adapters/views/dashboard/modules/formatting.js
@@ -1,0 +1,57 @@
+import { t, getLanguage } from './i18n.js';
+
+/**
+ * @param {string | null | undefined} dateStr
+ * @returns {string}
+ */
+export function formatTime(dateStr) {
+  if (!dateStr) return '-';
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diff = now - date;
+  if (diff < 60000) return t('time.justNow');
+  if (diff < 3600000) return t('time.minutesAgo', { minutes: Math.floor(diff / 60000) });
+  if (diff < 86400000) return t('time.hoursAgo', { hours: Math.floor(diff / 3600000) });
+  const locale = getLanguage() === 'fr' ? 'fr-FR' : 'en-US';
+  return date.toLocaleDateString(locale);
+}
+
+/**
+ * @param {string | null | undefined} startStr
+ * @param {string | null | undefined} endStr
+ * @param {number | null | undefined} totalMs
+ * @returns {string}
+ */
+export function formatDuration(startStr, endStr, totalMs) {
+  let diff;
+  if (totalMs !== undefined && totalMs !== null) {
+    diff = Math.floor(totalMs / 1000);
+  } else if (startStr) {
+    const start = new Date(startStr);
+    const end = endStr ? new Date(endStr) : new Date();
+    diff = Math.floor((end - start) / 1000);
+  } else {
+    return '';
+  }
+  if (diff < 60) return `${diff}s`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ${diff % 60}s`;
+  return `${Math.floor(diff / 3600)}h ${Math.floor((diff % 3600) / 60)}m`;
+}
+
+/**
+ * @param {string} phase
+ * @returns {string}
+ */
+export function formatPhase(phase) {
+  return t(`phase.${phase}`);
+}
+
+/**
+ * @param {number} timestamp
+ * @returns {string}
+ */
+export function formatLogTime(timestamp) {
+  const date = new Date(timestamp);
+  const locale = getLanguage() === 'fr' ? 'fr-FR' : 'en-US';
+  return date.toLocaleTimeString(locale);
+}

--- a/src/interface-adapters/views/dashboard/modules/html.js
+++ b/src/interface-adapters/views/dashboard/modules/html.js
@@ -1,0 +1,48 @@
+/**
+ * @param {string | null | undefined} text
+ * @returns {string}
+ */
+export function escapeHtml(text) {
+  if (!text) return '';
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * @param {string} md
+ * @returns {string}
+ */
+export function markdownToHtml(md) {
+  const html = md
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/```(\w*)\n([\s\S]*?)```/g, '<pre><code>$2</code></pre>')
+    .replace(/`([^`]+)`/g, '<code>$1</code>')
+    .replace(/^### (.+)$/gm, '<h3>$1</h3>')
+    .replace(/^## (.+)$/gm, '<h2>$1</h2>')
+    .replace(/^# (.+)$/gm, '<h1>$1</h1>')
+    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*([^*]+)\*/g, '<em>$1</em>')
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank">$1</a>')
+    .replace(/^> (.+)$/gm, '<blockquote>$1</blockquote>')
+    .replace(/^- (.+)$/gm, '<li>$1</li>')
+    .replace(/^\d+\. (.+)$/gm, '<li>$1</li>')
+    .replace(/^---$/gm, '<hr>')
+    .replace(/^\|(.+)\|$/gm, (match, content) => {
+      const cells = content.split('|').map((/** @type {string} */ c) => c.trim());
+      if (cells.every((/** @type {string} */ c) => c.match(/^-+$/))) return '';
+      const cellTag = match.includes('---') ? 'th' : 'td';
+      return '<tr>' + cells.map((/** @type {string} */ c) => `<${cellTag}>${c}</${cellTag}>`).join('') + '</tr>';
+    })
+    .replace(/(<tr>[\s\S]*?<\/tr>)+/g, '<table>$&</table>')
+    .replace(/(<li>[\s\S]*?<\/li>)+/g, '<ul>$&</ul>')
+    .replace(/\n\n/g, '</p><p>')
+    .replace(/\n/g, '<br>');
+
+  return '<p>' + html + '</p>';
+}

--- a/src/interface-adapters/views/dashboard/modules/i18n.js
+++ b/src/interface-adapters/views/dashboard/modules/i18n.js
@@ -1,0 +1,350 @@
+/** @type {'en' | 'fr'} */
+let currentLanguage = 'en';
+
+const translations = {
+  en: {
+    // Time
+    'time.justNow': 'Just now',
+    'time.minutesAgo': '{{minutes}} min ago',
+    'time.hoursAgo': '{{hours}}h ago',
+
+    // Phases
+    'phase.initializing': 'Initializing',
+    'phase.agents-running': 'Agents running',
+    'phase.synthesizing': 'Synthesizing',
+    'phase.publishing': 'Publishing',
+    'phase.completed': 'Completed',
+
+    // Header
+    'header.checkClaude': 'Check Claude',
+    'header.logs': 'Logs',
+    'header.hideLogs': 'Hide Logs',
+
+    // Cards
+    'card.running': 'Running',
+    'card.queued': 'Queued',
+    'card.completed': 'Completed',
+    'card.claudeCli': 'Claude CLI',
+    'card.model': 'Model',
+    'card.language': 'Language',
+    'card.gitCli': 'Git CLI',
+    'card.gitlabCli': 'GitLab CLI',
+    'card.githubCli': 'GitHub CLI',
+
+    // Model options
+    'model.opus': 'Opus (powerful)',
+    'model.sonnet': 'Sonnet (fast)',
+
+    // Status
+    'status.connecting': 'Connecting...',
+    'status.checking': 'Checking...',
+    'status.loading': 'Loading...',
+    'status.loadProject': 'Load a project...',
+    'status.operational': 'Operational',
+    'status.undefined': 'not set',
+
+    // Connection
+    'connection.websocket': 'WebSocket real-time',
+    'connection.fallback': 'Fallback polling 5s',
+    'connection.online': 'Online',
+    'connection.onlinePolling': 'Online (polling)',
+    'connection.offline': 'Offline',
+    'connection.disconnected': 'Disconnected',
+    'connection.polling': 'Polling mode',
+
+    // Project loader
+    'project.selectPlaceholder': '-- Select a project --',
+    'project.inputPlaceholder': 'Or enter a new path...',
+    'project.load': 'Load',
+    'project.removeTooltip': 'Remove from list',
+    'project.removed': 'Project removed',
+    'project.noProjectSelected': 'No project selected',
+
+    // Login / Auth
+    'login.claude.title': 'Claude is not authenticated',
+    'login.claude.instruction': 'Run this command in a terminal:',
+    'login.claude.reload': 'Then reload this page.',
+    'login.git.title': 'CLI not authenticated',
+    'login.gitlab.title': 'GitLab CLI not authenticated',
+    'login.github.title': 'GitHub CLI not authenticated',
+
+    // Setup instructions
+    'setup.installAndAuth': '1. Install and authenticate {{cli}}:',
+    'setup.configureWebhook': '2. Configure the {{platform}} webhook:',
+    'setup.webhookPath': 'Settings → Webhooks → Add webhook',
+    'setup.reload': 'Then reload this page.',
+    'setup.github.contentType': 'Content type: application/json',
+    'setup.github.events': 'Events: Pull requests',
+    'setup.gitlab.trigger': 'Trigger: Merge request events',
+
+    // Sections
+    'section.logs': 'Recent logs',
+    'section.stats': 'Project statistics',
+    'section.activeReviews': 'Active reviews',
+    'section.activeFollowups': 'Active followups',
+    'section.pendingFix': 'Pending fix',
+    'section.pendingApproval': 'Pending approval',
+    'section.completedReviews': 'Completed reviews',
+
+    // Empty states
+    'empty.logs': 'No logs',
+    'empty.stats': 'Load a project to see stats',
+    'empty.statsNoData': 'No statistics available',
+    'empty.activeReviews': 'No active reviews',
+    'empty.activeFollowups': 'No active followups',
+    'empty.pendingFix': 'No MR pending fix',
+    'empty.pendingApproval': 'No MR pending approval',
+    'empty.reviewFiles': 'No review files',
+    'empty.reviewsNoProject': 'Load a project to see reviews',
+    'empty.statsNoProject': 'Load a project to see stats',
+    'empty.serverNotAccessible': 'Server not accessible',
+
+    // Stats labels
+    'stats.reviews': 'Reviews',
+    'stats.averageScore': 'Average score',
+    'stats.totalTime': 'Total time',
+    'stats.averageTime': 'Average time',
+    'stats.blocking': 'Blocking',
+    'stats.warnings': 'Important',
+
+    // Review types
+    'review.type.review': 'Review',
+    'review.type.followup': 'Followup',
+    'review.description': 'Description',
+
+    // Buttons
+    'button.cancel': 'Cancel',
+    'button.open': 'Open',
+    'button.followup': 'Followup',
+    'button.autoFollowup': 'Auto follow-up',
+    'button.delete': 'Delete',
+    'button.syncThreads': 'Sync GitLab threads',
+
+    // MR details
+    'mr.threads.open': '{{count}} open',
+    'mr.threads.resolved': 'Resolved',
+    'mr.detail.source': 'Source:',
+    'mr.detail.target': 'Target:',
+    'mr.detail.created': 'Created:',
+    'mr.detail.lastReview': 'Last review:',
+    'mr.detail.history': 'History ({{count}}):',
+    'mr.review.blocking': '{{count}} blocking',
+
+    // Logs
+    'logs.errorCount': '{{count}} errors',
+
+    // Modal
+    'modal.cancel.title': 'Cancel the {{type}} of {{label}} !{{number}} ({{type}})?',
+    'modal.cancel.message': 'This action is irreversible. The review will be stopped immediately.',
+    'modal.back': 'Go back',
+    'modal.confirm': 'Confirm',
+
+    // Confirm dialogs
+    'confirm.deleteReview': 'Delete {{filename}}?',
+    'confirm.removeProject': 'Remove "{{name}}" from the list?',
+    'confirm.approveMr': 'Mark this {{label}} as approved?',
+
+    // Success
+    'success.reviewCancelled': 'Review cancelled',
+    'success.reviewAlreadyCompleted': 'This review is already completed',
+
+    // Errors
+    'error.loading': 'Loading error',
+    'error.loadingStats': 'Error loading stats',
+    'error.loadingConfig': 'Loading error',
+    'error.checkStatus': 'Check error',
+    'error.deleteReview': 'Error deleting review',
+    'error.triggerFollowup': 'Error triggering followup',
+    'error.toggleAutoFollowup': 'Error changing auto follow-up',
+    'error.approveMr': 'Error approving',
+    'error.syncThreads': 'Error syncing threads',
+    'error.cancelReview': 'Error cancelling review',
+    'error.selectOrEnterPath': 'Select or enter a path',
+    'error.projectNotLoaded': 'Load a project first',
+  },
+  fr: {
+    // Time
+    'time.justNow': "À l'instant",
+    'time.minutesAgo': 'Il y a {{minutes}} min',
+    'time.hoursAgo': 'Il y a {{hours}}h',
+
+    // Phases
+    'phase.initializing': 'Initialisation',
+    'phase.agents-running': 'Agents en cours',
+    'phase.synthesizing': 'Synthèse',
+    'phase.publishing': 'Publication',
+    'phase.completed': 'Terminé',
+
+    // Header
+    'header.checkClaude': 'Vérifier Claude',
+    'header.logs': 'Logs',
+    'header.hideLogs': 'Masquer Logs',
+
+    // Cards
+    'card.running': 'En cours',
+    'card.queued': 'En attente',
+    'card.completed': 'Terminées',
+    'card.claudeCli': 'Claude CLI',
+    'card.model': 'Modèle',
+    'card.language': 'Langue',
+    'card.gitCli': 'Git CLI',
+    'card.gitlabCli': 'GitLab CLI',
+    'card.githubCli': 'GitHub CLI',
+
+    // Model options
+    'model.opus': 'Opus (puissant)',
+    'model.sonnet': 'Sonnet (rapide)',
+
+    // Status
+    'status.connecting': 'Connexion...',
+    'status.checking': 'Vérification...',
+    'status.loading': 'Chargement...',
+    'status.loadProject': 'Charger un projet...',
+    'status.operational': 'Opérationnel',
+    'status.undefined': 'non défini',
+
+    // Connection
+    'connection.websocket': 'WebSocket temps réel',
+    'connection.fallback': 'Fallback polling 5s',
+    'connection.online': 'En ligne',
+    'connection.onlinePolling': 'En ligne (polling)',
+    'connection.offline': 'Hors ligne',
+    'connection.disconnected': 'Déconnecté',
+    'connection.polling': 'Mode polling',
+
+    // Project loader
+    'project.selectPlaceholder': '-- Sélectionner un projet --',
+    'project.inputPlaceholder': 'Ou entrer un nouveau chemin...',
+    'project.load': 'Charger',
+    'project.removeTooltip': 'Retirer de la liste',
+    'project.removed': 'Projet retiré',
+    'project.noProjectSelected': 'Aucun projet sélectionné',
+
+    // Login / Auth
+    'login.claude.title': "Claude n'est pas authentifié",
+    'login.claude.instruction': 'Exécutez cette commande dans un terminal :',
+    'login.claude.reload': 'Puis rechargez cette page.',
+    'login.git.title': 'CLI non authentifié',
+    'login.gitlab.title': 'GitLab CLI non authentifié',
+    'login.github.title': 'GitHub CLI non authentifié',
+
+    // Setup instructions
+    'setup.installAndAuth': '1. Installer et authentifier {{cli}} :',
+    'setup.configureWebhook': '2. Configurer le webhook {{platform}} :',
+    'setup.webhookPath': 'Settings → Webhooks → Add webhook',
+    'setup.reload': 'Puis rechargez cette page.',
+    'setup.github.contentType': 'Content type: application/json',
+    'setup.github.events': 'Events: Pull requests',
+    'setup.gitlab.trigger': 'Trigger: Merge request events',
+
+    // Sections
+    'section.logs': 'Logs récents',
+    'section.stats': 'Statistiques du projet',
+    'section.activeReviews': 'Reviews actives',
+    'section.activeFollowups': 'Followups actifs',
+    'section.pendingFix': 'En attente de correctif',
+    'section.pendingApproval': "En attente d'approbation",
+    'section.completedReviews': 'Reviews terminées',
+
+    // Empty states
+    'empty.logs': 'Aucun log',
+    'empty.stats': 'Charger un projet pour voir les stats',
+    'empty.statsNoData': 'Aucune statistique disponible',
+    'empty.activeReviews': 'Aucune review en cours',
+    'empty.activeFollowups': 'Aucun followup en cours',
+    'empty.pendingFix': 'Aucune MR en attente de correctif',
+    'empty.pendingApproval': "Aucune MR en attente d'approbation",
+    'empty.reviewFiles': 'Aucun fichier de review',
+    'empty.reviewsNoProject': 'Charger un projet pour voir les reviews',
+    'empty.statsNoProject': 'Charger un projet pour voir les stats',
+    'empty.serverNotAccessible': 'Serveur non accessible',
+
+    // Stats labels
+    'stats.reviews': 'Reviews',
+    'stats.averageScore': 'Score moyen',
+    'stats.totalTime': 'Temps total',
+    'stats.averageTime': 'Durée moyenne',
+    'stats.blocking': 'Bloquants',
+    'stats.warnings': 'Importants',
+
+    // Review types
+    'review.type.review': 'Review',
+    'review.type.followup': 'Followup',
+    'review.description': 'Description',
+
+    // Buttons
+    'button.cancel': 'Annuler',
+    'button.open': 'Ouvrir',
+    'button.followup': 'Followup',
+    'button.autoFollowup': 'Auto follow-up',
+    'button.delete': 'Supprimer',
+    'button.syncThreads': 'Synchroniser les threads GitLab',
+
+    // MR details
+    'mr.threads.open': '{{count}} ouvert(s)',
+    'mr.threads.resolved': 'Résolus',
+    'mr.detail.source': 'Source :',
+    'mr.detail.target': 'Target :',
+    'mr.detail.created': 'Créée :',
+    'mr.detail.lastReview': 'Dernière review :',
+    'mr.detail.history': 'Historique ({{count}}) :',
+    'mr.review.blocking': '{{count}} bloquant(s)',
+
+    // Logs
+    'logs.errorCount': '{{count}} erreurs',
+
+    // Modal
+    'modal.cancel.title': 'Annuler la {{type}} de la {{label}} !{{number}} ({{type}}) ?',
+    'modal.cancel.message': 'Cette action est irréversible. La review sera arrêtée immédiatement.',
+    'modal.back': 'Revenir',
+    'modal.confirm': 'Confirmer',
+
+    // Confirm dialogs
+    'confirm.deleteReview': 'Supprimer {{filename}} ?',
+    'confirm.removeProject': 'Retirer "{{name}}" de la liste ?',
+    'confirm.approveMr': 'Marquer cette {{label}} comme approuvée ?',
+
+    // Success
+    'success.reviewCancelled': 'Review annulée',
+    'success.reviewAlreadyCompleted': 'Cette review est déjà terminée',
+
+    // Errors
+    'error.loading': 'Erreur de chargement',
+    'error.loadingStats': 'Erreur de chargement des stats',
+    'error.loadingConfig': 'Erreur de chargement',
+    'error.checkStatus': 'Erreur de vérification',
+    'error.deleteReview': 'Erreur lors de la suppression',
+    'error.triggerFollowup': 'Erreur lors du déclenchement du followup',
+    'error.toggleAutoFollowup': 'Erreur lors du changement de auto follow-up',
+    'error.approveMr': "Erreur lors de l'approbation",
+    'error.syncThreads': 'Erreur lors de la synchronisation des threads',
+    'error.cancelReview': "Erreur lors de l'annulation",
+    'error.selectOrEnterPath': 'Sélectionnez ou entrez un chemin',
+    'error.projectNotLoaded': "Charger un projet d'abord",
+  },
+};
+
+/** @returns {'en' | 'fr'} */
+export function getLanguage() {
+  return currentLanguage;
+}
+
+/** @param {'en' | 'fr'} language */
+export function setLanguage(language) {
+  currentLanguage = language;
+}
+
+/**
+ * @param {string} key
+ * @param {Record<string, string | number>} [params]
+ * @returns {string}
+ */
+export function t(key, params) {
+  let value = translations[currentLanguage]?.[key] ?? key;
+  if (params) {
+    for (const [param, replacement] of Object.entries(params)) {
+      value = value.replaceAll(`{{${param}}}`, String(replacement));
+    }
+  }
+  return value;
+}

--- a/src/interface-adapters/views/dashboard/modules/icons.js
+++ b/src/interface-adapters/views/dashboard/modules/icons.js
@@ -1,0 +1,29 @@
+const agentIconNames = {
+  pending: 'clock',
+  running: 'loader',
+  completed: 'check',
+  failed: 'x',
+};
+
+/**
+ * @param {string} status
+ * @returns {string}
+ */
+export function getAgentIcon(status) {
+  return `<i data-lucide="${agentIconNames[status] || 'help-circle'}"></i>`;
+}
+
+/**
+ * @param {string} name
+ * @param {string} [className]
+ * @returns {string}
+ */
+export function icon(name, className = '') {
+  return `<i data-lucide="${name}" class="${className}"></i>`;
+}
+
+export function refreshIcons() {
+  if (typeof lucide !== 'undefined') {
+    lucide.createIcons();
+  }
+}

--- a/src/tests/units/interface-adapters/views/dashboard/modules/constants.test.ts
+++ b/src/tests/units/interface-adapters/views/dashboard/modules/constants.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MAX_RECONNECT_ATTEMPTS,
+  RECONNECT_DELAY,
+  STORAGE_KEY_PROJECTS,
+  STORAGE_KEY_CURRENT,
+} from '@/interface-adapters/views/dashboard/modules/constants.js';
+
+describe('constants', () => {
+  it('should export reconnection settings', () => {
+    expect(MAX_RECONNECT_ATTEMPTS).toBe(10);
+    expect(RECONNECT_DELAY).toBe(3000);
+  });
+
+  it('should export localStorage keys', () => {
+    expect(STORAGE_KEY_PROJECTS).toBe('review-flow-projects');
+    expect(STORAGE_KEY_CURRENT).toBe('review-flow-current-project');
+  });
+});

--- a/src/tests/units/interface-adapters/views/dashboard/modules/formatting.test.ts
+++ b/src/tests/units/interface-adapters/views/dashboard/modules/formatting.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { formatTime, formatDuration, formatPhase, formatLogTime } from '@/interface-adapters/views/dashboard/modules/formatting.js';
+import { setLanguage } from '@/interface-adapters/views/dashboard/modules/i18n.js';
+
+describe('formatTime', () => {
+  beforeEach(() => {
+    setLanguage('en');
+  });
+
+  it('should return "-" for null or undefined input', () => {
+    expect(formatTime(null)).toBe('-');
+    expect(formatTime(undefined)).toBe('-');
+  });
+
+  it('should return "Just now" for a date less than 60 seconds ago', () => {
+    const result = formatTime(new Date().toISOString());
+    expect(result).toBe('Just now');
+  });
+
+  it('should return minutes ago for a date less than 1 hour ago', () => {
+    const fiveMinutesAgo = new Date(Date.now() - 5 * 60000).toISOString();
+    const result = formatTime(fiveMinutesAgo);
+    expect(result).toBe('5 min ago');
+  });
+
+  it('should return hours ago for a date less than 1 day ago', () => {
+    const threeHoursAgo = new Date(Date.now() - 3 * 3600000).toISOString();
+    const result = formatTime(threeHoursAgo);
+    expect(result).toBe('3h ago');
+  });
+
+  it('should return localized date for a date more than 1 day ago', () => {
+    const twoDaysAgo = new Date(Date.now() - 2 * 86400000).toISOString();
+    const result = formatTime(twoDaysAgo);
+    expect(result).toMatch(/\d/);
+  });
+
+  it('should return French translations when language is fr', () => {
+    setLanguage('fr');
+    const now = new Date().toISOString();
+    expect(formatTime(now)).toBe("À l'instant");
+
+    const fiveMinutesAgo = new Date(Date.now() - 5 * 60000).toISOString();
+    expect(formatTime(fiveMinutesAgo)).toBe('Il y a 5 min');
+
+    const threeHoursAgo = new Date(Date.now() - 3 * 3600000).toISOString();
+    expect(formatTime(threeHoursAgo)).toBe('Il y a 3h');
+  });
+});
+
+describe('formatDuration', () => {
+  it('should return empty string when no arguments provided', () => {
+    expect(formatDuration(null, null, undefined)).toBe('');
+  });
+
+  it('should format seconds from totalMs', () => {
+    expect(formatDuration(null, null, 45000)).toBe('45s');
+  });
+
+  it('should format minutes and seconds from totalMs', () => {
+    expect(formatDuration(null, null, 125000)).toBe('2m 5s');
+  });
+
+  it('should format hours and minutes from totalMs', () => {
+    expect(formatDuration(null, null, 7380000)).toBe('2h 3m');
+  });
+
+  it('should compute duration from start and end dates', () => {
+    const start = new Date('2026-01-01T10:00:00Z').toISOString();
+    const end = new Date('2026-01-01T10:05:30Z').toISOString();
+    expect(formatDuration(start, end, undefined)).toBe('5m 30s');
+  });
+
+  it('should compute duration from start to now when no end date', () => {
+    const fewSecondsAgo = new Date(Date.now() - 10000).toISOString();
+    const result = formatDuration(fewSecondsAgo, null, undefined);
+    expect(result).toMatch(/^\d+s$/);
+  });
+});
+
+describe('formatPhase', () => {
+  beforeEach(() => {
+    setLanguage('en');
+  });
+
+  it('should return translated phase labels in English', () => {
+    expect(formatPhase('initializing')).toBe('Initializing');
+    expect(formatPhase('agents-running')).toBe('Agents running');
+    expect(formatPhase('synthesizing')).toBe('Synthesizing');
+    expect(formatPhase('publishing')).toBe('Publishing');
+    expect(formatPhase('completed')).toBe('Completed');
+  });
+
+  it('should return translated phase labels in French', () => {
+    setLanguage('fr');
+    expect(formatPhase('initializing')).toBe('Initialisation');
+    expect(formatPhase('agents-running')).toBe('Agents en cours');
+    expect(formatPhase('synthesizing')).toBe('Synthèse');
+    expect(formatPhase('publishing')).toBe('Publication');
+    expect(formatPhase('completed')).toBe('Terminé');
+  });
+
+  it('should return the i18n key for unknown phases', () => {
+    expect(formatPhase('unknown-phase')).toBe('phase.unknown-phase');
+  });
+});
+
+describe('formatLogTime', () => {
+  it('should return a time string from a timestamp', () => {
+    const timestamp = new Date('2026-01-15T14:30:45Z').getTime();
+    const result = formatLogTime(timestamp);
+    expect(result).toMatch(/\d{1,2}:\d{2}:\d{2}/);
+  });
+});

--- a/src/tests/units/interface-adapters/views/dashboard/modules/html.test.ts
+++ b/src/tests/units/interface-adapters/views/dashboard/modules/html.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { escapeHtml, markdownToHtml } from '@/interface-adapters/views/dashboard/modules/html.js';
+
+describe('escapeHtml', () => {
+  it('should return empty string for null or undefined', () => {
+    expect(escapeHtml(null)).toBe('');
+    expect(escapeHtml(undefined)).toBe('');
+  });
+
+  it('should escape HTML special characters', () => {
+    expect(escapeHtml('<script>alert("xss")</script>')).toBe(
+      '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;'
+    );
+  });
+
+  it('should escape ampersands', () => {
+    expect(escapeHtml('a & b')).toBe('a &amp; b');
+  });
+
+  it('should escape single quotes', () => {
+    expect(escapeHtml("it's")).toBe('it&#39;s');
+  });
+
+  it('should return plain text unchanged', () => {
+    expect(escapeHtml('hello world')).toBe('hello world');
+  });
+});
+
+describe('markdownToHtml', () => {
+  it('should convert bold text', () => {
+    const result = markdownToHtml('**bold**');
+    expect(result).toContain('<strong>bold</strong>');
+  });
+
+  it('should convert inline code', () => {
+    const result = markdownToHtml('use `code` here');
+    expect(result).toContain('<code>code</code>');
+  });
+
+  it('should convert headers', () => {
+    expect(markdownToHtml('# Title')).toContain('<h1>Title</h1>');
+    expect(markdownToHtml('## Subtitle')).toContain('<h2>Subtitle</h2>');
+    expect(markdownToHtml('### Section')).toContain('<h3>Section</h3>');
+  });
+
+  it('should convert links', () => {
+    const result = markdownToHtml('[click](https://example.com)');
+    expect(result).toContain('<a href="https://example.com" target="_blank">click</a>');
+  });
+
+  it('should escape HTML in markdown input', () => {
+    const result = markdownToHtml('<script>alert("xss")</script>');
+    expect(result).not.toContain('<script>');
+  });
+});

--- a/src/tests/units/interface-adapters/views/dashboard/modules/i18n.test.ts
+++ b/src/tests/units/interface-adapters/views/dashboard/modules/i18n.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getLanguage, setLanguage, t } from '@/interface-adapters/views/dashboard/modules/i18n.js';
+
+describe('i18n', () => {
+  beforeEach(() => {
+    setLanguage('en');
+  });
+
+  it('should default to English language', () => {
+    expect(getLanguage()).toBe('en');
+  });
+
+  it('should change language to French', () => {
+    setLanguage('fr');
+    expect(getLanguage()).toBe('fr');
+  });
+
+  it('should return English translation for a known key', () => {
+    const result = t('time.justNow');
+    expect(result).toBe('Just now');
+  });
+
+  it('should return French translation when language is fr', () => {
+    setLanguage('fr');
+    const result = t('time.justNow');
+    expect(result).toBe("À l'instant");
+  });
+
+  it('should return the key itself when translation is missing', () => {
+    const result = t('nonexistent.key');
+    expect(result).toBe('nonexistent.key');
+  });
+
+  it('should replace multiple occurrences of the same param', () => {
+    const result = t('modal.cancel.title', { type: 'review', label: 'MR', number: 42 });
+    expect(result).toBe('Cancel the review of MR !42 (review)?');
+  });
+});

--- a/src/tests/units/interface-adapters/views/dashboard/modules/icons.test.ts
+++ b/src/tests/units/interface-adapters/views/dashboard/modules/icons.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { getAgentIcon, icon } from '@/interface-adapters/views/dashboard/modules/icons.js';
+
+describe('getAgentIcon', () => {
+  it('should return clock icon for pending status', () => {
+    expect(getAgentIcon('pending')).toBe('<i data-lucide="clock"></i>');
+  });
+
+  it('should return loader icon for running status', () => {
+    expect(getAgentIcon('running')).toBe('<i data-lucide="loader"></i>');
+  });
+
+  it('should return check icon for completed status', () => {
+    expect(getAgentIcon('completed')).toBe('<i data-lucide="check"></i>');
+  });
+
+  it('should return x icon for failed status', () => {
+    expect(getAgentIcon('failed')).toBe('<i data-lucide="x"></i>');
+  });
+
+  it('should return help-circle icon for unknown status', () => {
+    expect(getAgentIcon('unknown')).toBe('<i data-lucide="help-circle"></i>');
+  });
+});
+
+describe('icon', () => {
+  it('should return lucide icon markup', () => {
+    expect(icon('clock')).toBe('<i data-lucide="clock" class=""></i>');
+  });
+
+  it('should include className when provided', () => {
+    expect(icon('star', 'active')).toBe('<i data-lucide="star" class="active"></i>');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "paths": {
       "@/*": ["./*"]
     },
+    "allowJs": true /* Required for dashboard JS modules (browser-served, not compiled by tsc) */,
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

- Extract 5 utility modules from the monolithic dashboard `index.html` into separate ES6 files: `i18n.js`, `formatting.js`, `html.js`, `icons.js`, `constants.js`
- Add complete FR/EN internationalization with ~120 translation keys per language
- Rewrite `index.html` to use `<script type="module">` imports and `t()` calls for all user-facing strings
- Add `renderStaticLabels()` for static HTML text, re-invoked on language change
- Enable `allowJs` in tsconfig to support TS test imports of JS modules

## Test plan

- [x] 41 new unit tests (i18n: 6, formatting: 16, html: 10, icons: 7, constants: 2)
- [x] All 837 tests passing
- [x] `yarn verify` passes (typecheck + lint + tests)
- [x] `yarn build` succeeds and modules are correctly copied to dist
- [x] Auto-review performed: 2 blocking bugs found and fixed before commit

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)