### PR TITLE
fix: remove unused join import breaking the build

### DIFF
--- a/src/tests/acceptance/dashboardModulesCoverage.acceptance.test.ts
+++ b/src/tests/acceptance/dashboardModulesCoverage.acceptance.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { readdirSync, existsSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { resolve } from 'node:path';
 
 const MODULES_DIR = resolve(
   process.cwd(),


### PR DESCRIPTION
## Problem

`yarn build` (`tsc`) has been failing since commit c282855 (#151):

```
src/tests/acceptance/dashboardModulesCoverage.acceptance.test.ts(3,10): error TS6133: 'join' is declared but its value is never read.
```

`tsconfig.json` has `noUnusedLocals: true` and includes `src/**/*` (tests included), so the unused `join` import from `node:path` breaks the whole build. The dashboard test only uses `resolve` from `node:path` (the `.join(...)` calls on lines 46/55 are `Array.prototype.join`).

## Impact

With a broken build, `dist/` cannot be regenerated. Any deployment running from source (e.g. a local daemon via systemd) stays frozen on a stale `dist/`.

## Fix

Drop the unused `join` from the import. One line.

## Verification

- `yarn build` — green
- `yarn verify` (typecheck + lint + test:ci) — green (1386 tests, 4 CLI integration tests pass once `dist/` is built)

🤖 Generated with [Claude Code](https://claude.com/claude-code)