### PR TITLE
refactor: inject gateways and use cases in GitLab webhook controller (#74)

### DIFF
--- a/src/interface-adapters/controllers/webhook/gitlab.controller.ts
+++ b/src/interface-adapters/controllers/webhook/gitlab.controller.ts
@@ -1,32 +1,32 @@
 import type { FastifyRequest, FastifyReply } from 'fastify';
 import type { Logger } from 'pino';
-import { verifyGitLabSignature, getGitLabEventType } from '../../../security/verifier.js';
-import { gitLabMergeRequestEventGuard } from '../../../entities/gitlab/gitlabMergeRequestEvent.guard.js';
-import { filterGitLabEvent, filterGitLabMrUpdate, filterGitLabMrClose, filterGitLabMrMerge, filterGitLabMrApprove } from './eventFilter.js';
-import { findRepositoryByProjectPath } from '../../../config/loader.js';
+import { verifyGitLabSignature, getGitLabEventType } from '@/security/verifier.js';
+import { gitLabMergeRequestEventGuard } from '@/entities/gitlab/gitlabMergeRequestEvent.guard.js';
+import { filterGitLabEvent, filterGitLabMrUpdate, filterGitLabMrClose, filterGitLabMrMerge, filterGitLabMrApprove } from '@/interface-adapters/controllers/webhook/eventFilter.js';
+import { findRepositoryByProjectPath } from '@/config/loader.js';
 import {
   enqueueReview,
   createJobId,
   updateJobProgress,
   cancelJob,
   type ReviewJob,
-} from '../../../frameworks/queue/pQueueAdapter.js';
-import { invokeClaudeReview, sendNotification } from '../../../claude/invoker.js';
-import type { ReviewRequestTrackingGateway } from '../../gateways/reviewRequestTracking.gateway.js';
-import { TrackAssignmentUseCase } from '../../../usecases/tracking/trackAssignment.usecase.js';
-import { RecordReviewCompletionUseCase } from '../../../usecases/tracking/recordReviewCompletion.usecase.js';
-import { RecordPushUseCase } from '../../../usecases/tracking/recordPush.usecase.js';
-import { TransitionStateUseCase } from '../../../usecases/tracking/transitionState.usecase.js';
-import { CheckFollowupNeededUseCase } from '../../../usecases/tracking/checkFollowupNeeded.usecase.js';
-import { SyncThreadsUseCase } from '../../../usecases/tracking/syncThreads.usecase.js';
+} from '@/frameworks/queue/pQueueAdapter.js';
+import { invokeClaudeReview, sendNotification } from '@/claude/invoker.js';
+import type { ReviewRequestTrackingGateway } from '@/interface-adapters/gateways/reviewRequestTracking.gateway.js';
+import type { TrackAssignmentUseCase } from '@/usecases/tracking/trackAssignment.usecase.js';
+import type { RecordReviewCompletionUseCase } from '@/usecases/tracking/recordReviewCompletion.usecase.js';
+import type { RecordPushUseCase } from '@/usecases/tracking/recordPush.usecase.js';
+import type { TransitionStateUseCase } from '@/usecases/tracking/transitionState.usecase.js';
+import type { CheckFollowupNeededUseCase } from '@/usecases/tracking/checkFollowupNeeded.usecase.js';
+import type { SyncThreadsUseCase } from '@/usecases/tracking/syncThreads.usecase.js';
 import { loadProjectConfig, getProjectAgents, getFollowupAgents, getProjectLanguage } from '@/config/projectConfig.js';
-import { DEFAULT_AGENTS, DEFAULT_FOLLOWUP_AGENTS } from '../../../entities/progress/agentDefinition.type.js';
-import { parseReviewOutput } from '../../../services/statsService.js';
-import { parseThreadActions } from '../../../services/threadActionsParser.js';
-import { executeThreadActions, defaultCommandExecutor } from '../../../services/threadActionsExecutor.js';
-import { executeActionsFromContext } from '../../../services/contextActionsExecutor.js';
-import { startWatchingReviewContext, stopWatchingReviewContext } from '../../../main/websocket.js';
-import type { ReviewContextGateway } from '../../../entities/reviewContext/reviewContext.gateway.js';
+import { DEFAULT_AGENTS, DEFAULT_FOLLOWUP_AGENTS } from '@/entities/progress/agentDefinition.type.js';
+import { parseReviewOutput } from '@/services/statsService.js';
+import { parseThreadActions } from '@/services/threadActionsParser.js';
+import { executeThreadActions, defaultCommandExecutor } from '@/services/threadActionsExecutor.js';
+import { executeActionsFromContext } from '@/services/contextActionsExecutor.js';
+import { startWatchingReviewContext, stopWatchingReviewContext } from '@/main/websocket.js';
+import type { ReviewContextGateway } from '@/entities/reviewContext/reviewContext.gateway.js';
 import type { ThreadFetchGateway } from '@/entities/threadFetch/threadFetch.gateway.js';
 import type { DiffMetadataFetchGateway } from '@/entities/diffMetadata/diffMetadata.gateway.js';
 
@@ -34,6 +34,12 @@ export interface GitLabWebhookDependencies {
   reviewContextGateway: ReviewContextGateway;
   threadFetchGateway: ThreadFetchGateway;
   diffMetadataFetchGateway: DiffMetadataFetchGateway;
+  trackAssignment: TrackAssignmentUseCase;
+  recordCompletion: RecordReviewCompletionUseCase;
+  recordPush: RecordPushUseCase;
+  transitionState: TransitionStateUseCase;
+  checkFollowupNeeded: CheckFollowupNeededUseCase;
+  syncThreads: SyncThreadsUseCase;
 }
 
 export async function handleGitLabWebhook(
@@ -43,11 +49,7 @@ export async function handleGitLabWebhook(
   trackingGateway: ReviewRequestTrackingGateway,
   deps: GitLabWebhookDependencies
 ): Promise<void> {
-  const trackAssignment = new TrackAssignmentUseCase(trackingGateway);
-  const recordCompletion = new RecordReviewCompletionUseCase(trackingGateway);
-  const recordPush = new RecordPushUseCase(trackingGateway);
-  const transitionState = new TransitionStateUseCase(trackingGateway);
-  const checkFollowupNeeded = new CheckFollowupNeededUseCase(trackingGateway);
+  const { trackAssignment, recordCompletion, recordPush, transitionState, checkFollowupNeeded, syncThreads } = deps;
   // 1. Verify signature
   const verification = verifyGitLabSignature(request);
   if (!verification.valid) {
@@ -332,8 +334,7 @@ export async function handleGitLabWebhook(
 
               // Sync threads from GitLab FIRST to get real state after followup resolves threads
               const mrId = `gitlab-${j.projectPath}-${j.mrNumber}`;
-              const syncUseCase = new SyncThreadsUseCase(trackingGateway, threadFetchGw);
-              const updatedMr = syncUseCase.execute({ projectPath: j.localPath, mrId });
+              const updatedMr = syncThreads.execute({ projectPath: j.localPath, mrId });
 
               // Record followup completion with parsed stats
               // threadsClosed comes from THREAD_RESOLVE markers parsed from output

--- a/src/main/routes.ts
+++ b/src/main/routes.ts
@@ -2,22 +2,28 @@ import type { FastifyInstance } from 'fastify';
 import fastifyStatic from '@fastify/static';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import type { Dependencies } from './dependencies.js';
-import { healthRoutes } from '../interface-adapters/controllers/http/health.routes.js';
-import { settingsRoutes } from '../interface-adapters/controllers/http/settings.routes.js';
-import { reviewRoutes } from '../interface-adapters/controllers/http/reviews.routes.js';
-import { statsRoutes } from '../interface-adapters/controllers/http/stats.routes.js';
-import { mrTrackingRoutes } from '../interface-adapters/controllers/http/mrTracking.routes.js';
-import { mrTrackingAdvancedRoutes } from '../interface-adapters/controllers/http/mrTrackingAdvanced.routes.js';
-import { logsRoutes } from '../interface-adapters/controllers/http/logs.routes.js';
-import { cliStatusRoutes } from '../interface-adapters/controllers/http/cliStatus.routes.js';
-import { projectConfigRoutes } from '../interface-adapters/controllers/http/projectConfig.routes.js';
-import { registerWebSocketRoutes } from './websocket.js';
-import { handleGitLabWebhook } from '../interface-adapters/controllers/webhook/gitlab.controller.js';
-import { handleGitHubWebhook } from '../interface-adapters/controllers/webhook/github.controller.js';
-import { cancelJob, getJobStatus } from '../frameworks/queue/pQueueAdapter.js';
-import { GitLabThreadFetchGateway, defaultGitLabExecutor } from '../interface-adapters/gateways/threadFetch.gitlab.gateway.js';
-import { GitLabDiffMetadataFetchGateway } from '../interface-adapters/gateways/diffMetadataFetch.gitlab.gateway.js';
+import type { Dependencies } from '@/main/dependencies.js';
+import { healthRoutes } from '@/interface-adapters/controllers/http/health.routes.js';
+import { settingsRoutes } from '@/interface-adapters/controllers/http/settings.routes.js';
+import { reviewRoutes } from '@/interface-adapters/controllers/http/reviews.routes.js';
+import { statsRoutes } from '@/interface-adapters/controllers/http/stats.routes.js';
+import { mrTrackingRoutes } from '@/interface-adapters/controllers/http/mrTracking.routes.js';
+import { mrTrackingAdvancedRoutes } from '@/interface-adapters/controllers/http/mrTrackingAdvanced.routes.js';
+import { logsRoutes } from '@/interface-adapters/controllers/http/logs.routes.js';
+import { cliStatusRoutes } from '@/interface-adapters/controllers/http/cliStatus.routes.js';
+import { projectConfigRoutes } from '@/interface-adapters/controllers/http/projectConfig.routes.js';
+import { registerWebSocketRoutes } from '@/main/websocket.js';
+import { handleGitLabWebhook } from '@/interface-adapters/controllers/webhook/gitlab.controller.js';
+import { handleGitHubWebhook } from '@/interface-adapters/controllers/webhook/github.controller.js';
+import { cancelJob, getJobStatus } from '@/frameworks/queue/pQueueAdapter.js';
+import { GitLabThreadFetchGateway, defaultGitLabExecutor } from '@/interface-adapters/gateways/threadFetch.gitlab.gateway.js';
+import { GitLabDiffMetadataFetchGateway } from '@/interface-adapters/gateways/diffMetadataFetch.gitlab.gateway.js';
+import { TrackAssignmentUseCase } from '@/usecases/tracking/trackAssignment.usecase.js';
+import { RecordReviewCompletionUseCase } from '@/usecases/tracking/recordReviewCompletion.usecase.js';
+import { RecordPushUseCase } from '@/usecases/tracking/recordPush.usecase.js';
+import { TransitionStateUseCase } from '@/usecases/tracking/transitionState.usecase.js';
+import { CheckFollowupNeededUseCase } from '@/usecases/tracking/checkFollowupNeeded.usecase.js';
+import { SyncThreadsUseCase } from '@/usecases/tracking/syncThreads.usecase.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -66,11 +72,20 @@ export async function registerRoutes(
 
   await registerWebSocketRoutes(app, deps);
 
+  const trackingGw = deps.reviewRequestTrackingGateway;
+  const threadFetchGw = new GitLabThreadFetchGateway(defaultGitLabExecutor);
+
   app.post('/webhooks/gitlab', async (request, reply) => {
-    await handleGitLabWebhook(request, reply, deps.logger, deps.reviewRequestTrackingGateway, {
+    await handleGitLabWebhook(request, reply, deps.logger, trackingGw, {
       reviewContextGateway: deps.reviewContextGateway,
-      threadFetchGateway: new GitLabThreadFetchGateway(defaultGitLabExecutor),
+      threadFetchGateway: threadFetchGw,
       diffMetadataFetchGateway: new GitLabDiffMetadataFetchGateway(defaultGitLabExecutor),
+      trackAssignment: new TrackAssignmentUseCase(trackingGw),
+      recordCompletion: new RecordReviewCompletionUseCase(trackingGw),
+      recordPush: new RecordPushUseCase(trackingGw),
+      transitionState: new TransitionStateUseCase(trackingGw),
+      checkFollowupNeeded: new CheckFollowupNeededUseCase(trackingGw),
+      syncThreads: new SyncThreadsUseCase(trackingGw, threadFetchGw),
     });
   });
 


### PR DESCRIPTION
Part of #74

## Summary

- **Inject `ReviewContextGateway`, `ThreadFetchGateway`, and `DiffMetadataFetchGateway`** into `handleGitLabWebhook` via a `GitLabWebhookDependencies` interface — controller no longer instantiates concrete gateway classes
- **Inject 6 tracking use cases** (`TrackAssignment`, `RecordReviewCompletion`, `RecordPush`, `TransitionState`, `CheckFollowupNeeded`, `SyncThreads`) via deps — controller receives instances instead of constructing them
- **Migrate all imports to `@/` alias** in `gitlab.controller.ts` and `routes.ts` — no more relative path imports
- **Composition root** (`routes.ts`) now creates all concrete implementations and wires them into the controller

## What's left (see #101)

Remaining concrete dependencies in the controller that still need extraction:
- Queue operations (`enqueueReview`, `createJobId`, `updateJobProgress`, `cancelJob`)
- Claude invoker (`invokeClaudeReview`, `sendNotification`)
- Config functions (`findRepositoryByProjectPath`, `loadProjectConfig`, `getProjectAgents`, etc.)
- Services (`parseReviewOutput`, `parseThreadActions`, `executeThreadActions`, `executeActionsFromContext`)
- WebSocket (`startWatchingReviewContext`, `stopWatchingReviewContext`)
- Same pattern to apply to `github.controller.ts`

## Test plan

- [x] All 9 gitlab.controller tests pass (including 3 new DI-specific tests)
- [x] Full suite: 915/915 tests pass
- [x] TypeScript typecheck clean
- [x] No behavior change — pure structural refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)