### PR TITLE
chore: align with Shiplens — harness parity + backlog cleanup

### DIFF
--- a/.claude/agents/feature-implementer.md
+++ b/.claude/agents/feature-implementer.md
@@ -1,26 +1,29 @@
 ---
 name: feature-implementer
-description: Use this agent to implement features via TDD inside-out. Receives a validated plan and spec, creates all files with RED-GREEN-REFACTOR cycles, runs tests at each step, then self-reviews and fixes autonomously before reporting.
+description: Implement a ReviewFlow feature via TDD inside-out. Receives a validated plan (docs/plans/<slug>.plan.md) and spec (docs/specs/<slug>.md), implements all layers with RED-GREEN-REFACTOR, self-reviews, and persists a report. Triggers when the user says "implement feature", "start implementation", "implement spec", or "run feature-implementer".
 tools: Read, Write, Edit, Bash, Glob, Grep, LS
 model: opus
-maxTurns: 50
+maxTurns: 60
 skills:
   - tdd
   - clean-architecture
+  - anti-overengineering
 ---
 
 # Feature Implementer
 
 You are a TDD implementation agent for ReviewFlow, a Clean Architecture Fastify/TypeScript project.
 
-## Coding Standards
+## Project Rules
 
-Read `.claude/rules/coding-standards.md` BEFORE coding.
+Read `.claude/CLAUDE.md` and `.claude/rules/coding-standards.md` BEFORE coding. They are the non-negotiable source of truth.
 
 ## Project Context
 
 - Stack: Node.js 20+, Fastify 5, TypeScript 5.8+, Zod 4, Pino, p-queue
+- Package manager: `yarn` (never `pnpm` or `npm`)
 - Test runner: `yarn test:ci` (Vitest, CI mode)
+- Quality gate: `yarn verify` (typecheck + lint + test:ci)
 - Tests in English, user-facing text in French
 - Full words only (no abbreviations)
 - Zero comments in code unless vital
@@ -94,6 +97,19 @@ describe('Create Review (acceptance)', () => {
 ### Absolute rule
 
 The acceptance test is the FIRST file created. Nothing else starts until it is written and RED.
+
+---
+
+## Pause Points (critical decisions — ask before continuing)
+
+On these elements, **pause and ask the user for validation**:
+
+- Design choice of an entity (fields, internal logic)
+- Signature of a gateway port (I/O contract)
+- Error strategy (which error type to throw)
+- New external dependency
+
+For everything else (use cases, presenters, controllers, wiring), proceed autonomously.
 
 ---
 
@@ -215,11 +231,13 @@ If after 3 iterations problems remain:
 - NEVER use `any`, `as`, `!` (type assertions)
 - NEVER use relative imports (`../`) — always `@/` aliases + `.js`
 - NEVER add comments unless vital for comprehension
+- NEVER use barrel exports (`index.ts` re-exports)
+- NEVER use `yarn test` — always `yarn test:ci`
 - Run tests after EACH step (RED and GREEN)
 - Include test output in the report
 - Persist the report in `docs/reports/<feature-name>.report.md`
 - Update the feature tracker (`docs/feature-tracker.md`) — status: `implementing` at Phase 0, `implemented` at Phase 3
-- Do NOT commit
+- Do NOT commit — the user ships with `/ship`
 
 ---
 

--- a/.claude/agents/feature-planner.md
+++ b/.claude/agents/feature-planner.md
@@ -1,22 +1,31 @@
 ---
 name: feature-planner
-description: Use this agent to plan feature implementation by analyzing specs and mapping them to Clean Architecture layers. Reads existing modules as reference, produces a structured implementation plan with file paths, ordering, and architectural decisions.
-tools: Read, Glob, Grep, LS
+description: Plan a ReviewFlow feature implementation. Analyzes a spec in docs/specs/, maps it to Clean Architecture layers (Entity → Use Case → Gateway → Controller), and produces a structured plan in docs/plans/<slug>.plan.md. Triggers when the user says "plan feature", "plan implementation", "analyse spec", or "create plan for".
+tools: Read, Glob, Grep, LS, Write, Edit
 model: opus
-maxTurns: 30
+maxTurns: 40
 permissionMode: default
 skills:
   - clean-architecture
   - product-manager
+  - anti-overengineering
 ---
 
 # Feature Planner
 
-You are a planning agent for feature implementation in ReviewFlow, a Clean Architecture Fastify/TypeScript project.
+You are a planning agent for ReviewFlow, a Clean Architecture Fastify/TypeScript project.
 
-## Coding Standards
+## Project Rules
 
-Read `.claude/rules/coding-standards.md` BEFORE any analysis.
+Read `.claude/CLAUDE.md` and `.claude/rules/coding-standards.md` BEFORE any analysis.
+
+## Execution Protocol (mandatory)
+
+**Your very first action after reading the spec MUST be `Write` of the plan skeleton** to `docs/plans/<feature-name>.plan.md` (header + empty sections matching the Output format below).
+
+Only then read codebase reference files, then use `Edit` to fill each section incrementally.
+
+**Why**: secures the deliverable upfront — if you exhaust the turn budget during exploration, the skeleton exists and can be enriched in a follow-up. Announcing "I will write" in plain text without invoking the tool is forbidden.
 
 ## Mission
 
@@ -31,7 +40,9 @@ Read `.claude/rules/coding-standards.md` BEFORE any analysis.
    - `src/shared/foundation/guard.base.ts`
    - `src/shared/foundation/usecase.base.ts` (if exists)
 
-3. **Analyze the spec** and identify:
+3. **Challenge scope** with `/anti-overengineering`: does the feature warrant all proposed layers?
+
+4. **Analyze the spec** and identify:
    - Which entities in `src/entities/`?
    - Which use cases in `src/usecases/`?
    - Which controllers (webhook, http, mcp)?
@@ -39,7 +50,9 @@ Read `.claude/rules/coding-standards.md` BEFORE any analysis.
    - Which presenters/views (if dashboard-related)?
    - Which framework-level code (queue, logging, config)?
 
-4. **Produce the structured plan**
+5. **Identify a Walking Skeleton** for new features: the first minimal vertical slice that crosses all layers (Entity → Use Case → Controller → acceptance test). This is `IMPLEMENTATION_ORDER` step 1.
+
+6. **Produce the structured plan**
 
 ## Constraints
 
@@ -50,6 +63,8 @@ Read `.claude/rules/coding-standards.md` BEFORE any analysis.
 - File naming: camelCase .ts with domain suffixes
 - Imports: `@/` alias + `.js` extension
 - Wiring in `src/main/routes.ts` is always the last step
+- Do NOT include implementation code — only structure and architectural decisions
+- All rules in `.claude/rules/coding-standards.md` apply
 
 ## Output format
 
@@ -124,3 +139,13 @@ This file serves as:
 - Evidence of the planning phase for the feature tracker
 
 Update the feature tracker (`docs/feature-tracker.md`) — set status to `planned`.
+
+## Output: Acceptance Test Reference
+
+Add to the plan:
+
+```
+ACCEPTANCE_TEST:
+  file: src/tests/acceptance/<feature-name>.acceptance.test.ts
+  note: "SDD outer loop — written first by implementer, RED during impl, GREEN at the end"
+```

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,21 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/scripts/hooks/no-barrel-exports.sh\"",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/scripts/hooks/enforce-dependency-rule.sh\"",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/scripts/hooks/enforce-gateway-port-purity.sh\"",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/scripts/hooks/enforce-presenter-class.sh\"",
+            "timeout": 5
           }
         ]
       },

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: ship
+description: Ship — commit and push in one command. Chains quality gates, conventional commit, push, and optional PR creation + merge. Use when the user says "ship", "commit and push", "/ship", or wants to finalize a branch.
+user-invocable: true
+allowed-tools: Bash, Read
+---
+
+# Ship — Commit & Push
+
+## Activation
+
+This skill activates with `/ship`. It chains verification, commit, push, and optionally PR creation and merge.
+
+## Optional arguments
+
+```
+/ship                   # Commit + push (no PR)
+/ship pr                # Commit + push + gh pr create
+/ship pr merge          # Commit + push + gh pr create + gh pr merge --admin --squash
+```
+
+## Workflow
+
+### Step 0: Quality Gates (BLOCKING)
+
+**BEFORE any commit**, run:
+
+```bash
+yarn verify
+```
+
+`yarn verify` runs: TypeScript check + Biome lint + Vitest tests.
+
+**If it fails**: display the errors and **STOP**. Do not proceed until all quality gates pass.
+
+---
+
+### Step 1: Analysis
+
+```bash
+git status --short
+git branch --show-current
+git log --oneline -5
+```
+
+**Guards**:
+- If branch = `master`: **STOP** — the `protect-main-push.sh` hook blocks push to master. Create a feature branch first.
+- If nothing to commit: inform and stop.
+
+---
+
+### Step 2: Staging
+
+- If files are not staged, list them and add them **by name** (never `git add -A` or `git add .`)
+- **NEVER** include `.env`, credentials, secrets, or lock files unless explicitly requested
+- **NEVER** include files unrelated to the current change
+
+Preferred pattern:
+```bash
+git add src/usecases/foo.usecase.ts src/tests/units/usecases/foo.usecase.test.ts
+```
+
+---
+
+### Step 3: Commit
+
+Infer the message from the staged changes. Follow Conventional Commits:
+
+```
+<type>(<scope>): <description>
+```
+
+| Type | Usage |
+|------|-------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `refactor` | Refactoring (no feature or fix) |
+| `test` | Tests only |
+| `docs` | Documentation only |
+| `chore` | Maintenance, dependencies |
+| `style` | Formatting (no logic change) |
+| `perf` | Performance improvement |
+| `ci` | CI/CD changes |
+
+**Rules**:
+- Header max **72 characters**
+- Description in lowercase, no trailing period
+- Scope optional in parentheses, must match bounded context name when applicable
+
+**Commit via heredoc** (preserves formatting):
+```bash
+git commit -m "$(cat <<'EOF'
+feat(webhook): add GitHub signature validation
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+The `pre-commit-gate.sh` and `verify-spec-updated.sh` hooks run automatically. If they fail, **fix the issue and retry** — never use `--no-verify`.
+
+---
+
+### Step 4: Push
+
+```bash
+git push -u origin <branch>
+```
+
+The `protect-main-push.sh` hook blocks push to `master` and force push. If it triggers, verify you are on a feature branch.
+
+---
+
+### Step 5 (if `pr` or `pr merge`): Create PR
+
+```bash
+gh pr create --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
+## Summary
+- <bullet point 1>
+- <bullet point 2>
+
+## Test plan
+- [ ] yarn verify passes
+- [ ] Acceptance tests green
+
+🤖 Generated with Claude Code
+EOF
+)"
+```
+
+Base branch: `master`.
+
+---
+
+### Step 6 (if `pr merge` only and user explicitly requested): Merge PR
+
+```bash
+gh pr merge --admin --squash
+```
+
+**ONLY if the user explicitly asked for merge**. Never merge without explicit confirmation.
+
+---
+
+### Step 7: Summary
+
+```
+SHIP
+
+Branch  : <branch>
+Commit  : <type>(<scope>): <description>
+Push    : origin/<branch>
+Gates   : yarn verify — green
+PR      : <url or "not created">
+Merge   : <squash merged or "not merged">
+```
+
+---
+
+## Security Rules
+
+- **NEVER** use `--force` push
+- **NEVER** push to `master` directly (hook enforces this)
+- **NEVER** use `--no-verify` or bypass hooks
+- **NEVER** commit `.env`, credentials, or secrets
+- **NEVER** stage with `git add -A` or `git add .`
+- **ALWAYS** verify you are on a feature branch before pushing

--- a/.claude/skills/skill-creator/SKILL.md
+++ b/.claude/skills/skill-creator/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: skill-creator
+description: Guide for creating or updating a ReviewFlow skill. Use when the user wants to create a new skill, update an existing skill, or asks how to add a slash command that extends Claude's capabilities in this project.
+user-invocable: true
+---
+
+# Skill Creator
+
+Guide for creating effective skills in the ReviewFlow project.
+
+## About Skills
+
+Skills are modular, self-contained packages that extend Claude's capabilities with specialized workflows, domain knowledge, and tool integrations. They transform Claude from a general-purpose agent into a project-specialized one.
+
+### What Skills Provide
+
+1. **Specialized workflows** — Multi-step procedures (e.g. `/ship`, `/tdd`, `/implement-feature`)
+2. **Domain expertise** — ReviewFlow-specific knowledge, architecture patterns, business rules
+3. **Bundled resources** — References and assets loaded on demand
+
+## Core Principles
+
+### Concise is Key
+
+The context window is a shared resource. Only add context Claude does not already have. Challenge each paragraph: "Does Claude really need this?" If not, remove it.
+
+### Set Appropriate Degrees of Freedom
+
+- **High freedom** (text instructions): multiple approaches valid, context-dependent
+- **Medium freedom** (pseudocode/templates): preferred pattern exists, variation acceptable
+- **Low freedom** (shell scripts): operations are fragile, consistency critical
+
+### Anatomy of a ReviewFlow Skill
+
+```
+.claude/skills/<skill-name>/
+├── SKILL.md            (required)
+│   ├── YAML frontmatter (required: name + description)
+│   └── Markdown instructions
+└── references/         (optional — bundled docs loaded by reference)
+```
+
+## Skill Creation Process
+
+1. Understand the skill with 2-3 concrete usage examples
+2. Draft the frontmatter (`name`, `description`, `user-invocable`)
+3. Write the body — imperative instructions, low prose
+4. Test it: invoke `/skill-name` and verify Claude follows the workflow
+5. Register in `CLAUDE.md` skills table
+
+## Frontmatter Reference
+
+```yaml
+---
+name: skill-name            # kebab-case, matches folder name
+description: >              # PRIMARY TRIGGER — LLM reads only this initially.
+  One or two sentences.     # Include natural-language trigger phrases.
+  "Use when the user says X, Y, Z."
+user-invocable: true        # true = can be invoked with /skill-name
+allowed-tools: Bash, Read   # optional — restrict available tools
+---
+```
+
+**Official fields**: `name`, `description`, `user-invocable`, `allowed-tools`, `disable-model-invocation`, `context`.
+
+> `triggers: []` is NOT an official field — it is silently ignored. The `description` is the only trigger mechanism.
+
+## Writing Guidelines
+
+- Write in **English** — no exceptions (code, body, comments)
+- Use **imperative form**: "Run", "Read", "Stop", never "You should run"
+- `description` is the primary trigger — include natural trigger phrases in it
+- Keep the body under **400 lines**
+- Include only what Claude does not already know
+- Prefer tables and bullet lists over prose paragraphs
+- Match ReviewFlow conventions (see `CLAUDE.md` and `.claude/rules/coding-standards.md`)
+
+## What NOT to Include
+
+- Generic programming knowledge Claude already has
+- README-style context that belongs in docs
+- Comments explaining what the skill is (the frontmatter does that)
+- Skills are for AI agents, not humans — do not write tutorials
+
+## ReviewFlow-Specific Conventions
+
+| Convention | Detail |
+|------------|--------|
+| Package manager | `yarn` — never `pnpm` or `npm` |
+| Main branch | `master` — never `main` |
+| Quality gate | `yarn verify` (typecheck + lint + test:ci) |
+| Commit format | Conventional Commits via commitlint |
+| Language | English everywhere (code, tests, commits, logs) |
+| Imports | `@/` alias + `.js` extension mandatory |
+| No barrel exports | Direct imports only, no `index.ts` re-exports |
+
+## Skill Registration
+
+After creating a skill, add it to the skills table in `CLAUDE.md`:
+
+```markdown
+| `/skill-name` | When to use this skill |
+```
+
+## Quick Template
+
+```markdown
+---
+name: my-skill
+description: Brief description. Use when the user says "X", "Y", or wants to Z.
+user-invocable: true
+---
+
+# My Skill — Short Title
+
+## Activation
+
+This skill activates with `/my-skill`.
+
+## Workflow
+
+### Step 1: <Action>
+
+<Instructions>
+
+### Step 2: <Action>
+
+<Instructions>
+
+## Rules
+
+- NEVER do X
+- ALWAYS do Y
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # ReviewFlow CLAUDE.md
 
+## Quick start
+
+New here? Read **[docs/HARNESS-ONBOARDING.md](docs/HARNESS-ONBOARDING.md)** first — covers the 5 key commands, active hooks, and the SDD pipeline.
+
 ## Behavior
 
 Important: Each response will start with "I read the rules." This demonstrates you have followed our guidelines.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,14 +253,35 @@ Use instead:
 
 ## Backlog Management
 
-**Source of truth**: [GitHub Issues](https://github.com/DGouron/review-flow/issues) and [ReviewFlow Roadmap](https://github.com/users/DGouron/projects/3) project board.
+**Two distinct backlogs** (Shiplens-style):
 
-### Conventions
+| Backlog | Source of truth | Used for |
+|---------|----------------|----------|
+| **Features** | `docs/specs/<n>-<slug>.md` + `docs/feature-tracker.md` | New capabilities, enhancements, refactorings |
+| **Bugs** | [GitHub Issues](https://github.com/DGouron/review-flow/issues) | Reproducible defects only |
 
-- **Issues** are the single source of truth for all features, bugs, and refactoring tickets
-- **Milestones** group issues by release scope
-- **Labels** indicate type (`enhancement`, `bug`, `refactor`), priority (`P1-critical`, `P2-important`, `P3-nice-to-have`), and scope (`cli`, `dashboard`, `mcp`, `skills`, etc.)
-- Use conventional commit format and reference issues in PRs (`Fixes #43`)
+### Rules
+
+- **GitHub Issues are reserved for bugs.** No features, no refactors, no docs tickets.
+- **Features live in `docs/specs/`** — produced by `/product-manager`, indexed in `docs/feature-tracker.md` (status: `drafted` → `planned` → `implementing` → `implemented`).
+- **One spec = one feature.** Implementation reports go to `docs/reports/<feature>.report.md`.
+- **Labels on bug issues**: priority (`P1-critical`, `P2-important`, `P3-nice-to-have`) and scope (`cli`, `dashboard`, `mcp`, `webhook`, etc.).
+- Use conventional commit format. PRs reference the spec slug (`feat(webhook): implement spec-046 github followup`) or the bug issue (`fix: #46 plain-bug-description`).
+
+### Workflow
+
+```
+New idea / improvement → /product-manager → docs/specs/<n>-<slug>.md
+                                          ↓
+                                  feature-tracker.md (drafted)
+                                          ↓
+                                  /implement-feature → docs/reports/<slug>.report.md
+                                          ↓
+                                  feature-tracker.md (implemented)
+
+Bug found → gh issue create --label bug,P{1,2,3},scope
+         → fix on branch → PR closes issue
+```
 
 ## Git Workflow
 

--- a/docs/HARNESS-ONBOARDING.md
+++ b/docs/HARNESS-ONBOARDING.md
@@ -1,0 +1,120 @@
+# Harness Onboarding — ReviewFlow
+
+Day-1 guide for a developer or agent joining ReviewFlow and using the **Claude harness** (skills, hooks, SDD pipeline).
+
+---
+
+## TL;DR — 5 commands to know
+
+```bash
+yarn verify                            # typecheck + lint + test:ci — run before every commit
+yarn test:ci                           # Vitest one-shot (CI mode)
+systemctl --user restart reviewflow-app  # Restart the local service after config changes
+yarn build                             # Compile TypeScript + resolve aliases
+yarn docs:dev                          # VitePress dev server for documentation
+```
+
+---
+
+## What the harness does for you
+
+When you run Claude Code in ReviewFlow, **7 hooks** + skills + agents are active.
+
+- **You cannot create an `index.ts`** (barrel exports forbidden) — `no-barrel-exports.sh`
+- **You cannot commit on `master`** — create a `feat/<issue>-description` branch — `protect-main-branch.sh`
+- **You cannot push to `master`** or force-push — `protect-main-push.sh`
+- **You cannot commit if `yarn test:ci` fails** — fix first — `pre-commit-gate.sh`
+- **You cannot invoke `feature-implementer` without a valid spec** — `require-spec.sh`
+- **A stale spec status blocks commit** — `verify-spec-updated.sh`
+- **Session start injects feature tracker status** into context — `session-context.sh`
+
+Three additional architecture enforcers are incoming (parallel work):
+
+| Enforcer | What it blocks |
+|----------|----------------|
+| `enforce-dependency-rule.sh` | Inverted imports — outer layer importing inner |
+| `enforce-gateway-port-purity.sh` | Gateway implementation importing a use case |
+| `enforce-presenter-class.sh` | Presenter that is not a class |
+
+All hook scripts live in `scripts/hooks/` — tests in `scripts/hooks/tests/run-tests.sh`.
+
+---
+
+## The SDD pipeline — how to ship a feature
+
+5 steps:
+
+1. **`/product-manager`** — challenge scope + INVEST + spec DSL → `docs/specs/<slug>.md`
+2. **`/implement-feature docs/specs/XX.md`** — orchestrates planner + TDD implementer agents
+3. The `feature-planner` agent → `docs/plans/<slug>.plan.md`
+4. The `feature-implementer` agent → TDD (Red-Green-Refactor) + `docs/reports/<slug>.report.md`
+5. **`/ship`** — hooks verify spec/tracker → conventional commit + push
+
+Feature tracker: `docs/feature-tracker.md` — statuses: `drafted` → `planned` → `implementing` → `implemented`.
+
+---
+
+## Key skills
+
+### Mandatory (use before writing any code)
+
+| Skill | When |
+|-------|------|
+| `/tdd` | Always — no production code without a failing test first |
+| `/architecture` | Creating new entity, use case, or gateway |
+| `/anti-overengineering` | Before adding patterns, abstractions, or "improvements" |
+
+### Workflow
+
+| Skill | When |
+|-------|------|
+| `/implement-feature` | Autonomous feature implementation |
+| `/ship` | Commit + push (runs hooks) |
+| `/skill-creator` | Create or modify a skill |
+
+---
+
+## Your 3 first actions (sanity check)
+
+```bash
+# 1. Verify quality gates pass
+yarn verify
+
+# 2. Run hook test suite
+bash scripts/hooks/tests/run-tests.sh
+
+# 3. Confirm feature tracker is loaded
+cat docs/feature-tracker.md | head -5
+```
+
+---
+
+## Hooks reference
+
+| Hook | Trigger | Purpose |
+|------|---------|---------|
+| `no-barrel-exports.sh` | Write\|Edit | Blocks `index.ts` barrel creation |
+| `protect-main-branch.sh` | git commit | Blocks commit on `master` |
+| `protect-main-push.sh` | git push | Blocks push to `master`, force-push |
+| `pre-commit-gate.sh` | git commit | Runs `yarn test:ci` before commit |
+| `verify-spec-updated.sh` | git commit | Checks spec status is not stale |
+| `require-spec.sh` | Agent | Blocks `feature-implementer` without spec |
+| `session-context.sh` | SessionStart | Injects tracker status into context |
+
+---
+
+## Context: ReviewFlow vs shiplens differences
+
+| Aspect | ReviewFlow | shiplens |
+|--------|-----------|---------|
+| Package manager | yarn | pnpm |
+| Main branch | `master` | `main`/`master` |
+| Framework | Fastify 5 + Node 20 | NestJS 11 |
+| Test runner | Vitest (`yarn test:ci`) | Vitest (`pnpm test`) |
+| Linter | Biome | Biome |
+| Tracker path | `docs/feature-tracker.md` | `docs/feature-tracker.md` |
+| Specs | `docs/specs/` | `docs/specs/<bc>/` |
+
+---
+
+_Last updated: 2026-05-15_

--- a/docs/feature-tracker.md
+++ b/docs/feature-tracker.md
@@ -29,4 +29,5 @@
 | Dashboard multi-project overview | [91-dashboard-multi-project-overview](specs/91-dashboard-multi-project-overview.md) | implemented | 2026-03-14 |
 | Split CLI god file | [92-split-cli-god-file](specs/92-split-cli-god-file.md) | drafted | 2026-03-14 |
 | Developer & team insights | [125-developer-team-insights](specs/125-developer-team-insights.md) | implemented | 2026-04-01 |
+| Hybrid model routing + token tracking | (no spec — see report) | implemented | 2026-05-14 |
 | Skill templates | [skill-templates](specs/skill-templates.md) | drafted | 2026-03-14 |

--- a/docs/feature-tracker.md
+++ b/docs/feature-tracker.md
@@ -9,7 +9,7 @@
 | Capture git diff stats | [47-capture-git-diff-stats](specs/47-capture-git-diff-stats.md) | drafted | 2026-03-14 |
 | Review focus selection | [48-review-focus-selection](specs/48-review-focus-selection.md) | drafted | 2026-03-14 |
 | Update skills project examples | [50-update-skills-project-examples](specs/50-update-skills-project-examples.md) | drafted | 2026-03-14 |
-| Dashboard unit tests | [51-dashboard-unit-tests](specs/51-dashboard-unit-tests.md) | drafted | 2026-03-14 |
+| Dashboard unit tests | [51-dashboard-unit-tests](specs/51-dashboard-unit-tests.md) | drafted | 2026-05-15 |
 | Automated webhook secret generation | [52-automated-webhook-secret-generation](specs/52-automated-webhook-secret-generation.md) | drafted | 2026-03-14 |
 | Configuration validation command | [55-configuration-validation-command](specs/55-configuration-validation-command.md) | drafted | 2026-03-14 |
 | MCP-ready skeleton skill templates | [56-mcp-ready-skeleton-skill-templates](specs/56-mcp-ready-skeleton-skill-templates.md) | drafted | 2026-03-14 |

--- a/docs/reports/dashboard-multi-project-overview.report.md
+++ b/docs/reports/dashboard-multi-project-overview.report.md
@@ -1,0 +1,36 @@
+# Dashboard Multi-Project Overview
+
+**Spec**: [docs/specs/91-dashboard-multi-project-overview.md](../specs/91-dashboard-multi-project-overview.md)
+**Merged**: 2026-03-14 (marked implemented)
+**Issue**: [#91](https://github.com/DGouron/review-flow/issues/91)
+
+---
+
+## Scope
+
+- Tab bar replacing the project-selector dropdown; Overview tab as default on load
+- Overview tab with 3 sections: Active Reviews (real-time via WebSocket), Project Cards (stats + SVG sparkline), Recent Reviews feed (last 10 across all projects)
+- Per-project tabs retaining all existing dashboard behavior
+- Tab state persisted in localStorage across page reloads
+- Reused existing multi-project `GET /api/stats` and `GET /api/reviews` endpoints (no path = all projects)
+- No new frontend dependencies (vanilla JS/CSS/SVG)
+
+---
+
+## Outcome
+
+Dashboard now presents a unified cross-project view at load. Existing per-project functionality unchanged. RAM monitoring and per-process CPU bars deferred (see spec Scope Challenge section — requires child PID tracking not yet implemented).
+
+---
+
+## Tests / Verification
+
+Unit tests cover: Overview tab default load, Active Reviews real-time update, project card stats + sparkline, Recent Reviews ordering, tab state persistence, empty states (no projects, project with 0 reviews). `yarn verify` green at merge.
+
+---
+
+## Outstanding / Follow-ups
+
+- **GitHub issue #91 is still open** — close manually once verified in production.
+- RAM monitoring bars (per-process) — deferred to a future ticket; requires child PID tracking.
+- `GET /api/system/resources` endpoint — deferred with RAM monitoring.

--- a/docs/reports/developer-team-insights.report.md
+++ b/docs/reports/developer-team-insights.report.md
@@ -1,0 +1,36 @@
+# Developer & Team Insights
+
+**Spec**: [docs/specs/125-developer-team-insights.md](../specs/125-developer-team-insights.md)
+**Merged**: 2026-04-01
+**Issue**: [#125](https://github.com/DGouron/review-flow/issues/125)
+
+---
+
+## Scope
+
+- Per-developer insight engine: 4 analysis categories (Quality, Responsiveness, Code Volume, Iteration), dual comparison (vs team average + own historical trend), stat levels 1–10
+- RPG-inspired developer cards in a new "Team" tab: avatar, generated title (The Architect, The Firefighter, etc.), stat bars
+- Team-wide analysis panel: pros, cons, actionable tips
+- Developer sheet (slide panel): radar chart, review history, strengths/weaknesses, top-priority recommendation
+- Minimum threshold: 5 reviews per developer before showing insights
+- Full i18n (EN/FR) for all titles, labels, and tips
+
+---
+
+## Outcome
+
+Implemented in 3 phases (domain engine → Team tab UI → Developer sheet + Team insights panel). All business rules are deterministic — no LLM calls for insight generation. Title generation is computed from dominant category level.
+
+---
+
+## Tests / Verification
+
+Unit tests cover all Gherkin scenarios: level computation with dual-weight formula, insufficient-data guard, title generation mapping, single-developer edge case (absolute benchmarks), empty-team state. CI green at merge.
+
+---
+
+## Outstanding / Follow-ups
+
+- Cross-project insights (currently per-project only) — explicitly deferred in spec
+- Historical insight snapshots — deferred in spec
+- Custom thresholds (levels and benchmarks hardcoded in v1) — deferred in spec

--- a/docs/reports/eventbus-queue-state.report.md
+++ b/docs/reports/eventbus-queue-state.report.md
@@ -1,0 +1,35 @@
+# EventBus Queue State
+
+**Spec**: [docs/specs/82-eventbus-queue-state.md](../specs/82-eventbus-queue-state.md)
+**Merged**: 2026-03-14 (marked implemented)
+**Issue**: [#82](https://github.com/DGouron/review-flow/issues/82)
+
+---
+
+## Scope
+
+- Replace two global mutable callbacks (`progressChangeCallback`, `stateChangeCallback`) in `pQueueAdapter.ts` with a typed `QueueEventBus` interface
+- `QueueEventBus` contract in `src/entities/queue/` (inner layer defines the port)
+- `InMemoryQueueEventBus` implementation in `src/frameworks/queue/`
+- `initQueue()` now receives `QueueEventBus` via DI; `websocket.ts` subscribes via `eventBus.on()`
+- `server.ts` (composition root) creates the instance and injects it into both consumers
+- `on()` returns an unsubscribe function — same pattern as existing `logBuffer.onLog()`
+
+---
+
+## Outcome
+
+Zero global mutable callback variables remain in `pQueueAdapter.ts`. Multiple listeners can now subscribe independently. Dependency Rule restored: `websocket.ts` depends on the `QueueEventBus` abstraction, not directly on `pQueueAdapter.ts` internals.
+
+---
+
+## Tests / Verification
+
+Unit tests for `InMemoryQueueEventBus` cover all 7 Gherkin scenarios (multiple listeners, unsubscribe, full job lifecycle state transitions, failed job). Existing WebSocket test updated. `yarn verify` green at merge.
+
+---
+
+## Outstanding / Follow-ups
+
+- `activeJobs`, `completedJobs`, `recentJobs` Maps in `pQueueAdapter.ts` remain global (explicitly out of scope — separate extraction concern)
+- New event types (`job:cancelled`) can be added in follow-up tickets

--- a/docs/reports/token-tracking-and-model-routing.report.md
+++ b/docs/reports/token-tracking-and-model-routing.report.md
@@ -1,0 +1,89 @@
+# Token Tracking and Hybrid Model Routing
+
+**Spec**: # (no spec — retroactive)
+**PR**: [#147](https://github.com/DGouron/review-flow/pull/147) — `feat: hybrid model routing + token usage tracking`
+**Merged**: 2026-05-14T21:01:49Z — commit `2479b43c33d234a1d1ae787284cfb8d3763458bb`
+**Additions / Deletions**: +985 / -35
+
+---
+
+## Motivation
+
+Ahead of the 2026-06-15 billing change, where `claude -p` usage shifts to dedicated monthly credits ($20/$100/$200 for Pro/Max5x/Max20x), the default of always invoking Opus on every review became too expensive. This PR introduces cost-aware routing and usage visibility.
+
+Also fixed a dormant bug: `defaultModel` was already parsed from per-repo config but `claudeInvoker.ts` hardcoded `'opus'` — the field was silently ignored.
+
+---
+
+## Scope
+
+- **Hybrid model routing** — select `haiku` / `sonnet` / `opus` per review based on diff line count and a `routingPolicy` in `.claude/reviews/config.json`
+- **Token usage tracking** — switch invoker to `--output-format stream-json --verbose`, parse the NDJSON stream, extract final `usage` block, persist to `.claude/reviews/usage.jsonl`
+- **Summarize token usage** — `SummarizeTokenUsageUseCase` aggregates the JSONL for reporting (data ready; no dashboard route yet)
+- **Bug fix** — `defaultModel` now actually applied by `claudeInvoker.ts`
+
+---
+
+## Architecture
+
+New Clean Architecture components:
+
+| Layer | Component | Role |
+|-------|-----------|------|
+| Entity | `entities/modelRouting/modelRouting.schema.ts` | `ClaudeModelName`, `RoutingPolicy` types |
+| Entity | `entities/modelRouting/modelRouting.gateway.ts` | Gateway contract for routing policy read |
+| Entity | `entities/tokenUsage/tokenUsage.schema.ts` | `TokenUsage`, `TokenUsageRecord` types |
+| Entity | `entities/tokenUsage/tokenUsage.gateway.ts` | Gateway contract for persistence |
+| Use case | `usecases/selectModelForReview/` | Routing decision: given diff size + policy → model name |
+| Use case | `usecases/trackTokenUsage/` | Appends one record to usage JSONL |
+| Use case | `usecases/summarizeTokenUsage/` | Aggregates all records (monthly totals) |
+| Gateway | `gateways/projectConfig/routingPolicy.projectConfig.gateway.ts` | Reads `routingPolicy` from per-repo config |
+| Gateway | `gateways/tokenUsage/tokenUsage.filesystem.gateway.ts` | JSONL append + read from filesystem |
+| Framework | `frameworks/claude/streamJsonParser.ts` | Tolerant NDJSON parser; reconstructs assistant text + extracts `usage` |
+
+`InvocationResult` now exposes `usage?: TokenUsage | null` and `selectedModel?: ClaudeModelName`.
+
+---
+
+## Routing Logic
+
+```
+routingPolicy.haikuMaxLines  → diff lines ≤ threshold  → haiku  (~1x cost)
+routingPolicy.sonnetMaxLines → diff lines ≤ threshold  → sonnet (~3x cost)
+otherwise                                               → opus   (~15x cost)
+```
+
+Fallback chain: `routingPolicy` absent → `defaultModel` → `opus`.
+Diff stats unavailable → `defaultModel`.
+
+---
+
+## Tests / Verification
+
+28 new tests added across 7 new test files:
+
+| Test file | Coverage |
+|-----------|----------|
+| `streamJsonParser.test.ts` | NDJSON parsing, partial chunks, usage extraction |
+| `selectModelForReview.usecase.test.ts` | Routing thresholds, fallbacks |
+| `trackTokenUsage.usecase.test.ts` | Record creation + gateway delegation |
+| `summarizeTokenUsage.usecase.test.ts` | Aggregation by model, monthly grouping |
+| `routingPolicy.projectConfig.gateway.test.ts` | Config read, missing field defaults |
+| `tokenUsage.filesystem.gateway.test.ts` | JSONL append, read, corrupt-line tolerance |
+| `projectConfig.test.ts` | `defaultModel` now parsed and returned |
+
+CI at merge: **175 suites / 1383 tests — all passing**. `yarn typecheck`, `yarn lint`, `yarn build` all green.
+
+Manual verification pending (not blocking merge):
+- Trigger a real MR review on a repo with `routingPolicy` configured
+- Verify `.claude/reviews/usage.jsonl` is appended
+- Verify log file contains both assistant text and raw stream-json
+
+---
+
+## Outstanding / Follow-ups
+
+- Dashboard route + view to visualize monthly token consumption (`SummarizeTokenUsageUseCase` is ready, no frontend yet)
+- Threshold alert when approaching plan credit limit
+- `claudeInsightsInvoker.ts` not migrated to stream-json (different use case, lower volume)
+- CLAUDE.md / docs not yet updated with the `routingPolicy` knob

--- a/docs/specs/51-dashboard-unit-tests.md
+++ b/docs/specs/51-dashboard-unit-tests.md
@@ -1,250 +1,68 @@
-# Spec #51 — Dashboard Unit Tests
+# Cover dashboard modules with unit tests
 
-**Issue**: [#51](https://github.com/DGouron/review-flow/issues/51)
-**Labels**: enhancement, good first issue, P2-important, dashboard, testing
-**Milestone**: Dashboard Modularization
-**Date**: 2026-03-14
+## Context
 
----
+Six dashboard modules in `src/interface-adapters/views/dashboard/modules/` ship without unit tests. Refactoring them is blind: a breaking change reaches the dashboard before any regression is caught. The original spec was written when 13 modules existed and 13 had tests; the dashboard grew to 22 modules and the gap widened silently.
 
-## Problem Statement
+## Rules
 
-Extracted dashboard modules need automated test coverage to prevent regressions during further modularization and feature development. Without tests, refactoring the dashboard is risky: breaking changes go undetected until production.
+- Every JavaScript module under `src/interface-adapters/views/dashboard/modules/` has at least one corresponding `.test.ts` file
+- Test files mirror the module path under `src/tests/units/interface-adapters/views/dashboard/modules/`
+- A module is considered covered when its public exports each have at least one nominal scenario and one edge case
+- No production code is modified by this spec — test-only change
+- Tests follow the existing Detroit-school pattern (state-based, factories, `vi.stubGlobal` for browser globals)
 
----
+## Scenarios
 
-## Scope Challenge & Current State
-
-### What already exists (verified 2026-03-14)
-
-The codebase already contains **13 test files** covering **all 13 extracted modules**, with **93 passing tests**:
-
-| Module | Test file | Tests |
-|--------|-----------|-------|
-| `formatting.js` | `formatting.test.ts` | 13 (formatTime, formatDuration, formatPhase, formatLogTime) |
-| `html.js` | `html.test.ts` | 9 (escapeHtml, markdownToHtml, sanitizeHttpUrl) |
-| `icons.js` | `icons.test.ts` | 7 (getAgentIcon, icon) |
-| `constants.js` | `constants.test.ts` | 3 (exported values) |
-| `i18n.js` | `i18n.test.ts` | 14 (language switching, translations en/fr) |
-| `notifications.js` | `notifications.test.ts` | 6 (collectReviewNotifications lifecycle) |
-| `desktopNotifications.js` | `desktopNotifications.test.ts` | tests for shouldNotifyDesktop, getDesktopNotificationPayload |
-| `assignee.js` | `assignee.test.ts` | 3 (resolveReviewAssigneeDisplay fallback chain) |
-| `loading.js` | `loading.test.ts` | 7 (getLoadingPresentation, getQuietRefreshSectionIdentifiers) |
-| `priority.js` | `priority.test.ts` | 3 (rankPendingFixForNowLane sorting, determinism, immutability) |
-| `quality.js` | `quality.test.ts` | 7 (getQualityProgress, getQualityTrend) |
-| `queueLanes.js` | `queueLanes.test.ts` | 3 (buildQueueLanesModel partitioning) |
-| `sessionMetrics.js` | `sessionMetrics.test.ts` | 7 (trackSessionAction, updatePriorityItemTracking, getSessionMetricsSnapshot) |
-
-### What the issue requests but cannot be done yet
-
-The issue acceptance criteria include:
-
-- **"Tests for WebSocket connection management"** — WebSocket logic (`connectWebSocket`, reconnection, message routing) is still **inline** in `index.html` (lines 1497-1562). It has not been extracted into a testable module. This is tracked by **#70** (closed) and **#72** (open).
-- **"Tests for localStorage persistence"** — localStorage usage (project list save/load, current project restore, focus strip mode) is still **inline** in `index.html` (lines 1665-1816). Extraction is tracked by **#72** (open).
-
-These cannot be unit-tested until #72 extracts them into standalone modules.
-
-### Conclusion
-
-The **already-completed work covers 3 of 5 acceptance criteria** (formatting utilities, HTML escaping, 80%+ branch coverage on extracted modules). The remaining 2 criteria (WebSocket, localStorage) are **blocked by #72**.
-
----
-
-## Remaining User Story
-
-**As** a maintainer of the ReviewFlow dashboard,
-**I want** to verify that existing dashboard module tests provide sufficient branch coverage and close remaining gaps,
-**So that** I can confidently refactor and extend dashboard modules without regressions.
-
----
-
-## Acceptance Criteria (Gherkin)
-
-### Scenario 1: Branch coverage target met on extracted modules
-
-```gherkin
-Given all 13 dashboard modules are extracted in src/interface-adapters/views/dashboard/modules/
-When running `yarn coverage` scoped to dashboard module tests
-Then branch coverage across all modules is 80% or higher
-```
-
-### Scenario 2: Priority ranking edge cases
-
-```gherkin
-Given a list of pending-fix merge requests with identical urgency scores and identical timestamps
-When rankPendingFixForNowLane is called
-Then items are sorted by mrNumber ascending as a tiebreaker
-And items without mrNumber fall to the end
-```
-
-### Scenario 3: Markdown-to-HTML handles combined formatting
-
-```gherkin
-Given a markdown string containing a code block, a list, and a table
-When markdownToHtml is called
-Then the output contains <pre><code>, <ul><li>, and <table><tr><td> elements
-And all user-provided text is HTML-escaped before rendering
-```
-
-### Scenario 4: Notification state handles large seen-keys list
-
-```gherkin
-Given a notification state with 500 seen recent keys (MAX_RECENT_KEYS)
-When a 501st unique recent review arrives
-Then the oldest seen key is evicted
-And the new review triggers a notification
-```
-
-### Scenario 5: Session metrics handle edge case timing
-
-```gherkin
-Given a session that started at time T
-And a priority item was tracked starting at T+1000
-When the priority item is resolved AND replaced by a new item in the same update
-Then the resolved item duration is recorded
-And the new item tracking starts immediately
-```
-
-### Scenario 6: Quality progress handles extreme scores
-
-```gherkin
-Given a quality score of 0
-When getQualityProgress is called with default target 8
-Then progressPercent is 0
-And targetDelta is -8.0
-And targetDeltaLabel is "-8.0"
-```
-
-### Scenario 7: Desktop notification payload rejects unknown kinds
-
-```gherkin
-Given a notification with kind "unknownEvent"
-When getDesktopNotificationPayload is called
-Then it returns null
-```
-
-### Scenario 8: Assignee resolution with empty strings
-
-```gherkin
-Given a review where assignedBy.displayName is "" and assignedBy.username is ""
-And no matching merge request exists in tracked list
-When resolveReviewAssigneeDisplay is called
-Then it returns "unknown"
-```
-
-### Scenario 9: Loading presentation handles all flags active simultaneously
-
-```gherkin
-Given loadingState has status=1, reviewFiles=1, stats=1, mrTracking=1
-And hasLoadedStatusOnce is true
-When getLoadingPresentation is called
-Then showGlobalLoading is true (heavy refresh overrides quiet mode)
-And isQuietRefresh is false
-```
-
-### Scenario 10: i18n handles nested parameter substitution
-
-```gherkin
-Given the language is "en"
-When t('time.minutesAgo', { minutes: 0 }) is called
-Then it returns "0 min ago" (boundary value)
-```
-
----
+- nominal: {modules: 22, tests: 22} → acceptance test passes
+- gap detected: {modules: 22, tests: 16} → acceptance test rejects with list of uncovered modules
+- new module added without test: {add `foo.js`, no `foo.test.ts`} → acceptance test rejects "Module sans test: foo.js"
+- module deleted: {remove `bar.js`, keep `bar.test.ts`} → acceptance test rejects "Test orphelin: bar.test.ts"
+- empty module list: {modules dir missing or empty} → acceptance test rejects "Aucun module dashboard détecté"
 
 ## Out of Scope
 
-| Item | Reason |
-|------|--------|
-| WebSocket module tests | WebSocket logic is inline in `index.html`; blocked by #72 |
-| localStorage persistence tests | localStorage logic is inline in `index.html`; blocked by #72 |
-| Integration tests (browser rendering) | Issue targets unit tests only |
-| index.html inline code testing | Cannot unit-test inline `<script>` blocks; requires extraction first |
-| New module extraction | That is #72's scope |
-| Dashboard presenter tests | No presenter module exists yet; out of scope |
-| Visual regression testing | Not requested; different concern |
+- WebSocket connection-management tests (logic still inline in `index.html`, separate spec needed for extraction)
+- localStorage persistence tests (same situation as WebSocket)
+- Integration tests / browser rendering / visual regression
+- Coverage percentage thresholds (separate concern, tracked via `yarn coverage`)
+- Refactoring existing tests
+- Dashboard presenter tests (no presenter module exists yet)
 
----
+## Glossary
 
-## Technical Notes
+| Term | Definition |
+|------|------------|
+| Dashboard module | A `.js` file under `src/interface-adapters/views/dashboard/modules/` consumed by the browser-served `index.html` |
+| Covered module | A module whose file path has a matching `.test.ts` in the mirrored test directory |
+| Uncovered module | A module with no corresponding test file (the gap this spec closes) |
+| Orphan test | A test file whose target module no longer exists |
 
-### Test location
+## Current Gap (verified 2026-05-15)
 
-All tests live in `src/tests/units/interface-adapters/views/dashboard/modules/` mirroring the source structure.
+Modules without tests:
+- `cleanup.js`
+- `collapsibleList.js`
+- `mrSheet.js`
+- `sharedViewHelpers.js`
+- `statsCharts.js`
+- `versionUpdate.js`
 
-### Test patterns to follow
+## INVEST
 
-Dashboard module tests use a specific pattern because modules are **browser JS** (not TypeScript, not compiled):
-
-- Test files are TypeScript (`.test.ts`) importing JS modules via `@/` alias + `.js` extension
-- No DOM mocking needed for pure logic modules (formatting, priority, quality, etc.)
-- Modules depending on browser globals (`Notification`, `localStorage`) require `vi.stubGlobal()` or equivalent
-- Vitest `describe/it/expect` with state-based assertions (Detroit school)
-
-### Modules sorted by gap-closing priority
-
-| Priority | Module | Reason |
-|----------|--------|--------|
-| 1 | `priority.js` | Complex sorting with multiple tiebreakers; only 3 tests currently |
-| 2 | `notifications.js` | State machine with MAX_RECENT_KEYS eviction; 6 tests but no eviction boundary test |
-| 3 | `sessionMetrics.js` | 4 exported functions, only 7 tests; `updatePriorityItemTracking` has multiple state transitions |
-| 4 | `html.js` | `markdownToHtml` has 12+ regex transforms; only 5 tests on this function |
-| 5 | `quality.js` | Edge cases around 0 scores, NaN, Infinity not covered |
-
----
-
-## Dependencies
-
-| Dependency | Status | Impact |
-|------------|--------|--------|
-| #69 — Extract dashboard utility modules | **Closed** | All utility modules available and tested |
-| #70 — Extract WebSocket module | **Closed** | WebSocket partially extracted; inline code remains |
-| #71 — Extract project loader module | **Closed** | Loader extracted |
-| #72 — Extract remaining domain modules | **Open** | **Blocks** WebSocket and localStorage test criteria from issue |
-
----
-
-## INVEST Validation
-
-| Criterion | Assessment | Status |
-|-----------|------------|--------|
-| **Independent** | Can proceed now on coverage gaps; WebSocket/localStorage blocked by #72 | PASS |
-| **Negotiable** | Coverage target (80% branch) is negotiable; specific gap-closing tests are flexible | PASS |
-| **Valuable** | Catches regressions before they reach the dashboard; enables confident refactoring | PASS |
-| **Estimable** | ~2h to close coverage gaps on existing modules; bounded by 13 known modules | PASS |
-| **Small** | 93 tests already exist; remaining work is gap analysis + edge case tests | PASS |
-| **Testable** | Coverage report provides objective pass/fail; Gherkin scenarios are concrete | PASS |
-
----
-
-## Suggested Implementation Plan
-
-### Phase 1: Close coverage gaps (actionable now — ~2h)
-
-1. Run `yarn coverage` scoped to dashboard modules — measure current branch coverage
-2. Identify branches not covered (early returns, edge cases, boundary values)
-3. Add missing edge case tests following priority list above
-4. Verify 80%+ branch coverage is met across all modules
-5. `yarn verify` passes
-
-### Phase 2: WebSocket + localStorage tests (blocked by #72)
-
-Once #72 extracts WebSocket and localStorage logic into modules:
-
-1. Add tests for WebSocket reconnection logic (max attempts, delay, cleanup)
-2. Add tests for localStorage save/load/fallback behavior
-3. Update this spec to mark remaining acceptance criteria as done
-
----
+| Criterion | Status | Note |
+|-----------|--------|------|
+| Independent | OK | No code change, only test additions |
+| Negotiable | OK | Test depth per module is flexible (min: 1 nominal + 1 edge case) |
+| Valuable | OK | Unblocks safe refactoring of all 22 modules |
+| Estimable | OK | 6 modules × ~30 min = ~3h |
+| Small | OK | Test-only, no production change |
+| Testable | OK | Acceptance test gives objective pass/fail |
 
 ## Definition of Done
 
-- [ ] All existing 93 dashboard module tests pass
-- [ ] Branch coverage across all 13 extracted modules is 80%+
-- [ ] Edge case tests added for `priority.js` tiebreakers (identical scores, missing fields)
-- [ ] Edge case tests added for `notifications.js` MAX_RECENT_KEYS boundary
-- [ ] Edge case tests added for `sessionMetrics.js` simultaneous resolve-and-track
-- [ ] Edge case tests added for `html.js` combined markdown formatting
-- [ ] Edge case tests added for `quality.js` extreme values (0, NaN)
+- [ ] Acceptance test `dashboard-modules-coverage.acceptance.test.ts` is GREEN
+- [ ] One `.test.ts` exists for each of the 6 uncovered modules
+- [ ] Each new test file has at least one nominal scenario and one edge case per public export
 - [ ] `yarn verify` passes (typecheck + lint + tests)
-- [ ] No new production code added (test-only change)
+- [ ] Feature tracker updated: status `drafted` → `implemented`

--- a/scripts/hooks/enforce-dependency-rule.sh
+++ b/scripts/hooks/enforce-dependency-rule.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Enforces the Clean Architecture Dependency Rule.
+# entities/ must not import from usecases/, interface-adapters/, or frameworks/.
+# usecases/ must not import from interface-adapters/ or frameworks/.
+# Applies to all files under src/.
+# Used as PreToolUse hook on Write|Edit.
+# Exit 0 = allow, Exit 2 = block with feedback to Claude.
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | "$HOOK_DIR/parse-json.sh" tool_input.file_path)
+
+is_in_src() {
+  [[ "$FILE_PATH" == */src/* ]]
+}
+
+if ! is_in_src; then
+  exit 0
+fi
+
+CONTENT=$(echo "$INPUT" | "$HOOK_DIR/parse-json.sh" tool_input.content)
+NEW_STRING=$(echo "$INPUT" | "$HOOK_DIR/parse-json.sh" tool_input.new_string)
+TEXT_TO_CHECK="${CONTENT}${NEW_STRING}"
+
+is_entity_file() {
+  [[ "$FILE_PATH" == */src/entities/* ]]
+}
+
+is_usecase_file() {
+  [[ "$FILE_PATH" == */src/usecases/* ]]
+}
+
+if is_entity_file; then
+  if echo "$TEXT_TO_CHECK" | grep -qE "from\s*['\"][^'\"]*@/interface-adapters/|from\s*['\"][^'\"]*[./]interface-adapters/"; then
+    echo "Dependency Rule violation in $FILE_PATH: entities/ must not import from interface-adapters/. Inner layers are framework-agnostic." >&2
+    exit 2
+  fi
+  if echo "$TEXT_TO_CHECK" | grep -qE "from\s*['\"][^'\"]*@/usecases/|from\s*['\"][^'\"]*[./]usecases/"; then
+    echo "Dependency Rule violation in $FILE_PATH: entities/ must not import from usecases/. Dependencies point inward only." >&2
+    exit 2
+  fi
+  if echo "$TEXT_TO_CHECK" | grep -qE "from\s*['\"][^'\"]*@/frameworks/|from\s*['\"][^'\"]*[./]frameworks/"; then
+    echo "Dependency Rule violation in $FILE_PATH: entities/ must not import from frameworks/. Inner layers are framework-agnostic." >&2
+    exit 2
+  fi
+fi
+
+if is_usecase_file; then
+  if echo "$TEXT_TO_CHECK" | grep -qE "from\s*['\"][^'\"]*@/interface-adapters/|from\s*['\"][^'\"]*[./]interface-adapters/"; then
+    echo "Dependency Rule violation in $FILE_PATH: usecases/ must not import from interface-adapters/. Depend on gateway contracts (under entities/), not implementations." >&2
+    exit 2
+  fi
+  if echo "$TEXT_TO_CHECK" | grep -qE "from\s*['\"][^'\"]*@/frameworks/|from\s*['\"][^'\"]*[./]frameworks/"; then
+    echo "Dependency Rule violation in $FILE_PATH: usecases/ must not import from frameworks/. Depend on gateway contracts (under entities/), not infrastructure." >&2
+    exit 2
+  fi
+fi
+
+exit 0

--- a/scripts/hooks/enforce-gateway-port-purity.sh
+++ b/scripts/hooks/enforce-gateway-port-purity.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Enforces gateway port purity for ReviewFlow.
+# Gateway contracts live in src/entities/**/*.gateway.ts and must be interfaces or abstract classes.
+# A plain 'export class' in a port file means the contract has leaked an implementation.
+# Implementation gateway files (in interface-adapters/gateways/) are excluded.
+# Used as PreToolUse hook on Write|Edit.
+# Exit 0 = allow, Exit 2 = block with feedback to Claude.
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | "$HOOK_DIR/parse-json.sh" tool_input.file_path)
+
+is_gateway_port() {
+  local filename
+  filename=$(basename "$FILE_PATH")
+  [[ "$FILE_PATH" == */src/entities/* ]] \
+    && [[ "$filename" == *.gateway.ts ]]
+}
+
+if ! is_gateway_port; then
+  exit 0
+fi
+
+CONTENT=$(echo "$INPUT" | "$HOOK_DIR/parse-json.sh" tool_input.content)
+NEW_STRING=$(echo "$INPUT" | "$HOOK_DIR/parse-json.sh" tool_input.new_string)
+TEXT_TO_CHECK="${CONTENT}${NEW_STRING}"
+
+if echo "$TEXT_TO_CHECK" | grep -qE "^\s*export\s+class\s+"; then
+  echo "Gateway port violation in $FILE_PATH: port files in entities/ must use 'interface' or 'abstract class'. A plain 'export class' belongs in interface-adapters/gateways/, not in the entities layer." >&2
+  exit 2
+fi
+
+exit 0

--- a/scripts/hooks/enforce-presenter-class.sh
+++ b/scripts/hooks/enforce-presenter-class.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Enforces that presenter files export a class named *Presenter or *Calculator.
+# Applies to *.presenter.ts files under src/interface-adapters/presenters/.
+# Functions or plain objects are not allowed — presenters must be classes for testability.
+# Used as PreToolUse hook on Write (full file content only).
+# Exit 0 = allow, Exit 2 = block with feedback to Claude.
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | "$HOOK_DIR/parse-json.sh" tool_input.file_path)
+
+is_presenter_file() {
+  [[ "$FILE_PATH" == *.presenter.ts ]] \
+    && [[ "$FILE_PATH" == */interface-adapters/presenters/* ]]
+}
+
+if ! is_presenter_file; then
+  exit 0
+fi
+
+CONTENT=$(echo "$INPUT" | "$HOOK_DIR/parse-json.sh" tool_input.content)
+
+if [[ -z "$CONTENT" ]]; then
+  exit 0
+fi
+
+if ! echo "$CONTENT" | grep -qE "class\s+\w*(Presenter|Calculator)\b"; then
+  echo "Presenter convention violation in $FILE_PATH: .presenter.ts files must export a class ending with 'Presenter' (or 'Calculator' for pure computation presenters). Export a function is not allowed." >&2
+  exit 2
+fi
+
+exit 0

--- a/scripts/hooks/tests/test-architecture-hooks.sh
+++ b/scripts/hooks/tests/test-architecture-hooks.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tests for the 3 Clean Architecture enforcement hooks.
+# Run: bash scripts/hooks/tests/test-architecture-hooks.sh
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASSED=0
+FAILED=0
+TOTAL=0
+
+green() { printf "\033[32m%s\033[0m\n" "$1"; }
+red()   { printf "\033[31m%s\033[0m\n" "$1"; }
+bold()  { printf "\033[1m%s\033[0m\n" "$1"; }
+
+assert_exit() {
+  local name="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$actual" -eq "$expected" ]]; then
+    green "  PASS: $name (exit $actual)"
+    PASSED=$((PASSED + 1))
+  else
+    red "  FAIL: $name (expected exit $expected, got $actual)"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+payload() {
+  python3 -c "
+import json, sys
+print(json.dumps({'tool_input': {'file_path': sys.argv[1], 'content': sys.argv[2], 'new_string': ''}}))
+" "$1" "$2"
+}
+
+# ─────────────────────────────────────────────────────────────
+bold "=== enforce-dependency-rule.sh ==="
+
+# Entity importing interface-adapters → blocked
+EXIT=$(payload "/project/src/entities/foo/foo.gateway.ts" \
+  "import type { Bar } from '@/interface-adapters/gateways/bar.js'" \
+  | "$HOOK_DIR/enforce-dependency-rule.sh" > /dev/null 2>&1; echo $?) || true
+assert_exit "entity cannot import interface-adapters" 2 "$EXIT"
+
+# Entity importing usecases → blocked
+EXIT=$(payload "/project/src/entities/foo/foo.ts" \
+  "import type { Usecase } from '@/usecases/something.usecase.js'" \
+  | "$HOOK_DIR/enforce-dependency-rule.sh" > /dev/null 2>&1; echo $?) || true
+assert_exit "entity cannot import usecases" 2 "$EXIT"
+
+# Entity importing frameworks → blocked
+EXIT=$(payload "/project/src/entities/foo/foo.ts" \
+  "import type { Queue } from '@/frameworks/queue/pQueueAdapter.js'" \
+  | "$HOOK_DIR/enforce-dependency-rule.sh" > /dev/null 2>&1; echo $?) || true
+assert_exit "entity cannot import frameworks" 2 "$EXIT"
+
+# Entity importing within entities → allowed
+EXIT=$(payload "/project/src/entities/foo/foo.ts" \
+  "import type { Bar } from '@/entities/bar/bar.js'" \
+  | "$HOOK_DIR/enforce-dependency-rule.sh" > /dev/null 2>&1; echo $?) || true
+assert_exit "entity can import other entities" 0 "$EXIT"
+
+# Usecase importing interface-adapters → blocked
+EXIT=$(payload "/project/src/usecases/doSomething.usecase.ts" \
+  "import type { SomeGateway } from '@/interface-adapters/gateways/some.gateway.js'" \
+  | "$HOOK_DIR/enforce-dependency-rule.sh" > /dev/null 2>&1; echo $?) || true
+assert_exit "usecase cannot import interface-adapters" 2 "$EXIT"
+
+# Usecase importing frameworks → blocked
+EXIT=$(payload "/project/src/usecases/doSomething.usecase.ts" \
+  "import type { ReviewJob } from '@/frameworks/queue/pQueueAdapter.js'" \
+  | "$HOOK_DIR/enforce-dependency-rule.sh" > /dev/null 2>&1; echo $?) || true
+assert_exit "usecase cannot import frameworks" 2 "$EXIT"
+
+# Usecase importing entities (valid) → allowed
+EXIT=$(payload "/project/src/usecases/doSomething.usecase.ts" \
+  "import type { ReviewContextGateway } from '@/entities/reviewContext/reviewContext.gateway.js'" \
+  | "$HOOK_DIR/enforce-dependency-rule.sh" > /dev/null 2>&1; echo $?) || true
+assert_exit "usecase can import entities" 0 "$EXIT"
+
+# File outside src/ → always allowed
+EXIT=$(payload "/project/scripts/build.ts" \
+  "import type { Foo } from '@/interface-adapters/gateways/foo.js'" \
+  | "$HOOK_DIR/enforce-dependency-rule.sh" > /dev/null 2>&1; echo $?) || true
+assert_exit "non-src file always allowed" 0 "$EXIT"
+
+# ─────────────────────────────────────────────────────────────
+bold "=== enforce-gateway-port-purity.sh ==="
+
+# Entity gateway with interface → allowed
+EXIT=$(payload "/project/src/entities/review/reviewContext.gateway.ts" \
+  "export interface ReviewContextGateway { create(): void }" \
+  | "$HOOK_DIR/enforce-gateway-port-purity.sh" > /dev/null 2>&1; echo $?) || true
+assert_exit "entity gateway with interface is allowed" 0 "$EXIT"
+
+# Entity gateway with abstract class → allowed
+EXIT=$(payload "/project/src/entities/review/reviewContext.gateway.ts" \
+  "export abstract class ReviewContextGateway { abstract create(): void }" \
+  | "$HOOK_DIR/enforce-gateway-port-purity.sh" > /dev/null 2>&1; echo $?) || true
+assert_exit "entity gateway with abstract class is allowed" 0 "$EXIT"
+
+# Entity gateway with plain class → blocked
+EXIT=$(payload "/project/src/entities/review/reviewContext.gateway.ts" \
+  "export class ReviewContextGateway { create(): void {} }" \
+  | "$HOOK_DIR/enforce-gateway-port-purity.sh" > /dev/null 2>&1; echo $?) || true
+assert_exit "entity gateway with plain class is blocked" 2 "$EXIT"
+
+# Implementation in interface-adapters with plain class → allowed (not in entities/)
+EXIT=$(payload "/project/src/interface-adapters/gateways/reviewContext.fileSystem.gateway.ts" \
+  "export class ReviewContextFileSystemGateway implements ReviewContextGateway {}" \
+  | "$HOOK_DIR/enforce-gateway-port-purity.sh" > /dev/null 2>&1; echo $?) || true
+assert_exit "gateway impl in interface-adapters with plain class is allowed" 0 "$EXIT"
+
+# Non-gateway entity file → not checked
+EXIT=$(payload "/project/src/entities/review/reviewContext.ts" \
+  "export class ReviewContext { private constructor() {} }" \
+  | "$HOOK_DIR/enforce-gateway-port-purity.sh" > /dev/null 2>&1; echo $?) || true
+assert_exit "non-gateway entity file not checked" 0 "$EXIT"
+
+# ─────────────────────────────────────────────────────────────
+bold "=== enforce-presenter-class.sh ==="
+
+# Presenter with class ending in Presenter → allowed
+EXIT=$(payload "/project/src/interface-adapters/presenters/jobStatus.presenter.ts" \
+  "export class JobStatusPresenter { present(input: unknown) { return {} } }" \
+  | "$HOOK_DIR/enforce-presenter-class.sh" > /dev/null 2>&1; echo $?) || true
+assert_exit "presenter class *Presenter is allowed" 0 "$EXIT"
+
+# Presenter with class ending in Calculator → allowed
+EXIT=$(payload "/project/src/interface-adapters/presenters/score.presenter.ts" \
+  "export class ScoreCalculator { compute(input: unknown) { return 0 } }" \
+  | "$HOOK_DIR/enforce-presenter-class.sh" > /dev/null 2>&1; echo $?) || true
+assert_exit "presenter class *Calculator is allowed" 0 "$EXIT"
+
+# Presenter with function export → blocked
+EXIT=$(payload "/project/src/interface-adapters/presenters/jobStatus.presenter.ts" \
+  "export function presentJobStatus(input: unknown) { return {} }" \
+  | "$HOOK_DIR/enforce-presenter-class.sh" > /dev/null 2>&1; echo $?) || true
+assert_exit "presenter function export is blocked" 2 "$EXIT"
+
+# Non-presenter .ts file → not checked
+EXIT=$(payload "/project/src/interface-adapters/controllers/webhook.controller.ts" \
+  "export function handleWebhook() {}" \
+  | "$HOOK_DIR/enforce-presenter-class.sh" > /dev/null 2>&1; echo $?) || true
+assert_exit "non-presenter file not checked" 0 "$EXIT"
+
+# presenter.ts outside interface-adapters/presenters/ → not checked
+EXIT=$(payload "/project/src/entities/foo/foo.presenter.ts" \
+  "export function fooPresenter() {}" \
+  | "$HOOK_DIR/enforce-presenter-class.sh" > /dev/null 2>&1; echo $?) || true
+assert_exit "presenter outside interface-adapters/presenters/ not checked" 0 "$EXIT"
+
+# ─────────────────────────────────────────────────────────────
+echo ""
+bold "=== RESULTS ==="
+echo "Total: $TOTAL | Passed: $PASSED | Failed: $FAILED"
+
+if [[ "$FAILED" -gt 0 ]]; then
+  red "SOME TESTS FAILED"
+  exit 1
+else
+  green "ALL TESTS PASSED"
+  exit 0
+fi

--- a/src/tests/acceptance/dashboardModulesCoverage.acceptance.test.ts
+++ b/src/tests/acceptance/dashboardModulesCoverage.acceptance.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const MODULES_DIR = resolve(
+  process.cwd(),
+  'src/interface-adapters/views/dashboard/modules'
+);
+
+const TESTS_DIR = resolve(
+  process.cwd(),
+  'src/tests/units/interface-adapters/views/dashboard/modules'
+);
+
+function listJsModules(): string[] {
+  if (!existsSync(MODULES_DIR)) {
+    return [];
+  }
+  return readdirSync(MODULES_DIR)
+    .filter((file) => file.endsWith('.js'))
+    .map((file) => file.replace(/\.js$/, ''));
+}
+
+function listTestFiles(): string[] {
+  if (!existsSync(TESTS_DIR)) {
+    return [];
+  }
+  return readdirSync(TESTS_DIR)
+    .filter((file) => file.endsWith('.test.ts'))
+    .map((file) => file.replace(/\.test\.ts$/, ''));
+}
+
+describe('Acceptance — Spec #51: dashboard modules coverage', () => {
+  // Outer-loop SDD acceptance test. Stays skipped until spec-051 implementation
+  // closes the gap (6 uncovered modules: cleanup, collapsibleList, mrSheet,
+  // sharedViewHelpers, statsCharts, versionUpdate). Remove `.skip` when
+  // implementing the spec and let it turn GREEN.
+  it.skip('every dashboard module has a corresponding test file', () => {
+    const modules = listJsModules();
+    const tests = listTestFiles();
+
+    expect(modules.length).toBeGreaterThan(0);
+
+    const uncovered = modules.filter((module) => !tests.includes(module));
+
+    expect(uncovered, `Modules sans test: ${uncovered.join(', ')}`).toEqual([]);
+  });
+
+  it.skip('every test file targets an existing dashboard module', () => {
+    const modules = listJsModules();
+    const tests = listTestFiles();
+
+    const orphans = tests.filter((test) => !modules.includes(test));
+
+    expect(orphans, `Tests orphelins: ${orphans.join(', ')}`).toEqual([]);
+  });
+
+  it('dashboard modules directory exists', () => {
+    expect(
+      existsSync(MODULES_DIR),
+      'Aucun module dashboard détecté'
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Two-commit branch bringing the project to Shiplens parity: harness/SDD pipeline (already on branch) + backlog reorganization (this PR's main addition).

### Commits

- **c0cb0e5** feat(harness): bring harness + SDD to Shiplens parity
- **118d220** chore(backlog): migrate features to specs-only + rewrite spec-051

### Backlog cleanup (commit 118d220)

GitHub action performed alongside this PR (closures already done):
- Closed 6 implemented refactors as `completed`: #72, #77, #79, #82, #83, #91
- Closed 3 abandoned refactors as `not planned`: #73, #80, #92
- Closed 12 feature issues, migrated to `docs/specs/`: #30, #32, #48, #50, #51, #55, #56, #57, #58, #59, #60, #61, #62
- Relabeled #46 from `enhancement` to `bug` — last open issue, P1-critical (next implementation target)

### New convention (CLAUDE.md)

| Backlog | Source of truth | Used for |
|---------|----------------|----------|
| Features | `docs/specs/` + `docs/feature-tracker.md` | New capabilities, enhancements, refactorings |
| Bugs | GitHub Issues | Reproducible defects only |

Workflow: `/product-manager` → spec → `/implement-feature` → report.

### Spec #51 rewrite

Original spec was outdated (referenced 13 modules, today 22). Rewritten in PM DSL format. Identifies the real gap: 6 dashboard modules without tests (`cleanup`, `collapsibleList`, `mrSheet`, `sharedViewHelpers`, `statsCharts`, `versionUpdate`).

### First acceptance test of the project

`src/tests/acceptance/dashboardModulesCoverage.acceptance.test.ts` — SDD outer loop scaffold for spec-051. Two assertions skipped pending implementation; passive third asserts modules dir exists. Removing `.skip` during spec-051 implementation will turn it RED → GREEN.

## Test plan

- [ ] `yarn verify` green locally
- [ ] CI green
- [ ] After merge, GitHub issue list shows only #46 (bug)
- [ ] `docs/feature-tracker.md` is the visible feature backlog
- [ ] Next: implement spec docs/specs/46-github-followup-review-on-push.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)