### PR TITLE
docs: add DDD event storming docs and event-storming skill

### DIFF
--- a/.claude/skills/event-storming/SKILL.md
+++ b/.claude/skills/event-storming/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: event-storming
+description: "Event Storming Big Picture on a bounded context or the whole project. Explores code to discover domain events, commands, entities, context boundaries, and produces structured markdown following Vaughn Vernon's strategic patterns. Usage: /event-storming <bc-name> or /event-storming global"
+---
+
+# Event Storming Big Picture
+
+Tu es un facilitateur Event Storming (Alberto Brandolini) specialise en DDD strategique pour ReviewFlow (Node.js, Fastify 5, Clean Architecture).
+
+Tu appliques les patterns strategiques de Vaughn Vernon (*Implementing Domain-Driven Design*) pour le Context Mapping.
+
+## Terminologie Clean Architecture
+
+Ce projet utilise la terminologie Clean Architecture, PAS DDD tactique.
+
+| Clean Architecture (ce projet) | DDD tactique (NE PAS utiliser) |
+|--------------------------------|-------------------------------|
+| Entity (`entities/`) | Aggregate, Domain Entity |
+| Use Case (`usecases/`) | Application Service, Command Handler |
+| Gateway contract (`entities/<domain>/<domain>.gateway.ts`) | Repository, Port |
+| Gateway impl (`interface-adapters/gateways/`) | Adapter, Repository Impl |
+| Controller (`interface-adapters/controllers/`) | Inbound Adapter |
+| Presenter (`interface-adapters/presenters/`) | Read Model Projection |
+| View (`interface-adapters/views/`) | UI Component |
+| Guard (`*.guard.ts`) | Specification, Validator |
+
+Dans les livrables Event Storming, mapper vers cette terminologie :
+- 🟨 **Entity** (pas "Aggregate") — `entities/<domain>/`
+- 🟦 **Use Case** (pas "Command Handler") — `usecases/*.usecase.ts`
+- 🟩 **Presenter** (pas "Read Model") — `interface-adapters/presenters/*.presenter.ts`
+- ⬜ **Gateway** (pas "Repository") — `entities/*/*.gateway.ts` + `interface-adapters/gateways/*`
+
+## Coding Standards
+
+Lire `.claude/rules/coding-standards.md` AVANT de travailler.
+
+## Ubiquitous Language
+
+Lire `docs/reference/ubiquitous-language.md` — c'est la source de verite pour les termes du domaine.
+
+## Modes d'execution
+
+### Mode cible (par defaut)
+
+Input : `/event-storming <bc-name>` (ex: `review`, `tracking`, `insight`, `job`)
+Output : `docs/ddd/event-storming/<bc-name>.md` + mise a jour du document global
+
+### Mode audit global
+
+Input : `/event-storming global`
+Output : `docs/ddd/EVENT_STORMING_BIG_PICTURE.md` avec tous les BCs
+
+---
+
+## Phase 1 : EXPLORATION — Decouvrir le domaine dans le code
+
+ReviewFlow organise le code par **couches** (pas par modules). Les Bounded Contexts sont implicites, revelees par les repertoires dans `entities/`.
+
+1. **Identifier les fichiers sources** du BC cible :
+
+| Repertoire | Ce qu'il revele |
+|------------|-----------------|
+| `entities/<domain>/` | Entities, schemas, guards, gateway contracts, value objects |
+| `usecases/<domain>/` ou `usecases/*.usecase.ts` | Commands (Use Cases) |
+| `interface-adapters/controllers/webhook/` | Event handlers (webhook events → domain) |
+| `interface-adapters/controllers/http/` | HTTP API commands |
+| `interface-adapters/controllers/mcp/` | MCP tool commands |
+| `interface-adapters/gateways/` | External system integrations |
+| `interface-adapters/presenters/` | Read models / projections |
+| `interface-adapters/views/dashboard/` | UI (Humble Objects) |
+| `frameworks/` | Infrastructure (queue, logging, Claude invocation) |
+
+2. **Scanner les patterns revelateurs** :
+
+| Pattern fichier | Signification |
+|-----------------|---------------|
+| `*.usecase.ts` | Command / Use Case |
+| `*.guard.ts` | Business Rule / Policy |
+| `*.schema.ts` | Entity shape / validation |
+| `*.gateway.ts` dans `entities/` | Gateway contract (frontiere du BC) |
+| `*.gitlab.gateway.ts` / `*.github.gateway.ts` | Platform-specific gateway impl |
+| `*.cli.gateway.ts` | CLI-based external interaction |
+| `*.fileSystem.ts` / `*.memory.gateway.ts` | Persistence gateway impl |
+| `*.presenter.ts` | Read model projection |
+| `*.routes.ts` | HTTP endpoint → controller wiring |
+
+| Pattern code | Signification |
+|-------------|---------------|
+| `UseCase<Input, Output>` | Command |
+| `createGuard(schema, 'context')` | Business Rule |
+| `z.object({...})` (Zod schema) | Entity / Value Object shape |
+| `interface *Gateway` | Frontiere du BC (dependency inversion) |
+| imports `@/entities/<autre-domain>/` | Relation cross-BC |
+| imports `@/shared/` | Shared Kernel |
+| `app.post('/webhooks/...')` dans routes.ts | External Event entry point |
+| `PQueue` / queue patterns | Async processing |
+
+3. **Analyser les relations** avec les autres BCs :
+   - Quels gateway contracts sont definis vs implementes ?
+   - Quels types de `shared/` sont utilises ?
+   - Y a-t-il des imports directs vers `@/entities/<autre-domain>/` dans les use cases ?
+   - Comment les controllers orchestrent-ils plusieurs use cases ?
+
+## Phase 2 : MODELISATION — Structurer les decouvertes
+
+Organiser selon le schema de couleurs Event Storming (Alberto Brandolini) :
+
+| Couleur | Element | Source dans le code |
+|---------|---------|---------------------|
+| 🟧 Orange | **Domain Event** | Webhook events, state transitions, completion callbacks |
+| 🟦 Bleu | **Use Case (Command)** | `*.usecase.ts`, controller handlers |
+| 🟨 Jaune | **Entity** | `entities/`, schemas, types, value objects |
+| 🟪 Violet | **Policy / Business Rule** | Guards, validations, conditions dans usecases |
+| 🩷 Rose | **Hot Spot / Question** | Violations, incoherences, dette technique |
+| 🟩 Vert | **Presenter** | Presenters, view models |
+| ⬜ Blanc | **External System (Gateway)** | Gateway implementations, CLI calls, API calls |
+
+## Phase 3 : CONTEXT MAPPING — Patterns de Vaughn Vernon
+
+Pour chaque relation entre BCs, identifier le pattern applicable :
+
+| Pattern | Signal dans le code |
+|---------|---------------------|
+| **Partnership** | Modifications synchronisees entre 2 domaines |
+| **Shared Kernel** | Types dans `shared/` utilises par plusieurs domaines |
+| **Customer-Supplier** | Gateway interface dans le consumer, implementation fournie par le supplier |
+| **Conformist** | Import direct de types d'un autre domaine sans transformation |
+| **Anti-Corruption Layer** | Controller/Adapter qui transforme les donnees d'une plateforme (GitLab/GitHub → domain) |
+| **Open Host Service** | API HTTP/MCP exposee par le BC |
+| **Published Language** | Schemas Zod partages, webhook event formats |
+| **Separate Ways** | Aucun import croise |
+
+### ACL specifique a ReviewFlow
+
+Le pattern ACL est central dans ReviewFlow — les controllers webhook transforment les evenements GitLab/GitHub en concepts domaine :
+- `GitLab MergeRequest Event` → `ReviewRequest` (ACL dans gitlab.controller.ts)
+- `GitHub PullRequest Event` → `ReviewRequest` (ACL dans github.controller.ts)
+
+## Phase 4 : REDACTION
+
+Utiliser les templates dans `references/templates.md` pour produire les livrables.
+
+**Regles de redaction :**
+- Documents en **anglais** (documentation language du projet)
+- Noms au **passe** pour les Domain Events : `ReviewCompleted`, pas `CompleteReview`
+- Noms **imperatifs** pour les Commands : `TriggerReview`, pas `ReviewTriggered`
+- Toujours nommer le **pattern Vaughn Vernon** pour les relations, pas juste "depends on"
+- Toujours referencer le **fichier source exact**, pas un repertoire vague
+- Respecter le **ubiquitous language** defini dans `docs/reference/ubiquitous-language.md`
+
+## Phase 5 : ECRITURE LOCALE
+
+1. Creer `docs/ddd/event-storming/` si inexistant
+2. Ecrire le document par BC : `docs/ddd/event-storming/<bc-name>.md`
+3. Lire le document global existant (s'il existe)
+4. Mettre a jour le document global `docs/ddd/EVENT_STORMING_BIG_PICTURE.md` (enrichir, jamais ecraser)
+5. Afficher un resume des decouvertes cles
+
+## Phase 6 : PUBLICATION WIKI GITHUB
+
+Apres l'ecriture locale, publier sur le wiki GitHub pour une lecture confortable.
+
+### Structure wiki
+
+```
+Home.md                              ← Landing page with links
+_Sidebar.md                          ← Side navigation
+DDD-Event-Storming-Big-Picture.md    ← Global document
+DDD-Event-Storming-<BC-Name>.md      ← Per-BC document (PascalCase)
+```
+
+### Commandes
+
+```bash
+cd /tmp && rm -rf review-flow.wiki
+git clone "https://$(gh auth token)@github.com/DGouron/review-flow.wiki.git" review-flow.wiki
+cd review-flow.wiki
+
+# Copy/update pages
+# Enrich _Sidebar.md with new links
+# Enrich Home.md with new links in Navigation section
+
+git add -A && git commit -m "docs: update event storming — <bc-name>" && git push origin master
+```
+
+### Conventions
+
+- Nommage des pages : `DDD-Event-Storming-<BC-Name>` (PascalCase, tirets)
+- Toujours mettre a jour `_Sidebar.md` et la section Navigation de `Home.md`
+- Utiliser des diagrammes Mermaid (supportes nativement par GitHub wiki)
+- Ajouter des liens de navigation en bas de chaque page (← Big Picture / Home)
+
+## Contraintes
+
+- **Read-first** : toujours lire le code source, ne jamais inventer des events ou commands
+- **Incremental** : ne jamais ecraser le document global, toujours enrichir
+- **Hot Spots** : signaler les violations de frontiere, imports cross-domain, dette technique
+- **Ubiquitous Language** : toujours verifier contre `docs/reference/ubiquitous-language.md`
+- Ne PAS commiter le repo principal — laisser l'utilisateur decider via `/commit`

--- a/.claude/skills/event-storming/references/templates.md
+++ b/.claude/skills/event-storming/references/templates.md
@@ -1,0 +1,134 @@
+# Event Storming Templates
+
+## Per-BC document: `docs/ddd/event-storming/<bc-name>.md`
+
+```markdown
+# Event Storming — [BC Name]
+
+*Date: YYYY-MM-DD*
+*Scope: [description of the analyzed perimeter]*
+
+## Domain Events (🟧)
+
+| Event | Trigger | Source file |
+|-------|---------|-------------|
+| [Past tense: ReviewCompleted, ReviewRequested...] | [Command or system] | [path] |
+
+## Commands / Use Cases (🟦)
+
+| Command | Actor | Event produced | Source file |
+|---------|-------|----------------|-------------|
+| [Imperative: TriggerReview, CancelReview...] | [user/system/webhook] | [event] | [path] |
+
+## Entities (🟨)
+
+| Entity | Responsibility | Files |
+|--------|----------------|-------|
+| [Name] | [What it protects/encapsulates] | [paths] |
+
+## Policies and Business Rules (🟪)
+
+| Rule | Description | Source file |
+|------|-------------|-------------|
+| [Name] | [When and what] | [path] |
+
+## Presenters (🟩)
+
+| Presenter | Data exposed | File |
+|-----------|-------------|------|
+| [Name] | [What it projects] | [path] |
+
+## Gateways and External Systems (⬜)
+
+| System | Interaction | Gateway contract | Implementation |
+|--------|-------------|-----------------|----------------|
+| [GitLab API, GitHub API, CLI, filesystem...] | [What is exchanged] | [entities/.../path] | [interface-adapters/.../path] |
+
+## Relations with other Bounded Contexts
+
+| Related BC | Pattern (Vaughn Vernon) | Direction | Detail |
+|-----------|------------------------|-----------|--------|
+| [Name] | [Partnership/Customer-Supplier/ACL/...] | [→ ← ↔] | [Explanation] |
+
+## Ubiquitous Language
+
+| Term | Definition in this BC | Equivalent term in other BCs |
+|------|----------------------|------------------------------|
+| [Word] | [Precise meaning here] | [Different meaning elsewhere if applicable] |
+
+## Hot Spots (🩷)
+
+| Problem | Severity | Detail |
+|---------|----------|--------|
+| [Description] | 🔴/🟠/🟡 | [Explanation + affected files] |
+```
+
+## Global document: `docs/ddd/EVENT_STORMING_BIG_PICTURE.md`
+
+This document is **incremental** — each session enriches it without overwriting.
+
+```markdown
+# Event Storming Big Picture — ReviewFlow
+
+*Last update: YYYY-MM-DD*
+
+## Identified Bounded Contexts
+
+| BC | Sub-domains | Main entity | Analysis status |
+|----|-------------|-------------|-----------------|
+| [Name] | [List] | [Name] | ✅ Analyzed / ⏳ To do |
+
+## Context Map (Vaughn Vernon patterns)
+
+[Mermaid diagram of relations between BCs with named patterns]
+
+```mermaid
+graph LR
+    subgraph "Core Domain"
+        Review[Review]
+        ReviewRequest[ReviewRequest]
+        Tracking[Tracking]
+    end
+    subgraph "Supporting"
+        Insight[Insight]
+        Stats[Stats]
+        Job[Job]
+    end
+    subgraph "Generic"
+        GitLab[GitLab ACL]
+        GitHub[GitHub ACL]
+    end
+    GitLab -->|ACL| ReviewRequest
+    GitHub -->|ACL| ReviewRequest
+    ReviewRequest -->|Customer-Supplier| Review
+    Review -->|Partnership| Tracking
+    Tracking -->|Customer-Supplier| Stats
+    Stats -->|Customer-Supplier| Insight
+```
+
+## Shared Kernel
+
+| Shared element | BCs involved | Stability |
+|----------------|-------------|-----------|
+| [Type/Module] | [BC list] | 🟢 Stable / 🟡 Evolving / 🔴 Unstable |
+
+## Ubiquitous Language — Global Glossary
+
+| Term | Origin BC | Definition |
+|------|----------|------------|
+| [Word] | [BC] | [Definition] |
+
+*Full reference: `docs/reference/ubiquitous-language.md`*
+
+## Global Hot Spots
+
+| Problem | Impacted BCs | Severity |
+|---------|-------------|----------|
+| [Description] | [List] | 🔴/🟠/🟡 |
+
+## Session History
+
+| Date | BC analyzed | Key discoveries |
+|------|------------|-----------------|
+| YYYY-MM-DD | [Name] | [1-line summary] |
+```

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -120,6 +120,60 @@ it("should reject rating below 1", () => { ... })
 
 ---
 
+## Transformation Priority Premise (Robert C. Martin)
+
+The Transformation Priority Premise guides the RED → GREEN transition. When writing minimal code to pass a test, we apply **transformations** — and these transformations have a **natural priority order**.
+
+**Always choose the highest transformation in the list (the simplest).** Skipping steps often leads to suboptimal design.
+
+### Transformation list (simplest to most complex)
+
+| Priority | Transformation | Description | Example |
+|----------|---------------|-------------|---------|
+| 1 | `{} → nil` | No code → return null/undefined | `return undefined` |
+| 2 | `nil → constant` | Return a hardcoded value | `return []` |
+| 3 | `constant → variable` | Replace constant with parameter | `return items` instead of `return []` |
+| 4 | `unconditional → conditional` | Add a branch | `if (age < 18) return false` |
+| 5 | `scalar → collection` | Go from single value to array | `string → string[]` |
+| 6 | `statement → recursion/iteration` | Loop over the collection | `items.map(transform)` |
+| 7 | `value → mutated value` | Transform the accumulated value | `items.reduce(accumulate)` |
+
+### When to apply
+
+The TPP is a **guide**, not an absolute rule. It is particularly useful when:
+
+- Going GREEN seems to require "a lot of code at once" → sign that we're skipping transformations
+- We hesitate between implementations → choose the highest transformation
+- Working on **algorithmic logic** (parsers, calculations, data transformations, complex validations)
+
+Less relevant for simple orchestration code (call a gateway and return the result).
+
+### Concrete example — a presenter formatting tags
+
+```
+// RED: test "should return empty list when no tags"
+// GREEN via {} → constant:
+return [];
+
+// RED: test "should return formatted tag for single item"
+// GREEN via constant → variable:
+return [formatTag(tags[0])];
+
+// RED: test "should return formatted tags for multiple items"
+// GREEN via scalar → collection + iteration:
+return tags.map(formatTag);
+```
+
+If we had jumped directly to `map()` on the first test, it works — but we would have **guessed** the design instead of **discovering** it through tests.
+
+### Warning signal
+
+If during GREEN phase you end up writing more than 3-5 lines of code, you're probably skipping transformations. Options:
+1. Go back and add a simpler intermediate test
+2. Check which transformation you're applying in the list
+
+---
+
 ## Activation
 
 This skill activates whenever the user asks to touch code:

--- a/docs/architecture/multi-llm-analysis.md
+++ b/docs/architecture/multi-llm-analysis.md
@@ -1,0 +1,155 @@
+# Multi-LLM Support — Analysis
+
+> Architectural analysis of what would need to change to support multiple LLM providers (OpenAI, Copilot, Ollama, etc.) instead of Claude only.
+
+## Current State: Claude Coupling Points
+
+### 1. Direct CLI Invocation (Strong Coupling)
+
+| File | Coupling |
+|------|----------|
+| `src/frameworks/claude/claudeInvoker.ts` | `spawn()` of `claude` binary with specific flags (`--model`, `--append-system-prompt`, `--mcp-config`) |
+| `src/frameworks/claude/claudeInsightsInvoker.ts` | Same pattern for insights generation |
+| `src/shared/services/claudePathResolver.ts` | Hardcoded resolution of the `claude` binary path |
+
+### 2. Claude-Specific Prompt Format
+
+| File | Nature |
+|------|--------|
+| `claudeInvoker.ts:116-219` | System prompt injected via `--append-system-prompt` (Claude CLI format) |
+| `src/frameworks/claude/languageDirective.ts` | Language directive in Claude format |
+| `.claude/skills/*/SKILL.md` | Skills = markdown instructions read by Claude Code |
+
+### 3. Claude-Specific Response Parsing
+
+| File | Nature |
+|------|--------|
+| `src/frameworks/claude/progressParser.ts` | Regex on stdout to capture `[PROGRESS:...]`, `[PHASE:...]` |
+| `src/services/threadActionsParser.ts` | Text marker parsing `[THREAD_RESOLVE:...]`, `[POST_COMMENT:...]` |
+
+### 4. Model & Configuration
+
+| File | Nature |
+|------|--------|
+| `src/frameworks/settings/runtimeSettings.ts` | `ClaudeModel = 'sonnet' \| 'opus'` — closed type |
+| `src/interface-adapters/controllers/http/settings.routes.ts` | Endpoint `/api/settings/model` |
+
+### 5. MCP (Model Context Protocol)
+
+The MCP server (`src/mcpServer.ts`) is a protocol **specific to Claude Code**. Other LLMs have no native equivalent.
+
+---
+
+## What Would Need to Change
+
+### Step 1 — LLM Gateway Contract (Entity Layer)
+
+Create a provider-agnostic interface in the domain layer:
+
+```
+src/entities/llm/
+├── llm.gateway.ts              # Interface: invokeReview(), invokeInsights()
+├── llmInvocationResult.ts      # Standardized return type
+└── llmProvider.ts              # Type: 'claude' | 'copilot' | 'openai' | ...
+```
+
+```typescript
+interface LLMGateway {
+  invokeReview(job: ReviewJob, options: InvocationOptions): Promise<LLMInvocationResult>;
+  invokeInsights(prompt: string, language: Language): Promise<string>;
+}
+```
+
+### Step 2 — Provider Implementations (Interface Adapters)
+
+```
+src/interface-adapters/gateways/llm/
+├── llm.claude.gateway.ts       # Wraps current claudeInvoker (CLI spawn)
+├── llm.copilot.gateway.ts      # GitHub Copilot API
+└── llm.openai.gateway.ts       # OpenAI API
+```
+
+Each implementation handles its own specifics:
+- **Claude**: CLI spawn + skills + MCP + text markers
+- **Copilot/OpenAI**: HTTP API calls + structured JSON output
+- **Ollama**: Local API
+
+### Step 3 — Prompt Abstraction
+
+Today, prompts are **Claude Code skills** (`.claude/skills/`). For other LLMs:
+
+- Extract **review logic** from skills into provider-agnostic templates
+- Each provider adapts the template to its format (system prompt, function calling, etc.)
+- MCP should be replaced by a generic reporting mechanism for non-Claude providers
+
+### Step 4 — Response Parsing Abstraction
+
+```
+src/interface-adapters/adapters/
+├── responseParser.claude.ts     # Regex [PROGRESS:...], [THREAD_RESOLVE:...]
+├── responseParser.openai.ts     # Parse structured JSON output
+└── responseParser.ts            # Common interface
+```
+
+### Step 5 — Extended Configuration
+
+```typescript
+// Before
+type ClaudeModel = 'sonnet' | 'opus';
+
+// After
+type LLMProvider = 'claude' | 'copilot' | 'openai' | 'ollama';
+type ModelConfig = {
+  provider: LLMProvider;
+  model: string;          // 'opus', 'gpt-4o', 'copilot-chat', etc.
+  apiKey?: string;         // For API-based providers
+  baseUrl?: string;        // For Ollama/self-hosted
+};
+```
+
+### Step 6 — Composition Root
+
+`src/main/routes.ts` would instantiate the right gateway based on config:
+
+```typescript
+const llmGateway = createLLMGateway(config.llm); // factory pattern
+```
+
+---
+
+## Difficulty Assessment
+
+| Aspect | Difficulty | Reason |
+|--------|-----------|--------|
+| Gateway interface | Low | Pattern already mastered in the project |
+| Wrap existing Claude code | Low | Move current code behind the interface |
+| Integrate an API-based LLM (OpenAI) | Medium | Standard HTTP calls, structured output |
+| Integrate Copilot specifically | **High** | Copilot has no public review API — it's an IDE product, not a standalone API |
+| Adapt prompts/skills | **High** | The skill system relies entirely on Claude Code |
+| Replace MCP | **High** | Claude-specific protocol, no universal equivalent |
+| Equivalent review quality | **Unknown** | Skills are optimized for Claude; results with other LLMs will differ |
+
+---
+
+## Key Architectural Insight
+
+The real blocker is not the code — it's the **interaction model**.
+
+Claude Code works in **autonomous agent mode** with filesystem + CLI access via `spawn`. Other LLMs work in **API request/response mode**. These are fundamentally different paradigms. Plugging in GPT-4o or Copilot is not swapping a driver — it means rethinking how the LLM interacts with the code under review.
+
+### What Already Works Well
+
+The Clean Architecture is already in place for GitLab/GitHub via the Gateway Pattern. The entities, use cases, and most interface adapters are **LLM-agnostic**. The coupling is concentrated in `src/frameworks/claude/` — which is exactly where the frameworks layer should contain infrastructure concerns.
+
+### The Gap
+
+Claude was treated as **fixed infrastructure** rather than an **interchangeable external service**. The gateway abstraction pattern used for GitLab/GitHub was not applied to the LLM layer.
+
+---
+
+## Open Questions
+
+1. **What does "Copilot" mean here?** Copilot has no public code review API. It's an IDE product. Are we talking about using the underlying model (GPT-4o) via OpenAI API instead?
+2. **How to handle the skill system?** Skills are deeply tied to Claude Code's agent execution model. Other LLMs would need a completely different prompting strategy.
+3. **Is MCP support needed for non-Claude providers?** MCP provides real-time progress tracking. Alternative providers would need a different mechanism (webhooks, polling, structured output).
+4. **Quality parity**: The review skills have been fine-tuned for Claude. Switching LLMs will require prompt engineering per provider to maintain review quality.

--- a/docs/ddd/EVENT_STORMING_BIG_PICTURE.md
+++ b/docs/ddd/EVENT_STORMING_BIG_PICTURE.md
@@ -1,0 +1,205 @@
+# Event Storming Big Picture — ReviewFlow
+
+*Last update: 2026-03-22*
+
+## Identified Bounded Contexts
+
+| BC | Sub-domains | Main entity | Analysis status |
+|----|-------------|-------------|-----------------|
+| **Review Execution** | reviewRequest, reviewContext, reviewAction, review, progress, job | ReviewRequest | ✅ Analyzed |
+| **Tracking** | tracking | TrackedMr | ✅ Analyzed |
+| **Statistics & Insights** | stats, diffStats, backfill, insight | ProjectStats, DeveloperInsight | ✅ Analyzed |
+| **Platform Integration** | gitlab, github, diffMetadata, threadFetch | GitLabMergeRequestEvent, GitHubPullRequestEvent | ✅ Analyzed |
+| **CLI & Configuration** | packageVersion, mcpSettings, language | PackageVersion | ✅ Analyzed |
+| **Data Lifecycle** | cleanup | RetentionPolicy | ✅ Analyzed |
+
+### Domain Classification
+
+| Classification | Bounded Contexts | Rationale |
+|----------------|-----------------|-----------|
+| **Core Domain** | Review Execution, Tracking | Unique business value — AI-powered code review lifecycle |
+| **Supporting Domain** | Statistics & Insights, Data Lifecycle | Enhances core but could be replaced |
+| **Generic Domain** | Platform Integration, CLI & Configuration | Technical plumbing, no business differentiation |
+
+## Context Map (Vaughn Vernon patterns)
+
+```mermaid
+graph TB
+    subgraph "Generic Domain"
+        Platform["🔌 Platform Integration<br/><small>GitLab / GitHub ACL</small>"]
+        CLI["⌨️ CLI & Configuration<br/><small>Daemon, Config, Version</small>"]
+    end
+
+    subgraph "Core Domain"
+        Review["⭐ Review Execution<br/><small>ReviewRequest, ReviewContext,<br/>ReviewAction, Progress</small>"]
+        Tracking["📊 Tracking<br/><small>TrackedMr, ReviewEvent,<br/>State Machine</small>"]
+    end
+
+    subgraph "Supporting Domain"
+        Stats["📈 Statistics & Insights<br/><small>ProjectStats, DeveloperInsight,<br/>TeamInsight, AiInsight</small>"]
+        Cleanup["🧹 Data Lifecycle<br/><small>RetentionPolicy</small>"]
+    end
+
+    Platform -->|"ACL"| Review
+    Platform -->|"ACL"| Tracking
+    Review -->|"Customer-Supplier"| Tracking
+    Tracking -->|"Customer-Supplier"| Stats
+    Review -->|"Published Language"| Stats
+    Cleanup -->|"Conformist"| Review
+    CLI -.->|"Separate Ways"| Review
+    CLI -->|"Open Host Service<br/>(HTTP API)"| Tracking
+    Platform -->|"Customer-Supplier"| Stats
+
+    DiffStats["📦 DiffStats<br/><small>Shared Kernel</small>"]
+    DiffStats ---|"Shared Kernel"| Stats
+    DiffStats ---|"Shared Kernel"| Tracking
+```
+
+### Context Map — Relationship Details
+
+| Upstream BC | Downstream BC | Pattern | Detail |
+|-------------|---------------|---------|--------|
+| Platform Integration | Review Execution | **Anti-Corruption Layer** | Webhook controllers transform GitLab MergeRequest / GitHub PullRequest events into domain `ReviewRequest`. Creates `ReviewContext`, executes `ReviewAction` via platform CLI. |
+| Platform Integration | Tracking | **Anti-Corruption Layer** | Controllers call `TrackAssignment`, `RecordPush`, `TransitionState` with domain-transformed data. |
+| Review Execution | Tracking | **Customer-Supplier** | Review supplies completion data (score, duration, threads); Tracking consumes it as `ReviewEvent`. |
+| Tracking | Statistics & Insights | **Customer-Supplier** | Tracking provides `TrackedMr` data; Stats aggregates into `ProjectStats`. |
+| Review Execution | Statistics & Insights | **Published Language** | `ReviewScore` and review files consumed for analysis. |
+| Data Lifecycle | Review Execution | **Conformist** | Cleanup conforms to `ReviewFileGateway` contract owned by Review domain. |
+| Platform Integration | Statistics & Insights | **Customer-Supplier** | `DiffStatsFetchGateway` platform-specific implementations used by Stats backfill. |
+| CLI & Configuration | Review Execution | **Separate Ways** | CLI manages daemon lifecycle; review execution is independent once server runs. |
+| CLI & Configuration | Tracking | **Open Host Service** | `FollowupImportants` CLI command triggers followup via HTTP API. |
+| (shared) | Tracking ↔ Stats | **Shared Kernel** | `DiffStats` type from `entities/diffStats/` imported by both. |
+
+## Shared Kernel
+
+| Shared element | BCs involved | Stability |
+|----------------|-------------|-----------|
+| `DiffStats` type | Statistics & Insights, Tracking | 🟢 Stable — simple data structure (commits, additions, deletions) |
+| `Duration` value object | All BCs (via shared/) | 🟢 Stable — utility type with formatting |
+| `Language` enum | Review Execution, Statistics & Insights | 🟢 Stable — `'en' \| 'fr'` |
+| `ReviewFileGateway` contract | Review Execution, Data Lifecycle, Statistics & Insights | 🟡 Evolving — used by 3 BCs |
+
+## Event Flow — Main Scenarios
+
+### Scenario 1: Initial Review
+
+```mermaid
+sequenceDiagram
+    participant GL as GitLab/GitHub
+    participant ACL as Platform Integration (ACL)
+    participant RE as Review Execution
+    participant TR as Tracking
+    participant ST as Statistics
+
+    GL->>ACL: Webhook (reviewer assigned)
+    ACL->>ACL: Verify signature + validate payload
+    ACL->>TR: TrackAssignment(mrInfo, assignedBy)
+    ACL->>RE: TriggerReview(platform, projectPath, mrNumber)
+    RE->>RE: Check deduplication
+    RE->>RE: Enqueue ReviewJob
+    RE->>RE: Create ReviewContext (threads, diff metadata)
+    RE->>RE: Invoke Claude (MCP agents)
+    Note over RE: Claude uses MCP: StartAgent, CompleteAgent, SetPhase, AddAction
+    RE->>ACL: Execute ReviewActions (resolve, comment, label)
+    ACL->>GL: glab/gh CLI calls
+    RE->>TR: RecordReviewCompletion(score, duration, threads)
+    TR->>ST: (data available for recalculation)
+```
+
+### Scenario 2: Followup Review
+
+```mermaid
+sequenceDiagram
+    participant GL as GitLab/GitHub
+    participant ACL as Platform Integration (ACL)
+    participant TR as Tracking
+    participant RE as Review Execution
+
+    GL->>ACL: Webhook (push event)
+    ACL->>TR: RecordPush(projectPath, mrNumber)
+    ACL->>TR: CheckFollowupNeeded(projectPath, mrNumber)
+    TR-->>ACL: true (pending-fix + lastPushAt > lastReviewAt)
+    ACL->>RE: TriggerReview(jobType: followup)
+    RE->>RE: Enqueue followup ReviewJob
+    Note over RE: Uses review-followup skill, focuses on addressed issues
+    RE->>ACL: Execute ReviewActions
+    ACL->>GL: glab/gh CLI calls
+```
+
+### Scenario 3: Developer Insights
+
+```mermaid
+sequenceDiagram
+    participant UI as Dashboard
+    participant ST as Statistics & Insights
+    participant CL as Claude (AI)
+
+    UI->>ST: GetInsightsWithAiStatus(projectPath)
+    ST->>ST: Load ProjectStats
+    ST->>ST: ComputeDeveloperInsights (per-developer metrics)
+    ST->>ST: ComputeTeamInsights (team aggregation)
+    ST-->>UI: DeveloperInsight[], TeamInsight, aiStatus
+
+    UI->>ST: GenerateAiInsights(projectPath)
+    ST->>CL: Prompt with stats + review samples
+    CL-->>ST: AI narrative (strengths, weaknesses, recommendations)
+    ST->>ST: Persist AI insights
+    ST-->>UI: AiInsightsResult
+```
+
+## Ubiquitous Language — Global Glossary
+
+| Term | Origin BC | Definition |
+|------|----------|------------|
+| ReviewRequest | Review Execution | A request to review code changes; always used instead of MR/PR in domain code |
+| ReviewAction | Review Execution | Atomic executable action on a platform (resolve, comment, label) |
+| ReviewContext | Review Execution | Session state for one review run (threads, actions, agents, diff metadata) |
+| ReviewJob | Review Execution | Queued unit of work representing one review execution |
+| ReviewScore | Review Execution | Blocking + warnings + suggestions → severity level |
+| FollowupReview | Review Execution | Subsequent review after author pushes fixes |
+| Agent | Review Execution | Specialized Claude audit (clean-architecture, ddd, solid, testing, code-quality) |
+| TrackedMr | Tracking | Full lifecycle record of a MR/PR being tracked |
+| ReviewEvent | Tracking | Record of one review run with metrics |
+| ReviewRequestState | Tracking | State machine: pending-review → pending-fix → pending-approval → approved → merged/closed |
+| DeveloperInsight | Statistics & Insights | Computed performance profile: title, levels, strengths, trend |
+| TeamInsight | Statistics & Insights | Aggregated team performance with actionable tips |
+| AiInsight | Statistics & Insights | Claude-generated narrative analysis |
+| InsightCategory | Statistics & Insights | Performance dimension: quality, responsiveness, codeVolume, iteration |
+| DeveloperTitle | Statistics & Insights | Performance archetype: architect, firefighter, workhorse, sentinel, balanced |
+| DiffStats | Shared Kernel | Commit count, additions, deletions, changed files |
+| RetentionPolicy | Data Lifecycle | Rule for determining data expiration |
+| Thread | Platform Integration | Code comment discussion requiring resolution |
+
+*Full reference: `docs/reference/ubiquitous-language.md`*
+
+## Global Hot Spots
+
+| Problem | Impacted BCs | Severity | Detail |
+|---------|-------------|----------|--------|
+| Fat webhook controllers | Platform Integration, Review Execution, Tracking | 🔴 High | GitLab/GitHub controllers orchestrate 6+ use cases, handle context creation, Claude invocation, action execution, stats recording. 400+ lines with too many responsibilities. Should extract orchestration into a dedicated use case. |
+| Duplicated controller logic | Platform Integration | 🟠 Medium | GitLab and GitHub controllers share ~60% similar logic (context creation, action execution, stats recording) with no shared abstraction. |
+| TrackedMr vs ReviewRequest overlap | Tracking, Review Execution | 🟠 Medium | Both represent a MR/PR but with different shapes and lifecycles. Could lead to concept confusion. |
+| Strangler Fig incomplete | Review Execution | 🟡 Low | `reviewContextAction` re-exports from `reviewAction` with "will be removed" comment — migration started but not finished. |
+| Direct fs usage in CLI use cases | CLI & Configuration | 🟠 Medium | `writeInitConfig`, `validateConfig`, `addRepositories` use `fs` directly instead of gateway contracts — violates dependency rule. |
+| Claude invocation not abstracted | Review Execution, Statistics & Insights | 🟡 Low | Claude invoked via callback in controllers and use cases — no dedicated `ClaudeGateway` contract. |
+| No tracking/stats data cleanup | Data Lifecycle, Tracking, Statistics | 🟡 Low | Only review files have retention policy. TrackedMr and ProjectStats grow indefinitely. |
+| Large ReviewRequestTrackingGateway | Tracking | 🟡 Low | 12+ methods on a single gateway contract — may benefit from Interface Segregation. |
+| DiffStats cross-domain coupling | Tracking, Statistics | 🟡 Low | Shared type creates implicit coupling between two BCs. |
+| CLI tool dependency | Platform Integration | 🟠 Medium | All platform interactions depend on `glab`/`gh` CLI tools — no REST API fallback. |
+
+## Architecture Quality Metrics
+
+| Metric | Value | Assessment |
+|--------|-------|------------|
+| Cross-domain entity imports | 2 (both `DiffStats`) | 🟢 Excellent — minimal coupling |
+| Gateway contracts | 14 | 🟢 Good boundary definition |
+| Use cases | 37 | 🟢 Well-decomposed business logic |
+| Presenters | 5 | 🟢 Proper separation of concerns |
+| Value Objects | 4 (ReviewScore, Duration, RetentionPolicy, ReviewRequestState) | 🟢 Rich domain model |
+| Guards (Zod) | 9 | 🟢 Strong boundary validation |
+
+## Session History
+
+| Date | BC analyzed | Key discoveries |
+|------|------------|-----------------|
+| 2026-03-22 | All (global audit) | 6 BCs identified, 37 use cases, 14 gateway contracts. Main hot spot: fat webhook controllers. Architecture is clean with minimal cross-domain coupling (only DiffStats). Strangler Fig migration in progress on reviewContextAction. |

--- a/docs/ddd/event-storming/cli-configuration.md
+++ b/docs/ddd/event-storming/cli-configuration.md
@@ -1,0 +1,96 @@
+# Event Storming — CLI & Configuration
+
+*Date: 2026-03-22*
+*Scope: Daemon lifecycle, project configuration, MCP setup, versioning and self-update*
+
+## Domain Events (🟧)
+
+| Event | Trigger | Source file |
+|-------|---------|-------------|
+| DaemonStarted | CLI `start` command | `usecases/cli/startDaemon.usecase.ts` |
+| DaemonStopped | CLI `stop` command | `usecases/cli/stopDaemon.usecase.ts` |
+| DaemonAlreadyRunning | Start attempted while running | `usecases/cli/startDaemon.usecase.ts` |
+| ConfigWritten | `init` command completes | `usecases/cli/writeInitConfig.usecase.ts` |
+| ConfigValidated | Config check passes | `usecases/cli/validateConfig.usecase.ts` |
+| ConfigInvalid | Config check fails with issues | `usecases/cli/validateConfig.usecase.ts` |
+| RepositoriesAdded | New repos added to config | `usecases/cli/addRepositoriesToConfig.usecase.ts` |
+| RepositoriesDiscovered | Git repos found via filesystem scan | `usecases/cli/discoverRepositories.usecase.ts` |
+| McpConfigured | MCP server entry added to Claude settings | `usecases/cli/configureMcp.usecase.ts` |
+| VersionChecked | npm version check completed | `usecases/version/checkVersion.usecase.ts` |
+| UpdateAvailable | Newer version detected | `usecases/version/checkVersion.usecase.ts` |
+| SelfUpdateStarted | Global update command triggered | `usecases/version/triggerSelfUpdate.usecase.ts` |
+| FollowupImportantsTriggered | CLI triggers followup for important MRs | `usecases/cli/followupImportants.usecase.ts` |
+
+## Commands / Use Cases (🟦)
+
+| Command | Actor | Event produced | Source file |
+|---------|-------|----------------|-------------|
+| StartDaemon | User (CLI) | DaemonStarted, DaemonAlreadyRunning | `usecases/cli/startDaemon.usecase.ts` |
+| StopDaemon | User (CLI) | DaemonStopped | `usecases/cli/stopDaemon.usecase.ts` |
+| QueryStatus | User (CLI) | — (query) | `usecases/cli/queryStatus.usecase.ts` |
+| ReadLogs | User (CLI) | — (query/stream) | `usecases/cli/readLogs.usecase.ts` |
+| WriteInitConfig | User (CLI `init`) | ConfigWritten | `usecases/cli/writeInitConfig.usecase.ts` |
+| ValidateConfig | User (CLI) | ConfigValidated, ConfigInvalid | `usecases/cli/validateConfig.usecase.ts` |
+| AddRepositoriesToConfig | User (CLI) | RepositoriesAdded | `usecases/cli/addRepositoriesToConfig.usecase.ts` |
+| DiscoverRepositories | User (CLI) | RepositoriesDiscovered | `usecases/cli/discoverRepositories.usecase.ts` |
+| ConfigureMcp | User (CLI) | McpConfigured | `usecases/cli/configureMcp.usecase.ts` |
+| CheckVersion | System (startup) | VersionChecked, UpdateAvailable | `usecases/version/checkVersion.usecase.ts` |
+| TriggerSelfUpdate | User (CLI/dashboard) | SelfUpdateStarted | `usecases/version/triggerSelfUpdate.usecase.ts` |
+| FollowupImportants | User (CLI) | FollowupImportantsTriggered | `usecases/cli/followupImportants.usecase.ts` |
+
+## Entities (🟨)
+
+| Entity | Responsibility | Files |
+|--------|----------------|-------|
+| PackageVersion | npm version check result and current version info | `entities/packageVersion/packageVersion.ts`, `packageVersion.schema.ts`, `packageVersion.guard.ts` |
+| McpSettings | MCP server configuration in Claude settings | `entities/mcpSettings/mcpSettings.schema.ts`, `mcpSettings.guard.ts` |
+| Language | UI language enum (en/fr) | `entities/language/language.schema.ts` |
+
+## Policies and Business Rules (🟪)
+
+| Rule | Description | Source file |
+|------|-------------|-------------|
+| PID file management | Daemon uses PID file to detect if already running | `usecases/cli/startDaemon.usecase.ts` |
+| Version cache expiration | Version check result cached to avoid repeated npm calls | `entities/packageVersion/versionCache.gateway.ts` |
+| Platform detection | Repository platform (GitLab/GitHub) detected from git remote URL | `usecases/cli/discoverRepositories.usecase.ts` |
+| MCP server path resolution | Resolves absolute path to `dist/mcpServer.js` for Claude settings | `usecases/cli/configureMcp.usecase.ts` |
+| Config validation rules | Validates server, user, queue, repositories sections + .env file | `usecases/cli/validateConfig.usecase.ts` |
+
+## Presenters (🟩)
+
+*No dedicated presenters — CLI output handled directly by CLI adapters.*
+
+## Gateways and External Systems (⬜)
+
+| System | Interaction | Gateway contract | Implementation |
+|--------|-------------|-----------------|----------------|
+| File System | PID file read/write | (inline in use cases) | `shared/services/pidFileManager.js` |
+| File System | Config file read/write | (inline in use cases) | Direct `fs` usage |
+| npm registry | Fetch latest package version | `entities/packageVersion/packageVersion.gateway.ts` | `interface-adapters/gateways/packageVersion.npm.gateway.ts` |
+| Shell | Execute `npm install -g` | `entities/packageVersion/selfUpdateCommand.gateway.ts` | `interface-adapters/gateways/selfUpdate.cli.gateway.ts` |
+| In-memory | Cache version check result | `entities/packageVersion/versionCache.gateway.ts` | `interface-adapters/gateways/versionCache.memory.gateway.ts` |
+| Claude settings | Read/write `~/.claude/settings.json` | (inline in use case) | Direct file manipulation |
+| HTTP | Trigger followup via server API | (inline in use case) | Direct `fetch()` call |
+
+## Relations with other Bounded Contexts
+
+| Related BC | Pattern (Vaughn Vernon) | Direction | Detail |
+|-----------|------------------------|-----------|--------|
+| Review Execution | Separate Ways | — | CLI manages daemon lifecycle; review execution happens independently once server is running |
+| Tracking | Open Host Service | CLI → Tracking | FollowupImportants triggers review via HTTP API endpoint |
+
+## Ubiquitous Language
+
+| Term | Definition in this BC | Equivalent term in other BCs |
+|------|----------------------|------------------------------|
+| Daemon | Background server process managed by CLI | Server in Review Execution |
+| Config | JSON configuration file for ReviewFlow | — |
+| Repository | Configured git repo with platform info | — |
+
+## Hot Spots (🩷)
+
+| Problem | Severity | Detail |
+|---------|----------|--------|
+| Direct `fs` usage in use cases | 🟠 | Several CLI use cases (writeInitConfig, validateConfig, addRepositories) use `fs` directly instead of through gateway contracts — violates dependency rule |
+| FollowupImportants via HTTP | 🟡 | CLI command triggers followup via HTTP fetch to own server — indirect coupling, assumes server is running |
+| No gateway for Claude settings | 🟡 | ConfigureMcp reads/writes `~/.claude/settings.json` directly — no abstraction for Claude settings management |

--- a/docs/ddd/event-storming/data-lifecycle.md
+++ b/docs/ddd/event-storming/data-lifecycle.md
@@ -1,0 +1,62 @@
+# Event Storming — Data Lifecycle
+
+*Date: 2026-03-22*
+*Scope: Cleanup of expired reviews, log files, and data retention policies*
+
+## Domain Events (🟧)
+
+| Event | Trigger | Source file |
+|-------|---------|-------------|
+| ReviewsExpired | Cleanup use case identifies expired reviews | `usecases/cleanup/cleanupExpiredReviews.usecase.ts` |
+| ReviewFileDeleted | Individual review file removed | `usecases/cleanup/cleanupExpiredReviews.usecase.ts` |
+| LogFileDeleted | Individual log file removed | `usecases/cleanup/cleanupExpiredReviews.usecase.ts` |
+
+## Commands / Use Cases (🟦)
+
+| Command | Actor | Event produced | Source file |
+|---------|-------|----------------|-------------|
+| CleanupExpiredReviews | User (API/scheduled) | ReviewsExpired | `usecases/cleanup/cleanupExpiredReviews.usecase.ts` |
+
+## Entities (🟨)
+
+| Entity | Responsibility | Files |
+|--------|----------------|-------|
+| RetentionPolicy | Value object: determines if a review is expired based on retention days and current date | `entities/cleanup/retentionPolicy.valueObject.ts` |
+
+## Policies and Business Rules (🟪)
+
+| Rule | Description | Source file |
+|------|-------------|-------------|
+| Retention expiration | Review files older than `retentionDays` are eligible for deletion | `entities/cleanup/retentionPolicy.valueObject.ts` |
+| Dual cleanup | Both review files and associated log files are cleaned up together | `usecases/cleanup/cleanupExpiredReviews.usecase.ts` |
+
+## Presenters (🟩)
+
+*No dedicated presenters.*
+
+## Gateways and External Systems (⬜)
+
+| System | Interaction | Gateway contract | Implementation |
+|--------|-------------|-----------------|----------------|
+| File System | List and delete review files | `entities/review/reviewFile.gateway.ts` | `interface-adapters/gateways/reviewFile.gateway.ts` |
+| File System | List and delete log files | `ReviewLogFileGateway` | `interface-adapters/gateways/reviewLogFile.gateway.ts` |
+
+## Relations with other Bounded Contexts
+
+| Related BC | Pattern (Vaughn Vernon) | Direction | Detail |
+|-----------|------------------------|-----------|--------|
+| Review Execution | Conformist | Cleanup → Review | Cleanup conforms to ReviewFileGateway contract owned by Review Execution domain |
+
+## Ubiquitous Language
+
+| Term | Definition in this BC | Equivalent term in other BCs |
+|------|----------------------|------------------------------|
+| RetentionPolicy | Rule for determining data expiration | — |
+| Cleanup | Process of removing expired data | — |
+
+## Hot Spots (🩷)
+
+| Problem | Severity | Detail |
+|---------|----------|--------|
+| No tracking data cleanup | 🟡 | Only review files and logs are cleaned up — tracking data (`TrackedMr`) has no retention policy and grows indefinitely |
+| No stats cleanup | 🟡 | ProjectStats are never pruned — historical stats accumulate without bound |

--- a/docs/ddd/event-storming/platform-integration.md
+++ b/docs/ddd/event-storming/platform-integration.md
@@ -1,0 +1,89 @@
+# Event Storming — Platform Integration
+
+*Date: 2026-03-22*
+*Scope: Anti-Corruption Layer — GitLab and GitHub webhook handling, platform API interactions*
+
+## Domain Events (🟧)
+
+| Event | Trigger | Source file |
+|-------|---------|-------------|
+| WebhookReceived | HTTP POST from GitLab/GitHub | `interface-adapters/controllers/webhook/gitlab.controller.ts`, `github.controller.ts` |
+| ReviewerAssigned | GitLab MR reviewer added | `interface-adapters/controllers/webhook/eventFilter.ts` (`filterGitLabEvent`) |
+| ReviewRequestedByLabel | GitHub PR `needs-review` label added | `interface-adapters/controllers/webhook/eventFilter.ts` (`filterGitHubLabelEvent`) |
+| MrUpdated | New commits pushed to existing MR | `interface-adapters/controllers/webhook/eventFilter.ts` (`filterGitLabMrUpdate`) |
+| MrClosed | MR/PR closed without merge | `interface-adapters/controllers/webhook/eventFilter.ts` (`filterGitLabMrClose`, `filterGitHubPrClose`) |
+| MrMerged | MR merged into target branch | `interface-adapters/controllers/webhook/eventFilter.ts` (`filterGitLabMrMerge`) |
+| MrApproved | MR approved by reviewer | `interface-adapters/controllers/webhook/eventFilter.ts` (`filterGitLabMrApprove`) |
+| SignatureVerified | Webhook HMAC signature validated | `security/verifier.ts` |
+| SignatureRejected | Invalid webhook signature | `security/verifier.ts` |
+
+## Commands / Use Cases (🟦)
+
+| Command | Actor | Event produced | Source file |
+|---------|-------|----------------|-------------|
+| HandleGitLabWebhook | GitLab (webhook) | Multiple (dispatches to domain use cases) | `interface-adapters/controllers/webhook/gitlab.controller.ts` |
+| HandleGitHubWebhook | GitHub (webhook) | Multiple (dispatches to domain use cases) | `interface-adapters/controllers/webhook/github.controller.ts` |
+| VerifyWebhookSignature | System | SignatureVerified, SignatureRejected | `security/verifier.ts` |
+| FilterEvent | System | Determines which domain flow to trigger | `interface-adapters/controllers/webhook/eventFilter.ts` |
+
+## Entities (🟨)
+
+| Entity | Responsibility | Files |
+|--------|----------------|-------|
+| GitLabMergeRequestEvent | Validated GitLab webhook payload (Zod schema) | `entities/gitlab/gitlabMergeRequestEvent.guard.ts` |
+| GitHubPullRequestEvent | Validated GitHub webhook payload (Zod schema) | `entities/github/githubPullRequestEvent.guard.ts` |
+| DiffMetadata | Commit SHAs for inline comment positioning | `entities/diffMetadata/diffMetadata.gateway.ts` |
+
+## Policies and Business Rules (🟪)
+
+| Rule | Description | Source file |
+|------|-------------|-------------|
+| Event filtering | Only specific event combinations trigger reviews (reviewer assigned, label added, MR updated) | `interface-adapters/controllers/webhook/eventFilter.ts` |
+| Assignee extraction | Prefers MR assignee (`event.assignees[0]`) over webhook sender (`event.user`) | `interface-adapters/controllers/webhook/gitlab.controller.ts` |
+| Platform-specific thread format | GitLab uses REST API discussions, GitHub uses GraphQL review threads | `interface-adapters/gateways/threadFetch.gitlab.gateway.ts`, `threadFetch.github.gateway.ts` |
+| Inline comment positioning | Requires diff metadata (base/head SHA) for accurate code positioning | `interface-adapters/gateways/cli/reviewAction.gitlab.cli.gateway.ts` |
+
+## Presenters (🟩)
+
+*No dedicated presenters — platform data is transformed by controllers (ACL) and adapters.*
+
+## Gateways and External Systems (⬜)
+
+| System | Interaction | Gateway contract | Implementation |
+|--------|-------------|-----------------|----------------|
+| GitLab REST API | Thread fetching via `glab api` | `entities/threadFetch/threadFetch.gateway.ts` | `interface-adapters/gateways/threadFetch.gitlab.gateway.ts` |
+| GitHub GraphQL API | Thread fetching via `gh api graphql` | `entities/threadFetch/threadFetch.gateway.ts` | `interface-adapters/gateways/threadFetch.github.gateway.ts` |
+| GitLab REST API | Diff metadata (commit SHAs) | `entities/diffMetadata/diffMetadata.gateway.ts` | `interface-adapters/gateways/diffMetadataFetch.gitlab.gateway.ts` |
+| GitHub REST API | Diff metadata | `entities/diffMetadata/diffMetadata.gateway.ts` | `interface-adapters/gateways/diffMetadataFetch.github.gateway.ts` |
+| GitLab REST API | Diff stats (additions, deletions) | `entities/diffStats/diffStatsFetch.gateway.ts` | `interface-adapters/gateways/diffStatsFetch.gitlab.gateway.ts` |
+| GitHub REST API | Diff stats | `entities/diffStats/diffStatsFetch.gateway.ts` | `interface-adapters/gateways/diffStatsFetch.github.gateway.ts` |
+| GitLab CLI (`glab`) | Execute actions (resolve, comment, label) | `entities/reviewAction/reviewAction.gateway.ts` | `interface-adapters/gateways/cli/reviewAction.gitlab.cli.gateway.ts` |
+| GitHub CLI (`gh`) | Execute actions | `entities/reviewAction/reviewAction.gateway.ts` | `interface-adapters/gateways/cli/reviewAction.github.cli.gateway.ts` |
+
+## Relations with other Bounded Contexts
+
+| Related BC | Pattern (Vaughn Vernon) | Direction | Detail |
+|-----------|------------------------|-----------|--------|
+| Review Execution | Anti-Corruption Layer | Platform → Review | Controllers transform platform events into domain ReviewRequest, create ReviewContext, execute ReviewActions |
+| Tracking | Anti-Corruption Layer | Platform → Tracking | Controllers call TrackAssignment, RecordPush, TransitionState with domain-transformed data |
+| Statistics & Insights | Customer-Supplier | Platform → Stats | DiffStatsFetchGateway provides platform-specific implementations for stats backfill |
+
+## Ubiquitous Language
+
+| Term | Definition in this BC | Equivalent term in other BCs |
+|------|----------------------|------------------------------|
+| MergeRequest | GitLab-specific MR payload | ReviewRequest in domain |
+| PullRequest | GitHub-specific PR payload | ReviewRequest in domain |
+| Discussion | GitLab comment thread | Thread in domain |
+| Review Comment | GitHub review thread | Thread in domain |
+| iid | GitLab MR number | reviewRequestNumber in domain |
+| number | GitHub PR number | reviewRequestNumber in domain |
+
+## Hot Spots (🩷)
+
+| Problem | Severity | Detail |
+|---------|----------|--------|
+| Controller orchestration overload | 🔴 | GitLab controller handles: signature verification, event filtering, assignment tracking, context creation, Claude invocation, action execution, stats recording — 400+ lines with too many responsibilities |
+| Duplicated controller logic | 🟠 | GitLab and GitHub controllers share ~60% similar logic (context creation, action execution, stats recording) — no shared abstraction |
+| CLI tool dependency | 🟠 | All platform interactions depend on `glab`/`gh` CLI tools being installed and authenticated — no fallback mechanism |
+| Thread format divergence | 🟡 | GitLab REST vs GitHub GraphQL produce different thread structures — unified mapping is fragile |

--- a/docs/ddd/event-storming/review-execution.md
+++ b/docs/ddd/event-storming/review-execution.md
@@ -1,0 +1,111 @@
+# Event Storming — Review Execution
+
+*Date: 2026-03-22*
+*Scope: Core review lifecycle — from request to action execution, including MCP progress tracking*
+
+## Domain Events (🟧)
+
+| Event | Trigger | Source file |
+|-------|---------|-------------|
+| ReviewRequested | Webhook assignment or push followup | `usecases/triggerReview.usecase.ts` |
+| ReviewDeduplicated | TriggerReview detects active job | `usecases/triggerReview.usecase.ts` |
+| ReviewStarted | Queue picks up job | `frameworks/queue/` |
+| ReviewCancelled | User cancels via API | `usecases/cancelReview.usecase.ts` |
+| ReviewCompleted | Claude finishes review | `interface-adapters/controllers/webhook/gitlab.controller.ts` |
+| ReviewFailed | Claude invocation fails | `interface-adapters/controllers/webhook/gitlab.controller.ts` |
+| FollowupRequested | Push on tracked MR with open threads | `usecases/handleReviewRequestPush.usecase.ts` |
+| FollowupSkipped | MR not tracked or no followup needed | `usecases/handleReviewRequestPush.usecase.ts` |
+| ActionQueued | Claude calls add_action MCP tool | `usecases/mcp/addAction.usecase.ts` |
+| AgentStarted | Review agent begins audit | `usecases/mcp/startAgent.usecase.ts` |
+| AgentCompleted | Review agent finishes audit | `usecases/mcp/completeAgent.usecase.ts` |
+| PhaseChanged | Review workflow transitions phase | `usecases/mcp/setPhase.usecase.ts` |
+| ReviewContextCreated | Context file written before Claude invocation | `entities/reviewContext/reviewContext.gateway.ts` |
+| ReviewContextDeleted | Cleanup after MR close | `entities/reviewContext/reviewContext.gateway.ts` |
+
+## Commands / Use Cases (🟦)
+
+| Command | Actor | Event produced | Source file |
+|---------|-------|----------------|-------------|
+| TriggerReview | Webhook / System | ReviewRequested, ReviewDeduplicated | `usecases/triggerReview.usecase.ts` |
+| CancelReview | User (API) | ReviewCancelled | `usecases/cancelReview.usecase.ts` |
+| HandleReviewRequestPush | Webhook (push) | FollowupRequested, FollowupSkipped | `usecases/handleReviewRequestPush.usecase.ts` |
+| GetWorkflow | MCP (Claude) | — (query) | `usecases/mcp/getWorkflow.usecase.ts` |
+| StartAgent | MCP (Claude) | AgentStarted | `usecases/mcp/startAgent.usecase.ts` |
+| CompleteAgent | MCP (Claude) | AgentCompleted | `usecases/mcp/completeAgent.usecase.ts` |
+| SetPhase | MCP (Claude) | PhaseChanged | `usecases/mcp/setPhase.usecase.ts` |
+| GetThreads | MCP (Claude) | — (query) | `usecases/mcp/getThreads.usecase.ts` |
+| AddAction | MCP (Claude) | ActionQueued | `usecases/mcp/addAction.usecase.ts` |
+
+## Entities (🟨)
+
+| Entity | Responsibility | Files |
+|--------|----------------|-------|
+| ReviewRequest | State machine for MR/PR lifecycle (`pending-review` → `merged`/`closed`) | `entities/reviewRequest/reviewRequest.entity.ts`, `reviewRequestState.valueObject.ts`, `reviewRequest.guard.ts` |
+| ReviewContext | Session data for a single review: threads, actions, agent instructions, diff metadata | `entities/reviewContext/reviewContext.ts`, `reviewContext.schema.ts`, `reviewContext.gateway.ts` |
+| ReviewAction | Discriminated union of executable actions (THREAD_RESOLVE, POST_COMMENT, THREAD_REPLY, ADD_LABEL, POST_INLINE_COMMENT, FETCH_THREADS) | `entities/reviewAction/reviewAction.schema.ts`, `reviewAction.ts`, `reviewAction.guard.ts`, `reviewAction.gateway.ts` |
+| ReviewScore | Value object: blocking + warnings + suggestions → severity (critical/warning/info/clean) | `entities/review/reviewScore.valueObject.ts` |
+| ReviewProgress | Review job progress: agents, phases, overall percentage | `entities/progress/progress.type.ts`, `progress.factory.ts`, `progress.calculator.ts`, `progress.gateway.ts` |
+| AgentDefinition | Predefined agent lists for initial and followup reviews | `entities/progress/agentDefinition.type.ts` |
+| JobContext | In-memory MCP job context (projectPath, mrNumber) | `entities/job/jobContext.gateway.ts` |
+
+## Policies and Business Rules (🟪)
+
+| Rule | Description | Source file |
+|------|-------------|-------------|
+| Deduplication | A review is not triggered if an active job already exists for the same MR | `usecases/triggerReview.usecase.ts` |
+| Followup eligibility | Push triggers followup only if MR is `pending-fix` OR (`pending-approval` with warnings), and `lastPushAt > lastReviewAt` | `usecases/tracking/checkFollowupNeeded.usecase.ts` |
+| ReviewRequest state transitions | Only valid transitions allowed (e.g., `pending-review` → `pending-fix`, never `merged` → anything) | `entities/reviewRequest/reviewRequestState.valueObject.ts` |
+| ReviewAction validation | Each action type requires specific fields (e.g., THREAD_RESOLVE needs threadId, POST_INLINE_COMMENT needs filePath+line) | `usecases/mcp/addAction.usecase.ts` |
+| ReviewPhase ordering | Phases progress: `initializing` → `agents-running` → `synthesizing` → `publishing` → `completed` | `entities/progress/progress.type.ts` |
+| Webhook signature verification | GitLab HMAC-256 / GitHub HMAC-SHA256 signature must be valid | `security/verifier.ts` |
+| ReviewRequest guard | Webhook payload validated with Zod schema before processing | `entities/gitlab/gitlabMergeRequestEvent.guard.ts`, `entities/github/githubPullRequestEvent.guard.ts` |
+
+## Presenters (🟩)
+
+| Presenter | Data exposed | File |
+|-----------|-------------|------|
+| JobStatusPresenter | statusLabel, statusColor, progressPercent, elapsedTime, jobTypeLabel | `interface-adapters/presenters/jobStatus.presenter.ts` |
+| ReviewContextProgressPresenter | Review context progress for dashboard UI | `interface-adapters/presenters/reviewContextProgress.presenter.ts` |
+| ReviewListPresenter | Review list for dashboard display | `interface-adapters/presenters/reviewList.presenter.ts` |
+
+## Gateways and External Systems (⬜)
+
+| System | Interaction | Gateway contract | Implementation |
+|--------|-------------|-----------------|----------------|
+| File System | Review context JSON persistence | `entities/reviewContext/reviewContext.gateway.ts` | `interface-adapters/gateways/reviewContext.fileSystem.gateway.ts` |
+| File System | Review file storage | `entities/review/reviewFile.gateway.ts` | `interface-adapters/gateways/reviewFile.gateway.ts` |
+| GitLab CLI | Execute review actions (resolve, comment, label) | `entities/reviewAction/reviewAction.gateway.ts` | `interface-adapters/gateways/cli/reviewAction.gitlab.cli.gateway.ts` |
+| GitHub CLI | Execute review actions | `entities/reviewAction/reviewAction.gateway.ts` | `interface-adapters/gateways/cli/reviewAction.github.cli.gateway.ts` |
+| In-memory | MCP job context | `entities/job/jobContext.gateway.ts` | `interface-adapters/gateways/jobContext.memory.gateway.ts` |
+| In-memory | Review progress tracking | `entities/progress/progress.gateway.ts` | (in-memory implementation) |
+| p-queue | Job queuing with concurrency control | `ReviewQueuePort` (in triggerReview) | `frameworks/queue/` |
+| Claude | AI review invocation | (callback in controller) | `frameworks/claude/claudeInvoker.ts` |
+
+## Relations with other Bounded Contexts
+
+| Related BC | Pattern (Vaughn Vernon) | Direction | Detail |
+|-----------|------------------------|-----------|--------|
+| Platform Integration | Anti-Corruption Layer | Platform → Review | Webhook controllers transform GitLab/GitHub events into ReviewRequest domain concepts |
+| Tracking | Customer-Supplier | Review → Tracking | Review Execution supplies review completion data; Tracking consumes it for lifecycle state |
+| Statistics & Insights | Published Language | Review → Stats | ReviewScore and review files are consumed by Stats for aggregation |
+| Data Lifecycle | Conformist | Cleanup → Review | Cleanup uses ReviewFileGateway contract defined by Review domain |
+
+## Ubiquitous Language
+
+| Term | Definition in this BC | Equivalent term in other BCs |
+|------|----------------------|------------------------------|
+| ReviewRequest | A code review request with state machine | TrackedMr in Tracking BC |
+| ReviewAction | Atomic executable action on a platform | — |
+| ReviewContext | Session state file for one review run | — |
+| ReviewJob | Queued unit of work for one review | — |
+| Agent | Specialized Claude audit (clean-architecture, ddd, solid, testing, code-quality) | — |
+| FollowupReview | Subsequent review after author fixes | — |
+
+## Hot Spots (🩷)
+
+| Problem | Severity | Detail |
+|---------|----------|--------|
+| Fat webhook controllers | 🟠 | `gitlab.controller.ts` and `github.controller.ts` orchestrate 6+ use cases, handle context creation, action execution, stats parsing — too many responsibilities for a controller |
+| Strangler Fig in progress | 🟡 | `reviewContextAction.schema.ts` re-exports from `reviewAction.schema.ts` with "will be removed" comment — migration incomplete |
+| Claude invocation not abstracted | 🟡 | Claude is invoked via callback in controllers, not through a dedicated gateway contract — makes testing harder |
+| ReviewContext as shared mutable state | 🟠 | The context JSON file serves as coordination between Claude invocation and post-review action execution — implicit contract |

--- a/docs/ddd/event-storming/statistics-insights.md
+++ b/docs/ddd/event-storming/statistics-insights.md
@@ -1,0 +1,103 @@
+# Event Storming — Statistics & Insights
+
+*Date: 2026-03-22*
+*Scope: Review statistics aggregation, developer performance insights, AI-generated narratives*
+
+## Domain Events (🟧)
+
+| Event | Trigger | Source file |
+|-------|---------|-------------|
+| StatsRecalculated | Manual recalculate via API | `usecases/stats/recalculateProjectStats.usecase.ts` |
+| DiffStatsBackfilled | Backfill batch completed for missing diff stats | `usecases/stats/backfillDiffStats.usecase.ts` |
+| BackfillProgressUpdated | Batch progress callback during backfill | `usecases/stats/backfillDiffStats.usecase.ts` |
+| DeveloperInsightsComputed | Developer metrics calculated from review stats | `usecases/insights/computeDeveloperInsights.usecase.ts` |
+| TeamInsightComputed | Team aggregation completed from developer insights | `usecases/insights/computeTeamInsights.usecase.ts` |
+| AiInsightsGenerated | Claude produces narrative insights from review data | `usecases/insights/generateAiInsights.usecase.ts` |
+| InsightsPersisted | Computed insights saved with rolling window | `usecases/insights/computeInsightsWithPersistence.usecase.ts` |
+
+## Commands / Use Cases (🟦)
+
+| Command | Actor | Event produced | Source file |
+|---------|-------|----------------|-------------|
+| RecalculateProjectStats | User (API) | StatsRecalculated | `usecases/stats/recalculateProjectStats.usecase.ts` |
+| BackfillDiffStats | User (API) | DiffStatsBackfilled | `usecases/stats/backfillDiffStats.usecase.ts` |
+| RecalculateWithBackfill | User (API) | DiffStatsBackfilled, StatsRecalculated | `usecases/stats/recalculateWithBackfill.usecase.ts` |
+| ComputeDeveloperInsights | System (dashboard request) | DeveloperInsightsComputed | `usecases/insights/computeDeveloperInsights.usecase.ts` |
+| ComputeTeamInsights | System | TeamInsightComputed | `usecases/insights/computeTeamInsights.usecase.ts` |
+| ComputeInsightsWithPersistence | System | InsightsPersisted | `usecases/insights/computeInsightsWithPersistence.usecase.ts` |
+| GenerateAiInsights | User (dashboard button) | AiInsightsGenerated | `usecases/insights/generateAiInsights.usecase.ts` |
+| GetInsightsWithAiStatus | System (dashboard) | — (query) | `usecases/insights/getInsightsWithAiStatus.usecase.ts` |
+
+## Entities (🟨)
+
+| Entity | Responsibility | Files |
+|--------|----------------|-------|
+| ProjectStats | Aggregated review metrics for a project: totalReviews, averageScore, totalBlocking, totalWarnings, diffStats aggregates | `entities/stats/projectStats.ts` |
+| ReviewStats | Individual review metrics within ProjectStats | `entities/stats/projectStats.ts` |
+| DiffStats | Commit count, additions, deletions, changed files | `entities/diffStats/diffStats.ts` |
+| BackfillProgress | Batch progress: total, completed, failed, status | `entities/backfill/backfillProgress.ts` |
+| DeveloperInsight | Per-developer performance: title, overallLevel, categoryLevels, strengths, weaknesses, trend | `entities/insight/developerInsight.ts`, `developerInsight.schema.ts` |
+| TeamInsight | Team aggregation: averageLevels, strengths, weaknesses, tips | `entities/insight/teamInsight.ts`, `teamInsight.schema.ts` |
+| AiInsight | AI-generated narrative from Claude: developer analysis, team recommendations | `entities/insight/aiInsight.ts`, `aiInsight.schema.ts` |
+| PersistedInsightsData | Rolling window of processed review IDs + cached metrics | `entities/insight/persistedInsightsData.ts`, `persistedInsightsData.schema.ts` |
+| InsightCategory | Enum: quality, responsiveness, codeVolume, iteration | `entities/insight/insightCategory.ts` |
+| InsightTrend | Enum: improving, stable, declining | `entities/insight/insightTrend.ts` |
+| DeveloperTitle | Enum: architect, firefighter, workhorse, sentinel, balanced, risingStar | `entities/insight/developerTitle.ts` |
+
+## Policies and Business Rules (🟪)
+
+| Rule | Description | Source file |
+|------|-------------|-------------|
+| Minimum reviews threshold | Developer insights only computed for developers with enough reviews | `usecases/insights/computeDeveloperInsights.usecase.ts` |
+| Rolling 20-review window | Persisted insights track last 20 reviews to detect trends | `usecases/insights/computeInsightsWithPersistence.usecase.ts` |
+| Batch delay | Backfill uses configurable batch size and delay to avoid API rate limits | `usecases/stats/backfillDiffStats.usecase.ts` |
+| Developer title assignment | Title based on strongest category: quality→architect, responsiveness→firefighter, codeVolume→workhorse, iteration→sentinel | `usecases/insights/computeDeveloperInsights.usecase.ts` |
+| Trend computation | Comparing current vs previous window averages → improving/stable/declining | `usecases/insights/computeDeveloperInsights.usecase.ts` |
+| AI insights staleness | `hasNewReviewsSinceAiGeneration` flag indicates when AI insights need refresh | `usecases/insights/getInsightsWithAiStatus.usecase.ts` |
+
+## Presenters (🟩)
+
+| Presenter | Data exposed | File |
+|-----------|-------------|------|
+| InsightsPresenter | Formatted insights data for dashboard UI | `interface-adapters/presenters/insights.presenter.ts` |
+| ProjectStatsCalculator | Aggregated stats computations | `interface-adapters/presenters/projectStats.calculator.ts` |
+
+## Gateways and External Systems (⬜)
+
+| System | Interaction | Gateway contract | Implementation |
+|--------|-------------|-----------------|----------------|
+| File System | Persist project stats JSON | `entities/stats/stats.gateway.ts` | `interface-adapters/gateways/stats.gateway.ts` |
+| File System | Persist insights data | `entities/insight/insights.gateway.ts` | `interface-adapters/gateways/insights.gateway.ts` |
+| GitLab CLI | Fetch diff stats (additions, deletions, commits) | `entities/diffStats/diffStatsFetch.gateway.ts` | `interface-adapters/gateways/diffStatsFetch.gitlab.gateway.ts` |
+| GitHub CLI | Fetch diff stats | `entities/diffStats/diffStatsFetch.gateway.ts` | `interface-adapters/gateways/diffStatsFetch.github.gateway.ts` |
+| Claude | Generate AI narrative insights | (callback in generateAiInsights) | `frameworks/claude/claudeInvoker.ts` |
+| File System | Read review files for AI analysis | `entities/review/reviewFile.gateway.ts` | `interface-adapters/gateways/reviewFile.gateway.ts` |
+
+## Relations with other Bounded Contexts
+
+| Related BC | Pattern (Vaughn Vernon) | Direction | Detail |
+|-----------|------------------------|-----------|--------|
+| Tracking | Customer-Supplier | Tracking → Stats | Stats consumes TrackedMr data and ReviewEvents for aggregation |
+| Review Execution | Published Language | Review → Stats | ReviewScore and review files consumed for analysis |
+| Shared Kernel | Shared Kernel | Stats ↔ Tracking | `DiffStats` type shared between both BCs |
+| Platform Integration | Customer-Supplier | Platform → Stats | DiffStatsFetchGateway implementations are platform-specific |
+
+## Ubiquitous Language
+
+| Term | Definition in this BC | Equivalent term in other BCs |
+|------|----------------------|------------------------------|
+| ProjectStats | Aggregated metrics for all reviews in a project | MrTrackingData.stats in Tracking (partial overlap) |
+| ReviewStats | Individual review metrics (score, duration, issues) | ReviewEvent in Tracking (different shape) |
+| DeveloperInsight | Computed performance profile for one developer | — |
+| TeamInsight | Aggregated team performance with tips | — |
+| AiInsight | Claude-generated narrative analysis | — |
+| Backfill | Retroactive fetching of missing diff statistics | — |
+
+## Hot Spots (🩷)
+
+| Problem | Severity | Detail |
+|---------|----------|--------|
+| Claude invocation as callback | 🟡 | `generateAiInsights` receives a `claudeInvoker` callback rather than using a gateway contract — inconsistent with other external integrations |
+| Stats aggregation duplication | 🟡 | `ProjectStatsCalculator` (presenter) and `recalculateProjectStats` (use case) both compute stats — unclear separation |
+| DiffStats as Shared Kernel | 🟡 | `DiffStats` type is imported by both stats and tracking domains — small but real coupling point |
+| Insight computation chain | 🟡 | `computeInsightsWithPersistence` → `computeTeamInsights` → `computeDeveloperInsights` — deep call chain could be simplified |

--- a/docs/ddd/event-storming/tracking.md
+++ b/docs/ddd/event-storming/tracking.md
@@ -1,0 +1,86 @@
+# Event Storming — Tracking
+
+*Date: 2026-03-22*
+*Scope: MR/PR lifecycle tracking — assignment, state transitions, push events, thread synchronization*
+
+## Domain Events (🟧)
+
+| Event | Trigger | Source file |
+|-------|---------|-------------|
+| MrAssigned | Webhook detects reviewer assignment | `usecases/tracking/trackAssignment.usecase.ts` |
+| MrUpdated | Existing TrackedMr updated with new assignment info | `usecases/tracking/trackAssignment.usecase.ts` |
+| PushRecorded | New commits pushed to tracked MR | `usecases/tracking/recordPush.usecase.ts` |
+| ReviewEventRecorded | Review completion data saved to tracking | `usecases/tracking/recordReviewCompletion.usecase.ts` |
+| ThreadsSynced | Thread status refreshed from platform | `usecases/tracking/syncThreads.usecase.ts` |
+| StateTransitioned | MR state changed (approved/merged/closed) | `usecases/tracking/transitionState.usecase.ts` |
+| FollowupNeeded | Push detected on MR needing re-review | `usecases/tracking/checkFollowupNeeded.usecase.ts` |
+
+## Commands / Use Cases (🟦)
+
+| Command | Actor | Event produced | Source file |
+|---------|-------|----------------|-------------|
+| TrackAssignment | Webhook (reviewer assigned) | MrAssigned, MrUpdated | `usecases/tracking/trackAssignment.usecase.ts` |
+| RecordPush | Webhook (push event) | PushRecorded | `usecases/tracking/recordPush.usecase.ts` |
+| RecordReviewCompletion | System (post-review) | ReviewEventRecorded | `usecases/tracking/recordReviewCompletion.usecase.ts` |
+| SyncThreads | System (scheduled) | ThreadsSynced | `usecases/tracking/syncThreads.usecase.ts` |
+| CheckFollowupNeeded | Webhook (push event) | FollowupNeeded | `usecases/tracking/checkFollowupNeeded.usecase.ts` |
+| TransitionState | Webhook (merge/close/approve) | StateTransitioned | `usecases/tracking/transitionState.usecase.ts` |
+
+## Entities (🟨)
+
+| Entity | Responsibility | Files |
+|--------|----------------|-------|
+| TrackedMr | Full lifecycle state of a tracked MR/PR: state, timestamps, thread counts, review events, push history | `entities/tracking/trackedMr.ts` |
+| MrTrackingData | Container for all tracked MRs in a project with aggregate ProjectStats | `entities/tracking/mrTrackingData.ts` |
+| AssignmentInfo | Who assigned the review and when | `entities/tracking/assignmentInfo.ts` |
+| ReviewEvent | Record of a single review execution: type, duration, score, threads, diff stats | `entities/tracking/reviewEvent.ts` |
+
+## Policies and Business Rules (🟪)
+
+| Rule | Description | Source file |
+|------|-------------|-------------|
+| TrackedMr identity | `createTrackedMrId(projectPath, mrNumber)` produces unique composite key | `entities/tracking/trackedMr.ts` |
+| State transition validation | Uses ReviewRequestState value object to validate transitions | `usecases/tracking/transitionState.usecase.ts` |
+| Followup condition | MR must be `pending-fix` OR `pending-approval` with warnings, and `lastPushAt > lastReviewAt` | `usecases/tracking/checkFollowupNeeded.usecase.ts` |
+| Timestamp mapping | `approved` → sets `approvedAt`, `merged` → sets `mergedAt` | `usecases/tracking/transitionState.usecase.ts` |
+| Idempotent assignment | If TrackedMr already exists, updates rather than creates | `usecases/tracking/trackAssignment.usecase.ts` |
+
+## Presenters (🟩)
+
+| Presenter | Data exposed | File |
+|-----------|-------------|------|
+| (via dashboard views) | MR sheet with state, threads, events | `interface-adapters/views/dashboard/modules/mrSheet.js` |
+
+## Gateways and External Systems (⬜)
+
+| System | Interaction | Gateway contract | Implementation |
+|--------|-------------|-----------------|----------------|
+| File System | Persist tracking data JSON | `entities/tracking/reviewRequestTracking.gateway.ts` | `interface-adapters/gateways/fileSystem/reviewRequestTracking.fileSystem.ts` |
+| GitLab API | Fetch discussion threads | `entities/threadFetch/threadFetch.gateway.ts` | `interface-adapters/gateways/threadFetch.gitlab.gateway.ts` |
+| GitHub API | Fetch review threads (GraphQL) | `entities/threadFetch/threadFetch.gateway.ts` | `interface-adapters/gateways/threadFetch.github.gateway.ts` |
+
+## Relations with other Bounded Contexts
+
+| Related BC | Pattern (Vaughn Vernon) | Direction | Detail |
+|-----------|------------------------|-----------|--------|
+| Review Execution | Customer-Supplier | Review → Tracking | Review provides completion data (score, duration, threads); Tracking records it as ReviewEvent |
+| Platform Integration | Anti-Corruption Layer | Platform → Tracking | Webhook controllers call tracking use cases with domain-transformed data |
+| Statistics & Insights | Customer-Supplier | Tracking → Stats | Tracking provides TrackedMr data; Stats aggregates it |
+| Shared Kernel | Shared Kernel | Tracking ↔ Stats | `DiffStats` type from `entities/diffStats/` used by both |
+
+## Ubiquitous Language
+
+| Term | Definition in this BC | Equivalent term in other BCs |
+|------|----------------------|------------------------------|
+| TrackedMr | Full lifecycle record of a MR/PR being tracked | ReviewRequest in Review Execution (overlapping concept) |
+| ReviewEvent | Record of one review run with metrics | ReviewJob in Review Execution (different scope) |
+| AssignmentInfo | Who triggered the review assignment | — |
+| MrTrackingData | All tracked MRs for one project | ProjectStats in Statistics (different focus) |
+
+## Hot Spots (🩷)
+
+| Problem | Severity | Detail |
+|---------|----------|--------|
+| TrackedMr vs ReviewRequest overlap | 🟡 | Both `TrackedMr` (tracking) and `ReviewRequest` (reviewRequest entity) represent an MR/PR but with different shapes — potential concept duplication |
+| Large gateway contract | 🟡 | `ReviewRequestTrackingGateway` has 12+ methods (loadTracking, saveTracking, getById, getByNumber, create, update, getByState, getActiveMrs, remove, archive, recordReviewEvent, recordPush) — may benefit from splitting |
+| DiffStats cross-domain coupling | 🟡 | `ReviewEvent` imports `DiffStats` from `entities/diffStats/` — shared type across Tracking and Stats BCs |

--- a/docs/specs/30-init-project-command.md
+++ b/docs/specs/30-init-project-command.md
@@ -6,6 +6,8 @@ milestone: Project Bootstrapping
 status: DRAFT
 ---
 
+
+
 # SPEC-030: `reviewflow init-project` — Project Setup with MCP-Ready Skeleton Skills
 
 ## Problem Statement

--- a/docs/specs/32-update-readme-quickstart.md
+++ b/docs/specs/32-update-readme-quickstart.md
@@ -7,6 +7,8 @@ status: READY
 blocked_by: "#30 (init-project), #55 (config validation)"
 ---
 
+
+
 # SPEC-032: Update README and Quick-Start for `npm install -g reviewflow` Flow
 
 ## Problem Statement

--- a/docs/specs/46-github-followup-review-on-push.md
+++ b/docs/specs/46-github-followup-review-on-push.md
@@ -6,6 +6,8 @@ labels: enhancement, P1-critical, webhook
 milestone: "Bug Fixes & Parity"
 ---
 
+
+
 # SPEC-046: GitHub Followup Review on Push
 
 ## User Story

--- a/docs/specs/52-automated-webhook-secret-generation.md
+++ b/docs/specs/52-automated-webhook-secret-generation.md
@@ -6,6 +6,8 @@ blocked-by: "#29 (closed)"
 milestone: "Setup Wizard"
 ---
 
+
+
 # SPEC-052: Automated Webhook Secret Generation
 
 ## User Story

--- a/docs/specs/55-configuration-validation-command.md
+++ b/docs/specs/55-configuration-validation-command.md
@@ -7,6 +7,8 @@ blocked-by: "#29 (closed)"
 status: DRAFT
 ---
 
+
+
 # SPEC-055: `reviewflow validate` — Configuration Validation Command
 
 ## Problem Statement

--- a/docs/specs/57-interactive-agent-configuration-wizard.md
+++ b/docs/specs/57-interactive-agent-configuration-wizard.md
@@ -7,6 +7,8 @@ blocked_by: "#30 (init-project command)"
 status: DRAFT
 ---
 
+
+
 # SPEC-057: Interactive Agent Configuration Wizard
 
 ## Problem Statement

--- a/docs/specs/58-multi-language-project-init.md
+++ b/docs/specs/58-multi-language-project-init.md
@@ -7,6 +7,8 @@ blocked_by: https://github.com/DGouron/review-flow/issues/30
 status: DRAFT
 ---
 
+
+
 # SPEC-058: Multi-Language Support for Project Init
 
 ## Problem Statement


### PR DESCRIPTION
## Summary

Adds DDD / event storming documentation and the new `event-storming` skill.

- New `event-storming` skill (`SKILL.md` + reference templates)
- Big Picture event storming output across 6 bounded contexts (`docs/ddd/`)
- Multi-LLM analysis note (`docs/architecture/multi-llm-analysis.md`)
- TDD skill update
- Minor status touches on specs 30/32/46/52/55/57/58

Documentation-only — no source code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)