### PR TITLE
feat: capture git diff stats per review (commits, additions, deletions)

### DIFF
--- a/src/entities/diffStats/diffStats.ts
+++ b/src/entities/diffStats/diffStats.ts
@@ -1,0 +1,5 @@
+export type DiffStats = {
+  commitsCount: number;
+  additions: number;
+  deletions: number;
+};

--- a/src/entities/diffStats/diffStatsFetch.gateway.ts
+++ b/src/entities/diffStats/diffStatsFetch.gateway.ts
@@ -1,0 +1,5 @@
+import type { DiffStats } from '@/entities/diffStats/diffStats.js';
+
+export interface DiffStatsFetchGateway {
+  fetchDiffStats(projectPath: string, mergeRequestNumber: number): DiffStats | null;
+}

--- a/src/entities/tracking/reviewEvent.ts
+++ b/src/entities/tracking/reviewEvent.ts
@@ -1,3 +1,5 @@
+import type { DiffStats } from '@/entities/diffStats/diffStats.js';
+
 export interface ReviewEvent {
   type: 'review' | 'followup';
   timestamp: string;
@@ -8,4 +10,5 @@ export interface ReviewEvent {
   suggestions: number;
   threadsClosed: number;
   threadsOpened: number;
+  diffStats: DiffStats | null;
 }

--- a/src/frameworks/claude/claudeInvoker.ts
+++ b/src/frameworks/claude/claudeInvoker.ts
@@ -12,6 +12,11 @@ import { getProjectAgents, getFollowupAgents } from '@/config/projectConfig.js';
 import { addReviewStats } from '@/services/statsService.js';
 import { FileSystemReviewRequestTrackingGateway } from '@/interface-adapters/gateways/fileSystem/reviewRequestTracking.fileSystem.js';
 import { ProjectStatsCalculator } from '@/interface-adapters/presenters/projectStats.calculator.js';
+import { GitLabDiffStatsFetchGateway } from '@/interface-adapters/gateways/diffStatsFetch.gitlab.gateway.js';
+import { GitHubDiffStatsFetchGateway } from '@/interface-adapters/gateways/diffStatsFetch.github.gateway.js';
+import { defaultGitLabExecutor } from '@/interface-adapters/gateways/threadFetch.gitlab.gateway.js';
+import { defaultGitHubExecutor } from '@/interface-adapters/gateways/threadFetch.github.gateway.js';
+import type { DiffStats } from '@/entities/diffStats/diffStats.js';
 import { resolveClaudePath } from '@/shared/services/claudePathResolver.js';
 import { getJobContextFilePath } from '@/shared/services/mcpJobContext.js';
 import { buildLanguageDirective } from '@/frameworks/claude/languageDirective.js';
@@ -513,7 +518,17 @@ export async function invokeClaudeReview(
             const mrDetails = trackingGateway.getById(job.localPath, mrId);
             const assignedBy = mrDetails?.assignment?.username;
 
-            const reviewStats = addReviewStats(job.localPath, job.mrNumber, durationMs, stdout, assignedBy);
+            let diffStats: DiffStats | null = null;
+            try {
+              const diffStatsFetchGateway = job.platform === 'github'
+                ? new GitHubDiffStatsFetchGateway(defaultGitHubExecutor)
+                : new GitLabDiffStatsFetchGateway(defaultGitLabExecutor);
+              diffStats = diffStatsFetchGateway.fetchDiffStats(job.projectPath, job.mrNumber);
+            } catch {
+              logger.warn({ jobId: job.id }, 'Failed to fetch diff stats, continuing without');
+            }
+
+            const reviewStats = addReviewStats(job.localPath, job.mrNumber, durationMs, stdout, assignedBy, diffStats);
             logger.info({ reviewStats }, 'Stats de review enregistrées');
           } catch (statsError) {
             logger.warn({ error: statsError }, 'Erreur lors de l\'enregistrement des stats');

--- a/src/interface-adapters/controllers/http/mrTrackingAdvanced.routes.ts
+++ b/src/interface-adapters/controllers/http/mrTrackingAdvanced.routes.ts
@@ -17,6 +17,8 @@ import { GitLabThreadFetchGateway, defaultGitLabExecutor } from '../../gateways/
 import { GitLabDiffMetadataFetchGateway } from '../../gateways/diffMetadataFetch.gitlab.gateway.js';
 import { GitHubDiffMetadataFetchGateway } from '../../gateways/diffMetadataFetch.github.gateway.js';
 import { startWatchingReviewContext, stopWatchingReviewContext } from '../../../main/websocket.js';
+import { GitLabDiffStatsFetchGateway } from '@/interface-adapters/gateways/diffStatsFetch.gitlab.gateway.js';
+import { GitHubDiffStatsFetchGateway } from '@/interface-adapters/gateways/diffStatsFetch.github.gateway.js';
 import type { Logger } from 'pino';
 
 interface MrTrackingAdvancedRoutesOptions {
@@ -209,8 +211,16 @@ export const mrTrackingAdvancedRoutes: FastifyPluginAsync<MrTrackingAdvancedRout
         const syncUseCase = new SyncThreadsUseCase(reviewRequestTrackingGateway, threadFetchGateway);
         const updatedMr = syncUseCase.execute({ projectPath: job.localPath, mrId });
 
-        // Record followup completion with parsed stats
-        // threadsClosed comes from THREAD_RESOLVE markers parsed from output
+        let diffStats = null;
+        try {
+          const diffStatsFetchGateway = job.platform === 'github'
+            ? new GitHubDiffStatsFetchGateway(defaultGitHubExecutor)
+            : new GitLabDiffStatsFetchGateway(defaultGitLabExecutor);
+          diffStats = diffStatsFetchGateway.fetchDiffStats(job.projectPath, job.mrNumber);
+        } catch {
+          logger.warn({ mrNumber: job.mrNumber }, 'Failed to fetch diff stats for manual followup');
+        }
+
         const recordCompletion = new RecordReviewCompletionUseCase(reviewRequestTrackingGateway);
         recordCompletion.execute({
           projectPath: job.localPath,
@@ -224,6 +234,7 @@ export const mrTrackingAdvancedRoutes: FastifyPluginAsync<MrTrackingAdvancedRout
             suggestions: parsed.suggestions,
             threadsOpened: 0,
             threadsClosed: threadResolveCount,
+            diffStats,
           },
         });
 

--- a/src/interface-adapters/controllers/webhook/github.controller.ts
+++ b/src/interface-adapters/controllers/webhook/github.controller.ts
@@ -25,11 +25,13 @@ import { DEFAULT_AGENTS } from '@/entities/progress/agentDefinition.type.js';
 import type { ReviewContextGateway } from '@/entities/reviewContext/reviewContext.gateway.js';
 import type { ThreadFetchGateway } from '@/entities/threadFetch/threadFetch.gateway.js';
 import type { DiffMetadataFetchGateway } from '@/entities/diffMetadata/diffMetadata.gateway.js';
+import type { DiffStatsFetchGateway } from '@/entities/diffStats/diffStatsFetch.gateway.js';
 
 export interface GitHubWebhookDependencies {
   reviewContextGateway: ReviewContextGateway;
   threadFetchGateway: ThreadFetchGateway;
   diffMetadataFetchGateway: DiffMetadataFetchGateway;
+  diffStatsFetchGateway: DiffStatsFetchGateway;
   trackAssignment: TrackAssignmentUseCase;
   recordCompletion: RecordReviewCompletionUseCase;
 }
@@ -312,8 +314,13 @@ export async function handleGitHubWebhook(
         );
       }
 
-      // Record review completion with parsed stats
-      // Only blocking issues count as open threads - warnings are informational
+      let reviewDiffStats = null;
+      try {
+        reviewDiffStats = deps.diffStatsFetchGateway.fetchDiffStats(j.projectPath, j.mrNumber);
+      } catch {
+        logger.warn({ prNumber: j.mrNumber }, 'Failed to fetch diff stats for review');
+      }
+
       recordCompletion.execute({
         projectPath: j.localPath,
         mrId: `github-${j.projectPath}-${j.mrNumber}`,
@@ -324,7 +331,8 @@ export async function handleGitHubWebhook(
           blocking: parsed.blocking,
           warnings: parsed.warnings,
           suggestions: parsed.suggestions,
-          threadsOpened: parsed.blocking, // Only blocking issues open threads
+          threadsOpened: parsed.blocking,
+          diffStats: reviewDiffStats,
         },
       });
 

--- a/src/interface-adapters/controllers/webhook/gitlab.controller.ts
+++ b/src/interface-adapters/controllers/webhook/gitlab.controller.ts
@@ -29,6 +29,7 @@ import { startWatchingReviewContext, stopWatchingReviewContext } from '@/main/we
 import type { ReviewContextGateway } from '@/entities/reviewContext/reviewContext.gateway.js';
 import type { ThreadFetchGateway } from '@/entities/threadFetch/threadFetch.gateway.js';
 import type { DiffMetadataFetchGateway } from '@/entities/diffMetadata/diffMetadata.gateway.js';
+import type { DiffStatsFetchGateway } from '@/entities/diffStats/diffStatsFetch.gateway.js';
 
 export function extractBaseUrl(remoteUrl: string): string | null {
   try {
@@ -52,6 +53,7 @@ export interface GitLabWebhookDependencies {
   reviewContextGateway: ReviewContextGateway;
   threadFetchGateway: ThreadFetchGateway;
   diffMetadataFetchGateway: DiffMetadataFetchGateway;
+  diffStatsFetchGateway: DiffStatsFetchGateway;
   trackAssignment: TrackAssignmentUseCase;
   recordCompletion: RecordReviewCompletionUseCase;
   recordPush: RecordPushUseCase;
@@ -356,8 +358,13 @@ export async function handleGitLabWebhook(
               const mrId = `gitlab-${j.projectPath}-${j.mrNumber}`;
               const updatedMr = syncThreads.execute({ projectPath: j.localPath, mrId });
 
-              // Record followup completion with parsed stats
-              // threadsClosed comes from THREAD_RESOLVE markers parsed from output
+              let followupDiffStats = null;
+              try {
+                followupDiffStats = deps.diffStatsFetchGateway.fetchDiffStats(j.projectPath, j.mrNumber);
+              } catch {
+                logger.warn({ mrNumber: j.mrNumber }, 'Failed to fetch diff stats for followup');
+              }
+
               recordCompletion.execute({
                 projectPath: j.localPath,
                 mrId,
@@ -370,6 +377,7 @@ export async function handleGitLabWebhook(
                   suggestions: parsed.suggestions,
                   threadsOpened: 0,
                   threadsClosed: threadResolveCount,
+                  diffStats: followupDiffStats,
                 },
               });
               logger.info(
@@ -587,8 +595,13 @@ export async function handleGitLabWebhook(
         }
       }
 
-      // Record review completion with parsed stats
-      // Only blocking issues count as open threads - warnings are informational
+      let reviewDiffStats = null;
+      try {
+        reviewDiffStats = deps.diffStatsFetchGateway.fetchDiffStats(j.projectPath, j.mrNumber);
+      } catch {
+        logger.warn({ mrNumber: j.mrNumber }, 'Failed to fetch diff stats for review');
+      }
+
       recordCompletion.execute({
         projectPath: j.localPath,
         mrId: `gitlab-${j.projectPath}-${j.mrNumber}`,
@@ -599,7 +612,8 @@ export async function handleGitLabWebhook(
           blocking: parsed.blocking,
           warnings: parsed.warnings,
           suggestions: parsed.suggestions,
-          threadsOpened: parsed.blocking, // Only blocking issues open threads
+          threadsOpened: parsed.blocking,
+          diffStats: reviewDiffStats,
         },
       });
 

--- a/src/interface-adapters/gateways/diffStatsFetch.github.gateway.ts
+++ b/src/interface-adapters/gateways/diffStatsFetch.github.gateway.ts
@@ -1,0 +1,39 @@
+import type { DiffStats } from '@/entities/diffStats/diffStats.js';
+import type { DiffStatsFetchGateway } from '@/entities/diffStats/diffStatsFetch.gateway.js';
+
+export type CommandExecutor = (command: string) => string;
+
+interface GitHubPullRequestStatsResponse {
+  additions: number;
+  deletions: number;
+  commits: number;
+}
+
+export class GitHubDiffStatsFetchGateway implements DiffStatsFetchGateway {
+  constructor(private readonly executor: CommandExecutor) {}
+
+  fetchDiffStats(projectPath: string, mergeRequestNumber: number): DiffStats | null {
+    try {
+      const response = this.executor(
+        `gh api repos/${projectPath}/pulls/${mergeRequestNumber}`
+      );
+      const pullRequest: GitHubPullRequestStatsResponse = JSON.parse(response);
+
+      if (
+        typeof pullRequest.additions !== 'number' ||
+        typeof pullRequest.deletions !== 'number' ||
+        typeof pullRequest.commits !== 'number'
+      ) {
+        return null;
+      }
+
+      return {
+        additions: pullRequest.additions,
+        deletions: pullRequest.deletions,
+        commitsCount: pullRequest.commits,
+      };
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/interface-adapters/gateways/diffStatsFetch.gitlab.gateway.ts
+++ b/src/interface-adapters/gateways/diffStatsFetch.gitlab.gateway.ts
@@ -1,0 +1,44 @@
+import type { DiffStats } from '@/entities/diffStats/diffStats.js';
+import type { DiffStatsFetchGateway } from '@/entities/diffStats/diffStatsFetch.gateway.js';
+
+export type CommandExecutor = (command: string) => string;
+
+interface GitLabMergeRequestStatsResponse {
+  additions: number;
+  deletions: number;
+}
+
+export class GitLabDiffStatsFetchGateway implements DiffStatsFetchGateway {
+  constructor(private readonly executor: CommandExecutor) {}
+
+  fetchDiffStats(projectPath: string, mergeRequestNumber: number): DiffStats | null {
+    try {
+      const encodedProject = projectPath.replace(/\//g, '%2F');
+
+      const mrResponse = this.executor(
+        `glab api projects/${encodedProject}/merge_requests/${mergeRequestNumber}`
+      );
+      const mergeRequest: GitLabMergeRequestStatsResponse = JSON.parse(mrResponse);
+
+      if (
+        typeof mergeRequest.additions !== 'number' ||
+        typeof mergeRequest.deletions !== 'number'
+      ) {
+        return null;
+      }
+
+      const commitsResponse = this.executor(
+        `glab api projects/${encodedProject}/merge_requests/${mergeRequestNumber}/commits`
+      );
+      const commits: unknown[] = JSON.parse(commitsResponse);
+
+      return {
+        additions: mergeRequest.additions,
+        deletions: mergeRequest.deletions,
+        commitsCount: Array.isArray(commits) ? commits.length : 0,
+      };
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/main/routes.ts
+++ b/src/main/routes.ts
@@ -23,6 +23,8 @@ import { GitLabThreadFetchGateway, defaultGitLabExecutor } from '@/interface-ada
 import { GitLabDiffMetadataFetchGateway } from '@/interface-adapters/gateways/diffMetadataFetch.gitlab.gateway.js';
 import { GitHubThreadFetchGateway, defaultGitHubExecutor } from '@/interface-adapters/gateways/threadFetch.github.gateway.js';
 import { GitHubDiffMetadataFetchGateway } from '@/interface-adapters/gateways/diffMetadataFetch.github.gateway.js';
+import { GitLabDiffStatsFetchGateway } from '@/interface-adapters/gateways/diffStatsFetch.gitlab.gateway.js';
+import { GitHubDiffStatsFetchGateway } from '@/interface-adapters/gateways/diffStatsFetch.github.gateway.js';
 import { TrackAssignmentUseCase } from '@/usecases/tracking/trackAssignment.usecase.js';
 import { RecordReviewCompletionUseCase } from '@/usecases/tracking/recordReviewCompletion.usecase.js';
 import { RecordPushUseCase } from '@/usecases/tracking/recordPush.usecase.js';
@@ -118,6 +120,7 @@ export async function registerRoutes(
       reviewContextGateway: deps.reviewContextGateway,
       threadFetchGateway: threadFetchGw,
       diffMetadataFetchGateway: new GitLabDiffMetadataFetchGateway(defaultGitLabExecutor),
+      diffStatsFetchGateway: new GitLabDiffStatsFetchGateway(defaultGitLabExecutor),
       trackAssignment: new TrackAssignmentUseCase(trackingGw),
       recordCompletion: new RecordReviewCompletionUseCase(trackingGw),
       recordPush: new RecordPushUseCase(trackingGw),
@@ -134,6 +137,7 @@ export async function registerRoutes(
       reviewContextGateway: deps.reviewContextGateway,
       threadFetchGateway: gitHubThreadFetchGw,
       diffMetadataFetchGateway: new GitHubDiffMetadataFetchGateway(defaultGitHubExecutor),
+      diffStatsFetchGateway: new GitHubDiffStatsFetchGateway(defaultGitHubExecutor),
       trackAssignment: new TrackAssignmentUseCase(trackingGw),
       recordCompletion: new RecordReviewCompletionUseCase(trackingGw),
     });

--- a/src/services/statsService.ts
+++ b/src/services/statsService.ts
@@ -1,19 +1,21 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import type { DiffStats } from '@/entities/diffStats/diffStats.js';
 
 /**
  * Individual review statistics
  */
 export interface ReviewStats {
-  id: string; // unique identifier (timestamp-based)
-  timestamp: string; // ISO 8601 timestamp
+  id: string;
+  timestamp: string;
   mrNumber: number;
-  duration: number; // milliseconds
-  score: number | null; // global score /10, null if not parseable
-  blocking: number; // count of blocking issues
-  warnings: number; // count of warnings/important issues
-  suggestions?: number; // count of suggestions
-  assignedBy?: string; // username of person who assigned the review
+  duration: number;
+  score: number | null;
+  blocking: number;
+  warnings: number;
+  suggestions?: number;
+  assignedBy?: string;
+  diffStats?: DiffStats | null;
 }
 
 /**
@@ -21,11 +23,15 @@ export interface ReviewStats {
  */
 export interface ProjectStats {
   totalReviews: number;
-  totalDuration: number; // milliseconds
+  totalDuration: number;
   averageScore: number | null;
-  averageDuration: number; // milliseconds
+  averageDuration: number;
   totalBlocking: number;
   totalWarnings: number;
+  totalAdditions: number;
+  totalDeletions: number;
+  averageAdditions: number | null;
+  averageDeletions: number | null;
   reviews: ReviewStats[];
   lastUpdated: string;
 }
@@ -89,6 +95,10 @@ function createEmptyStats(): ProjectStats {
     averageDuration: 0,
     totalBlocking: 0,
     totalWarnings: 0,
+    totalAdditions: 0,
+    totalDeletions: 0,
+    averageAdditions: null,
+    averageDeletions: null,
     reviews: [],
     lastUpdated: new Date().toISOString(),
   };
@@ -225,7 +235,8 @@ export function addReviewStats(
   mrNumber: number,
   duration: number,
   stdout: string,
-  assignedBy?: string
+  assignedBy?: string,
+  diffStats?: DiffStats | null
 ): ReviewStats {
   const stats = loadProjectStats(projectPath);
   const parsed = parseReviewOutput(stdout);
@@ -241,24 +252,28 @@ export function addReviewStats(
     warnings: parsed.warnings,
     suggestions: parsed.suggestions,
     assignedBy,
+    diffStats: diffStats ?? null,
   };
 
-  // Add to reviews array
   stats.reviews.push(reviewStats);
 
-  // Keep only last 100 reviews
   if (stats.reviews.length > 100) {
     stats.reviews = stats.reviews.slice(-100);
   }
 
-  // Recalculate aggregates
+  recalculateProjectStats(stats);
+  saveProjectStats(projectPath, stats);
+
+  return reviewStats;
+}
+
+function recalculateProjectStats(stats: ProjectStats): void {
   stats.totalReviews = stats.reviews.length;
   stats.totalDuration = stats.reviews.reduce((sum, r) => sum + r.duration, 0);
-  stats.averageDuration = stats.totalDuration / stats.totalReviews;
+  stats.averageDuration = stats.totalReviews > 0 ? stats.totalDuration / stats.totalReviews : 0;
   stats.totalBlocking = stats.reviews.reduce((sum, r) => sum + r.blocking, 0);
   stats.totalWarnings = stats.reviews.reduce((sum, r) => sum + r.warnings, 0);
 
-  // Calculate average score (only from reviews with scores)
   const reviewsWithScore = stats.reviews.filter((r) => r.score !== null);
   if (reviewsWithScore.length > 0) {
     stats.averageScore =
@@ -267,9 +282,17 @@ export function addReviewStats(
     stats.averageScore = null;
   }
 
-  saveProjectStats(projectPath, stats);
+  const reviewsWithDiffStats = stats.reviews.filter((r) => r.diffStats != null);
+  stats.totalAdditions = reviewsWithDiffStats.reduce((sum, r) => sum + (r.diffStats?.additions ?? 0), 0);
+  stats.totalDeletions = reviewsWithDiffStats.reduce((sum, r) => sum + (r.diffStats?.deletions ?? 0), 0);
 
-  return reviewStats;
+  if (reviewsWithDiffStats.length > 0) {
+    stats.averageAdditions = stats.totalAdditions / reviewsWithDiffStats.length;
+    stats.averageDeletions = stats.totalDeletions / reviewsWithDiffStats.length;
+  } else {
+    stats.averageAdditions = null;
+    stats.averageDeletions = null;
+  }
 }
 
 /**

--- a/src/tests/factories/diffStats.factory.ts
+++ b/src/tests/factories/diffStats.factory.ts
@@ -1,0 +1,12 @@
+import type { DiffStats } from '@/entities/diffStats/diffStats.js';
+
+export class DiffStatsFactory {
+  static create(overrides: Partial<DiffStats> = {}): DiffStats {
+    return {
+      commitsCount: 3,
+      additions: 150,
+      deletions: 30,
+      ...overrides,
+    };
+  }
+}

--- a/src/tests/factories/projectStats.factory.ts
+++ b/src/tests/factories/projectStats.factory.ts
@@ -1,4 +1,4 @@
-import type { ProjectStats, ReviewStats } from '../../services/statsService.js';
+import type { ProjectStats, ReviewStats } from '@/services/statsService.js';
 
 export class ReviewStatsFactory {
   static create(overrides: Partial<ReviewStats> = {}): ReviewStats {
@@ -12,6 +12,7 @@ export class ReviewStatsFactory {
       warnings: 2,
       suggestions: 3,
       assignedBy: 'developer',
+      diffStats: null,
       ...overrides,
     };
   }
@@ -26,6 +27,10 @@ export class ProjectStatsFactory {
       averageDuration: 0,
       totalBlocking: 0,
       totalWarnings: 0,
+      totalAdditions: 0,
+      totalDeletions: 0,
+      averageAdditions: null,
+      averageDeletions: null,
       reviews: [],
       lastUpdated: '2024-01-15T10:00:00Z',
       ...overrides,
@@ -34,10 +39,14 @@ export class ProjectStatsFactory {
 
   static withReviews(reviews: ReviewStats[]): ProjectStats {
     const totalDuration = reviews.reduce((sum, r) => sum + r.duration, 0);
-    const scores = reviews.filter((r) => r.score !== null).map((r) => r.score as number);
+    const scores = reviews.filter((r) => r.score !== null).map((r) => r.score ?? 0);
     const averageScore = scores.length > 0
       ? scores.reduce((a, b) => a + b, 0) / scores.length
       : null;
+
+    const reviewsWithDiffStats = reviews.filter((r) => r.diffStats != null);
+    const totalAdditions = reviewsWithDiffStats.reduce((sum, r) => sum + (r.diffStats?.additions ?? 0), 0);
+    const totalDeletions = reviewsWithDiffStats.reduce((sum, r) => sum + (r.diffStats?.deletions ?? 0), 0);
 
     return this.create({
       totalReviews: reviews.length,
@@ -46,6 +55,10 @@ export class ProjectStatsFactory {
       averageDuration: reviews.length > 0 ? totalDuration / reviews.length : 0,
       totalBlocking: reviews.reduce((sum, r) => sum + r.blocking, 0),
       totalWarnings: reviews.reduce((sum, r) => sum + r.warnings, 0),
+      totalAdditions,
+      totalDeletions,
+      averageAdditions: reviewsWithDiffStats.length > 0 ? totalAdditions / reviewsWithDiffStats.length : null,
+      averageDeletions: reviewsWithDiffStats.length > 0 ? totalDeletions / reviewsWithDiffStats.length : null,
       reviews,
     });
   }

--- a/src/tests/stubs/diffStatsFetch.stub.ts
+++ b/src/tests/stubs/diffStatsFetch.stub.ts
@@ -1,0 +1,14 @@
+import type { DiffStats } from '@/entities/diffStats/diffStats.js';
+import type { DiffStatsFetchGateway } from '@/entities/diffStats/diffStatsFetch.gateway.js';
+
+export class StubDiffStatsFetchGateway implements DiffStatsFetchGateway {
+  private readonly result: DiffStats | null;
+
+  constructor(result: DiffStats | null = null) {
+    this.result = result;
+  }
+
+  fetchDiffStats(): DiffStats | null {
+    return this.result;
+  }
+}

--- a/src/tests/units/entities/diffStats/diffStats.test.ts
+++ b/src/tests/units/entities/diffStats/diffStats.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { DiffStatsFactory } from '@/tests/factories/diffStats.factory.js';
+
+describe('DiffStats', () => {
+  it('should represent diff statistics with commits count, additions, and deletions', () => {
+    const diffStats = DiffStatsFactory.create();
+
+    expect(diffStats.commitsCount).toBe(3);
+    expect(diffStats.additions).toBe(150);
+    expect(diffStats.deletions).toBe(30);
+  });
+
+  it('should support zero values for all fields', () => {
+    const diffStats = DiffStatsFactory.create({
+      commitsCount: 0,
+      additions: 0,
+      deletions: 0,
+    });
+
+    expect(diffStats.commitsCount).toBe(0);
+    expect(diffStats.additions).toBe(0);
+    expect(diffStats.deletions).toBe(0);
+  });
+
+  it('should allow overriding individual fields', () => {
+    const diffStats = DiffStatsFactory.create({ additions: 500 });
+
+    expect(diffStats.commitsCount).toBe(3);
+    expect(diffStats.additions).toBe(500);
+    expect(diffStats.deletions).toBe(30);
+  });
+});

--- a/src/tests/units/interface-adapters/controllers/webhook/github.controller.test.ts
+++ b/src/tests/units/interface-adapters/controllers/webhook/github.controller.test.ts
@@ -80,6 +80,9 @@ function createMockDeps(): GitHubWebhookDependencies {
         startSha: 'ghi',
       })),
     },
+    diffStatsFetchGateway: {
+      fetchDiffStats: vi.fn(() => null),
+    },
     trackAssignment: { execute: vi.fn() },
     recordCompletion: { execute: vi.fn() },
   } as unknown as GitHubWebhookDependencies;

--- a/src/tests/units/interface-adapters/controllers/webhook/gitlab.controller.test.ts
+++ b/src/tests/units/interface-adapters/controllers/webhook/gitlab.controller.test.ts
@@ -135,6 +135,7 @@ function createDefaultDeps(trackingGateway: ReturnType<typeof createMockTracking
     reviewContextGateway: createStubContextGateway(),
     threadFetchGateway,
     diffMetadataFetchGateway: { fetchDiffMetadata: vi.fn(() => ({ baseSha: 'abc', headSha: 'def', startSha: 'ghi' })) },
+    diffStatsFetchGateway: { fetchDiffStats: vi.fn(() => null) },
     trackAssignment: new TrackAssignmentUseCase(trackingGateway),
     recordCompletion: new RecordReviewCompletionUseCase(trackingGateway),
     recordPush: new RecordPushUseCase(trackingGateway),

--- a/src/tests/units/interface-adapters/gateways/diffStatsFetch.github.gateway.test.ts
+++ b/src/tests/units/interface-adapters/gateways/diffStatsFetch.github.gateway.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { GitHubDiffStatsFetchGateway } from '@/interface-adapters/gateways/diffStatsFetch.github.gateway.js';
+
+describe('GitHubDiffStatsFetchGateway', () => {
+  describe('fetchDiffStats', () => {
+    it('should parse additions, deletions, and commits from GitHub PR API', () => {
+      const stubExecutor = () => JSON.stringify({
+        additions: 150,
+        deletions: 30,
+        commits: 3,
+      });
+
+      const gateway = new GitHubDiffStatsFetchGateway(stubExecutor);
+      const result = gateway.fetchDiffStats('owner/repo', 42);
+
+      expect(result).not.toBeNull();
+      expect(result?.additions).toBe(150);
+      expect(result?.deletions).toBe(30);
+      expect(result?.commitsCount).toBe(3);
+    });
+
+    it('should call the correct GitHub API endpoint', () => {
+      let capturedCommand = '';
+      const stubExecutor = (command: string) => {
+        capturedCommand = command;
+        return JSON.stringify({ additions: 0, deletions: 0, commits: 0 });
+      };
+
+      const gateway = new GitHubDiffStatsFetchGateway(stubExecutor);
+      gateway.fetchDiffStats('owner/repo', 42);
+
+      expect(capturedCommand).toContain('repos/owner/repo/pulls/42');
+    });
+
+    it('should return null when executor throws an error', () => {
+      const stubExecutor = () => {
+        throw new Error('Network error');
+      };
+
+      const gateway = new GitHubDiffStatsFetchGateway(stubExecutor);
+      const result = gateway.fetchDiffStats('owner/repo', 42);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when response is malformed JSON', () => {
+      const stubExecutor = () => 'not valid json';
+
+      const gateway = new GitHubDiffStatsFetchGateway(stubExecutor);
+      const result = gateway.fetchDiffStats('owner/repo', 42);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when response is missing required fields', () => {
+      const stubExecutor = () => JSON.stringify({ base: { sha: 'abc' } });
+
+      const gateway = new GitHubDiffStatsFetchGateway(stubExecutor);
+      const result = gateway.fetchDiffStats('owner/repo', 42);
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle zero-diff pull request', () => {
+      const stubExecutor = () => JSON.stringify({
+        additions: 0,
+        deletions: 0,
+        commits: 1,
+      });
+
+      const gateway = new GitHubDiffStatsFetchGateway(stubExecutor);
+      const result = gateway.fetchDiffStats('owner/repo', 10);
+
+      expect(result).not.toBeNull();
+      expect(result?.additions).toBe(0);
+      expect(result?.deletions).toBe(0);
+      expect(result?.commitsCount).toBe(1);
+    });
+  });
+});

--- a/src/tests/units/interface-adapters/gateways/diffStatsFetch.gitlab.gateway.test.ts
+++ b/src/tests/units/interface-adapters/gateways/diffStatsFetch.gitlab.gateway.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { GitLabDiffStatsFetchGateway } from '@/interface-adapters/gateways/diffStatsFetch.gitlab.gateway.js';
+
+describe('GitLabDiffStatsFetchGateway', () => {
+  describe('fetchDiffStats', () => {
+    it('should parse additions, deletions from MR API and count commits', () => {
+      const stubExecutor = (command: string) => {
+        if (command.includes('/commits')) {
+          return JSON.stringify([
+            { id: 'commit1' },
+            { id: 'commit2' },
+            { id: 'commit3' },
+          ]);
+        }
+        return JSON.stringify({
+          changes_count: '5',
+          additions: 150,
+          deletions: 30,
+        });
+      };
+
+      const gateway = new GitLabDiffStatsFetchGateway(stubExecutor);
+      const result = gateway.fetchDiffStats('group/project', 42);
+
+      expect(result).not.toBeNull();
+      expect(result?.additions).toBe(150);
+      expect(result?.deletions).toBe(30);
+      expect(result?.commitsCount).toBe(3);
+    });
+
+    it('should encode project path for API URL', () => {
+      const capturedCommands: string[] = [];
+      const stubExecutor = (command: string) => {
+        capturedCommands.push(command);
+        if (command.includes('/commits')) {
+          return JSON.stringify([{ id: 'commit1' }]);
+        }
+        return JSON.stringify({ additions: 0, deletions: 0 });
+      };
+
+      const gateway = new GitLabDiffStatsFetchGateway(stubExecutor);
+      gateway.fetchDiffStats('group/project', 99);
+
+      expect(capturedCommands[0]).toContain('group%2Fproject');
+      expect(capturedCommands[0]).toContain('merge_requests/99');
+    });
+
+    it('should return null when MR API call throws', () => {
+      const stubExecutor = () => {
+        throw new Error('API error');
+      };
+
+      const gateway = new GitLabDiffStatsFetchGateway(stubExecutor);
+      const result = gateway.fetchDiffStats('group/project', 42);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when commits API call throws', () => {
+      const stubExecutor = (command: string) => {
+        if (command.includes('/commits')) {
+          throw new Error('Commits API error');
+        }
+        return JSON.stringify({ additions: 10, deletions: 5 });
+      };
+
+      const gateway = new GitLabDiffStatsFetchGateway(stubExecutor);
+      const result = gateway.fetchDiffStats('group/project', 42);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when MR response is malformed', () => {
+      const stubExecutor = () => 'not valid json';
+
+      const gateway = new GitLabDiffStatsFetchGateway(stubExecutor);
+      const result = gateway.fetchDiffStats('group/project', 42);
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle MR with zero additions and deletions', () => {
+      const stubExecutor = (command: string) => {
+        if (command.includes('/commits')) {
+          return JSON.stringify([{ id: 'commit1' }]);
+        }
+        return JSON.stringify({ additions: 0, deletions: 0 });
+      };
+
+      const gateway = new GitLabDiffStatsFetchGateway(stubExecutor);
+      const result = gateway.fetchDiffStats('group/project', 10);
+
+      expect(result).not.toBeNull();
+      expect(result?.additions).toBe(0);
+      expect(result?.deletions).toBe(0);
+      expect(result?.commitsCount).toBe(1);
+    });
+
+    it('should handle empty commits array', () => {
+      const stubExecutor = (command: string) => {
+        if (command.includes('/commits')) {
+          return JSON.stringify([]);
+        }
+        return JSON.stringify({ additions: 10, deletions: 5 });
+      };
+
+      const gateway = new GitLabDiffStatsFetchGateway(stubExecutor);
+      const result = gateway.fetchDiffStats('group/project', 42);
+
+      expect(result).not.toBeNull();
+      expect(result?.commitsCount).toBe(0);
+    });
+  });
+});

--- a/src/tests/units/interface-adapters/gateways/reviewRequestTracking.gateway.test.ts
+++ b/src/tests/units/interface-adapters/gateways/reviewRequestTracking.gateway.test.ts
@@ -150,6 +150,7 @@ describe('ReviewRequestTrackingGateway', () => {
         suggestions: 3,
         threadsClosed: 0,
         threadsOpened: 3,
+        diffStats: null,
       });
 
       const result = gateway.getById('/my/project', 'mr-1');
@@ -174,6 +175,7 @@ describe('ReviewRequestTrackingGateway', () => {
         suggestions: 0,
         threadsClosed: 2,
         threadsOpened: 0,
+        diffStats: null,
       });
 
       const result = gateway.getById('/my/project', 'mr-1');

--- a/src/tests/units/services/statsService.diffStats.test.ts
+++ b/src/tests/units/services/statsService.diffStats.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { ProjectStatsFactory, ReviewStatsFactory } from '@/tests/factories/projectStats.factory.js';
+import { DiffStatsFactory } from '@/tests/factories/diffStats.factory.js';
+import type { ReviewStats } from '@/services/statsService.js';
+
+describe('StatsService DiffStats', () => {
+  describe('ReviewStats', () => {
+    it('should support diffStats field with additions, deletions, and commitsCount', () => {
+      const diffStats = DiffStatsFactory.create();
+      const reviewStats = ReviewStatsFactory.create({ diffStats });
+
+      expect(reviewStats.diffStats).toEqual({
+        commitsCount: 3,
+        additions: 150,
+        deletions: 30,
+      });
+    });
+
+    it('should support null diffStats for reviews without diff data', () => {
+      const reviewStats = ReviewStatsFactory.create({ diffStats: null });
+
+      expect(reviewStats.diffStats).toBeNull();
+    });
+  });
+
+  describe('ProjectStats', () => {
+    it('should include totalAdditions and totalDeletions aggregates', () => {
+      const stats = ProjectStatsFactory.create();
+
+      expect(stats.totalAdditions).toBe(0);
+      expect(stats.totalDeletions).toBe(0);
+    });
+
+    it('should include averageAdditions and averageDeletions', () => {
+      const stats = ProjectStatsFactory.create();
+
+      expect(stats.averageAdditions).toBeNull();
+      expect(stats.averageDeletions).toBeNull();
+    });
+
+    it('should compute aggregates from reviews with diffStats', () => {
+      const reviews: ReviewStats[] = [
+        ReviewStatsFactory.create({
+          diffStats: DiffStatsFactory.create({ additions: 100, deletions: 20 }),
+        }),
+        ReviewStatsFactory.create({
+          diffStats: DiffStatsFactory.create({ additions: 200, deletions: 40 }),
+        }),
+        ReviewStatsFactory.create({
+          diffStats: null,
+        }),
+      ];
+
+      const stats = ProjectStatsFactory.withReviews(reviews);
+
+      expect(stats.totalAdditions).toBe(300);
+      expect(stats.totalDeletions).toBe(60);
+      expect(stats.averageAdditions).toBe(150);
+      expect(stats.averageDeletions).toBe(30);
+    });
+
+    it('should return null averages when no reviews have diffStats', () => {
+      const reviews: ReviewStats[] = [
+        ReviewStatsFactory.create({ diffStats: null }),
+      ];
+
+      const stats = ProjectStatsFactory.withReviews(reviews);
+
+      expect(stats.totalAdditions).toBe(0);
+      expect(stats.totalDeletions).toBe(0);
+      expect(stats.averageAdditions).toBeNull();
+      expect(stats.averageDeletions).toBeNull();
+    });
+  });
+});

--- a/src/tests/units/usecases/tracking/recordReviewCompletion.usecase.test.ts
+++ b/src/tests/units/usecases/tracking/recordReviewCompletion.usecase.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { RecordReviewCompletionUseCase } from '../../../../usecases/tracking/recordReviewCompletion.usecase.js';
 import { InMemoryReviewRequestTrackingGateway } from '../../../stubs/reviewRequestTracking.stub.js';
 import { TrackedMrFactory } from '../../../factories/trackedMr.factory.js';
+import { DiffStatsFactory } from '@/tests/factories/diffStats.factory.js';
 
 describe('RecordReviewCompletionUseCase', () => {
   const reviewData = {
@@ -100,7 +101,7 @@ describe('RecordReviewCompletionUseCase', () => {
     const mr = TrackedMrFactory.create({
       id: 'mr-1',
       reviews: [
-        { type: 'review', timestamp: '2024-01-01T00:00:00Z', durationMs: 1000, score: 6, blocking: 0, warnings: 0, suggestions: 0, threadsClosed: 0, threadsOpened: 0 },
+        { type: 'review', timestamp: '2024-01-01T00:00:00Z', durationMs: 1000, score: 6, blocking: 0, warnings: 0, suggestions: 0, threadsClosed: 0, threadsOpened: 0, diffStats: null },
       ],
       totalReviews: 1,
       latestScore: 6,
@@ -122,7 +123,7 @@ describe('RecordReviewCompletionUseCase', () => {
     const mr = TrackedMrFactory.create({
       id: 'mr-1',
       reviews: [
-        { type: 'review', timestamp: '2024-01-01T00:00:00Z', durationMs: 1000, score: 5, blocking: 1, warnings: 0, suggestions: 0, threadsClosed: 0, threadsOpened: 1 },
+        { type: 'review', timestamp: '2024-01-01T00:00:00Z', durationMs: 1000, score: 5, blocking: 1, warnings: 0, suggestions: 0, threadsClosed: 0, threadsOpened: 1, diffStats: null },
       ],
       totalReviews: 1,
       latestScore: 5,
@@ -147,6 +148,40 @@ describe('RecordReviewCompletionUseCase', () => {
     });
 
     expect(result?.latestScore).toBe(8);
+  });
+
+  it('should record diffStats in review event when provided', () => {
+    const gateway = new InMemoryReviewRequestTrackingGateway();
+    const mr = TrackedMrFactory.create({ id: 'mr-1' });
+    gateway.create('/project', mr);
+    const useCase = new RecordReviewCompletionUseCase(gateway);
+
+    const diffStats = DiffStatsFactory.create({ commitsCount: 5, additions: 200, deletions: 50 });
+    const result = useCase.execute({
+      projectPath: '/project',
+      mrId: 'mr-1',
+      reviewData: { ...reviewData, diffStats },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.reviews).toHaveLength(1);
+    expect(result?.reviews[0].diffStats).toEqual({
+      commitsCount: 5,
+      additions: 200,
+      deletions: 50,
+    });
+  });
+
+  it('should set diffStats to null when not provided', () => {
+    const gateway = new InMemoryReviewRequestTrackingGateway();
+    const mr = TrackedMrFactory.create({ id: 'mr-1' });
+    gateway.create('/project', mr);
+    const useCase = new RecordReviewCompletionUseCase(gateway);
+
+    const result = useCase.execute({ projectPath: '/project', mrId: 'mr-1', reviewData });
+
+    expect(result).not.toBeNull();
+    expect(result?.reviews[0].diffStats).toBeNull();
   });
 
   it('should return null for unknown MR', () => {

--- a/src/usecases/tracking/recordReviewCompletion.usecase.ts
+++ b/src/usecases/tracking/recordReviewCompletion.usecase.ts
@@ -2,6 +2,7 @@ import type { UseCase } from '../../shared/foundation/usecase.base.js';
 import type { ReviewRequestTrackingGateway } from '../../interface-adapters/gateways/reviewRequestTracking.gateway.js';
 import type { TrackedMr } from '../../entities/tracking/trackedMr.js';
 import type { ReviewEvent } from '../../entities/tracking/reviewEvent.js';
+import type { DiffStats } from '@/entities/diffStats/diffStats.js';
 
 interface RecordReviewCompletionInput {
   projectPath: string;
@@ -15,6 +16,7 @@ interface RecordReviewCompletionInput {
     suggestions?: number;
     threadsOpened?: number;
     threadsClosed?: number;
+    diffStats?: DiffStats | null;
   };
 }
 
@@ -41,6 +43,7 @@ export class RecordReviewCompletionUseCase implements UseCase<RecordReviewComple
       suggestions,
       threadsOpened,
       threadsClosed,
+      diffStats: reviewData.diffStats ?? null,
     };
 
     this.trackingGateway.recordReviewEvent(projectPath, mrId, event);


### PR DESCRIPTION
Implements #47. Each review now captures code volume metrics from the platform API (GitHub/GitLab) to contextualize review quality against diff size.

- New DiffStats entity type { commitsCount, additions, deletions }
- DiffStatsFetchGateway contract + GitHub/GitLab implementations
- GitHub: single API call (PR returns stats directly)
- GitLab: two API calls (MR details + commits endpoint)
- ReviewEvent and ReviewStats extended with optional diffStats field
- ProjectStats includes aggregates (totalAdditions, averageDeletions...)
- Graceful degradation: fetch failure returns null, never blocks review
- Backward compatible: old reviews show null for diffStats
- 24 new tests covering all layers

Fixes #47

## Summary

Brief description of the changes.

## Changes

-

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] CI/Build

## Checklist

- [ ] `yarn verify` passes (typecheck + lint + tests)
- [ ] Tests added/updated for new functionality
- [ ] Documentation updated if needed
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

How was this tested?
