### PR TITLE
fix(version): detect source-checkout installs to stop the false update flow

### DIFF
--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -2598,7 +2598,7 @@
         const versionUpdateArea = document.getElementById('version-update-area');
         if (versionUpdateArea) {
           versionUpdateArea.innerHTML = renderVersionUpdateArea(
-            { currentVersion: data.currentVersion || '?', updateAvailable: data.updateAvailable || false, latestVersion: data.latestVersion || null },
+            { currentVersion: data.currentVersion || '?', updateAvailable: data.updateAvailable || false, latestVersion: data.latestVersion || null, installType: data.installType || 'global-npm' },
             t
           );
           if (typeof lucide !== 'undefined') lucide.createIcons();
@@ -2639,6 +2639,9 @@
         } else if (data.status === 'permission-denied') {
           setVersionCheckState('idle', t);
           showManualUpdateCommand(data.command);
+        } else if (data.status === 'source-checkout') {
+          setVersionCheckState('idle', t);
+          showManualUpdateCommand(data.manualCommand);
         } else {
           showToast(data.error || t('version.updateFailed'), 'error');
           setVersionCheckState('idle', t);
@@ -2647,6 +2650,21 @@
         console.error('Error triggering update:', error);
         showToast(t('version.updateFailed'), 'error');
         setVersionCheckState('idle', t);
+      }
+    }
+
+    async function showSourceCheckoutUpdate() {
+      try {
+        const response = await fetch(`${API_URL}/api/version/update`, { method: 'POST' });
+        const data = await response.json();
+        if (data.status === 'source-checkout') {
+          showManualUpdateCommand(data.manualCommand);
+        } else {
+          showToast(t('version.updateFailed'), 'error');
+        }
+      } catch (error) {
+        console.error('Error fetching manual update command:', error);
+        showToast(t('version.updateFailed'), 'error');
       }
     }
 
@@ -2719,6 +2737,7 @@
     // Expose functions to HTML onclick handlers
     window.checkForUpdates = checkForUpdates;
     window.triggerVersionUpdate = triggerVersionUpdate;
+    window.showSourceCheckoutUpdate = showSourceCheckoutUpdate;
     window.copyUpdateCommand = copyUpdateCommand;
     window.toggleCollapsibleList = toggleCollapsibleList;
     window.checkClaudeStatus = checkClaudeStatus;

--- a/src/dashboard/modules/i18n.js
+++ b/src/dashboard/modules/i18n.js
@@ -384,6 +384,8 @@ const translations = {
     'version.permissionDenied': 'Permission denied. Run this command manually:',
     'version.copyCommand': 'Copy command',
     'version.commandCopied': 'Command copied!',
+    'version.sourceCheckoutTooltip': 'Source-checkout install. Click to see the manual update command.',
+    'version.sourceCheckoutNotice': 'This daemon runs from a source checkout. Run this command manually to update:',
   },
   fr: {
     // Time
@@ -767,6 +769,8 @@ const translations = {
     'version.permissionDenied': 'Permission refusée. Exécutez cette commande manuellement :',
     'version.copyCommand': 'Copier la commande',
     'version.commandCopied': 'Commande copiée !',
+    'version.sourceCheckoutTooltip': "Installation depuis le code source. Cliquez pour voir la commande de mise à jour manuelle.",
+    'version.sourceCheckoutNotice': 'Ce daemon tourne depuis un checkout du code source. Exécutez cette commande manuellement pour mettre à jour :',
   },
 };
 

--- a/src/dashboard/modules/versionUpdate.js
+++ b/src/dashboard/modules/versionUpdate.js
@@ -1,7 +1,7 @@
 import { escapeHtml } from './html.js';
 
 /**
- * @param {{ currentVersion: string, updateAvailable: boolean, latestVersion: string | null }} versionData
+ * @param {{ currentVersion: string, updateAvailable: boolean, latestVersion: string | null, installType: 'global-npm' | 'source-checkout' }} versionData
  * @param {(key: string, params?: Record<string, string | number>) => string} translate
  * @returns {string}
  */
@@ -17,6 +17,15 @@ export function renderVersionUpdateArea(versionData, translate) {
   }
 
   const label = translate('version.updateAvailable', { version: versionData.latestVersion });
+
+  if (versionData.installType === 'source-checkout') {
+    const tooltip = translate('version.sourceCheckoutTooltip');
+    const sourceCheckoutButton = `<button id="version-source-checkout-btn" class="btn btn-update" title="${escapeHtml(tooltip)}" onclick="showSourceCheckoutUpdate()">
+    <i data-lucide="info"></i> <span>${escapeHtml(label)}</span>
+  </button>`;
+    return `${versionLabel}${sourceCheckoutButton}${checkButton}`;
+  }
+
   const updateButton = `<button id="version-update-btn" class="btn btn-update" onclick="triggerVersionUpdate()">
     <i data-lucide="download"></i> <span>${escapeHtml(label)}</span>
   </button>`;

--- a/src/main/routes.ts
+++ b/src/main/routes.ts
@@ -54,6 +54,7 @@ import { triggerSelfUpdate } from '@/modules/cli-configuration/usecases/version/
 import { NpmPackageVersionGateway } from '@/modules/cli-configuration/interface-adapters/gateways/packageVersion.npm.gateway.js';
 import { VersionCacheMemoryGateway } from '@/modules/cli-configuration/interface-adapters/gateways/versionCache.memory.gateway.js';
 import { SelfUpdateCliGateway } from '@/modules/cli-configuration/interface-adapters/gateways/selfUpdate.cli.gateway.js';
+import { InstallTypeDetectorFsGateway } from '@/modules/cli-configuration/interface-adapters/gateways/installTypeDetector.fs.gateway.js';
 import { broadcastBackfillProgress } from '@/main/websocket.js';
 import { createClaudeInsightsInvoker } from '@/frameworks/claude/claudeInsightsInvoker.js';
 import { getDefaultLanguage } from '@/frameworks/settings/runtimeSettings.js';
@@ -71,6 +72,7 @@ const currentVersion = readVersion();
 const packageVersionGateway = new NpmPackageVersionGateway();
 const versionCache = new VersionCacheMemoryGateway();
 const selfUpdateCommand = new SelfUpdateCliGateway();
+const installTypeDetector = new InstallTypeDetectorFsGateway();
 
 export async function registerRoutes(
   app: FastifyInstance,
@@ -183,6 +185,7 @@ export async function registerRoutes(
     packageVersionGateway,
     versionCache,
     selfUpdateCommand,
+    installTypeDetector,
     serverPort: deps.config.server.port,
   });
 
@@ -271,6 +274,6 @@ export async function registerRoutes(
 
   checkVersion(
     { currentVersion, forceRefresh: false },
-    { packageVersionGateway, cache: versionCache },
+    { packageVersionGateway, cache: versionCache, installTypeDetector },
   ).catch(() => {});
 }

--- a/src/modules/cli-configuration/entities/packageVersion/installType.ts
+++ b/src/modules/cli-configuration/entities/packageVersion/installType.ts
@@ -1,0 +1,1 @@
+export type InstallType = 'global-npm' | 'source-checkout'

--- a/src/modules/cli-configuration/entities/packageVersion/installTypeDetector.gateway.ts
+++ b/src/modules/cli-configuration/entities/packageVersion/installTypeDetector.gateway.ts
@@ -1,0 +1,5 @@
+import type { InstallType } from '@/modules/cli-configuration/entities/packageVersion/installType.js'
+
+export interface InstallTypeDetector {
+  detect(): InstallType
+}

--- a/src/modules/cli-configuration/entities/packageVersion/packageVersion.schema.ts
+++ b/src/modules/cli-configuration/entities/packageVersion/packageVersion.schema.ts
@@ -11,4 +11,5 @@ export const versionCheckResultSchema = z.object({
   latestVersion: z.string().nullable(),
   updateAvailable: z.boolean(),
   checkedAt: z.string(),
+  installType: z.enum(['global-npm', 'source-checkout']),
 })

--- a/src/modules/cli-configuration/entities/packageVersion/packageVersion.ts
+++ b/src/modules/cli-configuration/entities/packageVersion/packageVersion.ts
@@ -1,8 +1,11 @@
+import type { InstallType } from '@/modules/cli-configuration/entities/packageVersion/installType.js'
+
 export type VersionCheckResult = {
   currentVersion: string
   latestVersion: string | null
   updateAvailable: boolean
   checkedAt: string
+  installType: InstallType
 }
 
 export type SelfUpdateResult =
@@ -10,5 +13,6 @@ export type SelfUpdateResult =
   | { status: 'updated'; previousVersion: string; newVersion: string }
   | { status: 'failed'; error: string }
   | { status: 'permission-denied'; command: string }
+  | { status: 'source-checkout'; manualCommand: string }
 
-export type UpdateStatus = 'idle' | 'checking' | 'updating' | 'restarting' | 'failed'
+export type UpdateStatus = 'idle' | 'checking' | 'updating' | 'restarting' | 'failed' | 'manual-required'

--- a/src/modules/cli-configuration/interface-adapters/controllers/http/version.routes.ts
+++ b/src/modules/cli-configuration/interface-adapters/controllers/http/version.routes.ts
@@ -3,6 +3,7 @@ import type { VersionCheckResult, SelfUpdateResult } from '@/modules/cli-configu
 import type { PackageVersionGateway } from '@/modules/cli-configuration/entities/packageVersion/packageVersion.gateway.js'
 import type { VersionCachePort } from '@/modules/cli-configuration/entities/packageVersion/versionCache.gateway.js'
 import type { SelfUpdateCommandPort } from '@/modules/cli-configuration/entities/packageVersion/selfUpdateCommand.gateway.js'
+import type { InstallTypeDetector } from '@/modules/cli-configuration/entities/packageVersion/installTypeDetector.gateway.js'
 import type { CheckVersionInput, CheckVersionDependencies } from '@/modules/cli-configuration/usecases/version/checkVersion.usecase.js'
 import type { TriggerSelfUpdateDependencies } from '@/modules/cli-configuration/usecases/version/triggerSelfUpdate.usecase.js'
 
@@ -13,6 +14,7 @@ interface VersionRoutesOptions {
   packageVersionGateway: PackageVersionGateway
   versionCache: VersionCachePort
   selfUpdateCommand: SelfUpdateCommandPort
+  installTypeDetector: InstallTypeDetector
   serverPort: number
 }
 
@@ -20,12 +22,19 @@ export const versionRoutes: FastifyPluginAsync<VersionRoutesOptions> = async (fa
   fastify.get('/api/version/check', async () => {
     return options.checkVersion(
       { currentVersion: options.currentVersion, forceRefresh: true },
-      { packageVersionGateway: options.packageVersionGateway, cache: options.versionCache },
+      {
+        packageVersionGateway: options.packageVersionGateway,
+        cache: options.versionCache,
+        installTypeDetector: options.installTypeDetector,
+      },
     )
   })
 
   fastify.post('/api/version/update', async (_request, reply) => {
-    const result = await options.triggerSelfUpdate({ selfUpdateCommand: options.selfUpdateCommand })
+    const result = await options.triggerSelfUpdate({
+      selfUpdateCommand: options.selfUpdateCommand,
+      installTypeDetector: options.installTypeDetector,
+    })
 
     if (result.status === 'failed') {
       reply.code(500)

--- a/src/modules/cli-configuration/interface-adapters/gateways/installTypeDetector.fs.gateway.ts
+++ b/src/modules/cli-configuration/interface-adapters/gateways/installTypeDetector.fs.gateway.ts
@@ -1,0 +1,31 @@
+import { existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { InstallType } from '@/modules/cli-configuration/entities/packageVersion/installType.js'
+import type { InstallTypeDetector } from '@/modules/cli-configuration/entities/packageVersion/installTypeDetector.gateway.js'
+
+function defaultStartPath(): string {
+  return fileURLToPath(new URL('.', import.meta.url))
+}
+
+export class InstallTypeDetectorFsGateway implements InstallTypeDetector {
+  private readonly startPath: string
+
+  constructor(startPath: string = defaultStartPath()) {
+    this.startPath = startPath
+  }
+
+  detect(): InstallType {
+    let current = this.startPath
+    while (true) {
+      if (existsSync(join(current, '.git'))) {
+        return 'source-checkout'
+      }
+      const parent = dirname(current)
+      if (parent === current) {
+        return 'global-npm'
+      }
+      current = parent
+    }
+  }
+}

--- a/src/modules/cli-configuration/usecases/version/checkVersion.usecase.ts
+++ b/src/modules/cli-configuration/usecases/version/checkVersion.usecase.ts
@@ -1,10 +1,12 @@
 import type { VersionCheckResult } from '@/modules/cli-configuration/entities/packageVersion/packageVersion.js'
 import type { PackageVersionGateway } from '@/modules/cli-configuration/entities/packageVersion/packageVersion.gateway.js'
 import type { VersionCachePort } from '@/modules/cli-configuration/entities/packageVersion/versionCache.gateway.js'
+import type { InstallTypeDetector } from '@/modules/cli-configuration/entities/packageVersion/installTypeDetector.gateway.js'
 
 export interface CheckVersionDependencies {
   packageVersionGateway: PackageVersionGateway
   cache: VersionCachePort
+  installTypeDetector: InstallTypeDetector
 }
 
 export interface CheckVersionInput {
@@ -16,7 +18,7 @@ export async function checkVersion(
   input: CheckVersionInput,
   dependencies: CheckVersionDependencies,
 ): Promise<VersionCheckResult> {
-  const { cache } = dependencies
+  const { cache, installTypeDetector } = dependencies
 
   if (!input.forceRefresh && !cache.isExpired()) {
     const cached = cache.get()
@@ -33,6 +35,7 @@ export async function checkVersion(
     latestVersion,
     updateAvailable,
     checkedAt: new Date().toISOString(),
+    installType: installTypeDetector.detect(),
   }
 
   cache.set(result)

--- a/src/modules/cli-configuration/usecases/version/triggerSelfUpdate.usecase.ts
+++ b/src/modules/cli-configuration/usecases/version/triggerSelfUpdate.usecase.ts
@@ -1,14 +1,23 @@
 import type { SelfUpdateResult } from '@/modules/cli-configuration/entities/packageVersion/packageVersion.js'
 import type { SelfUpdateCommandPort } from '@/modules/cli-configuration/entities/packageVersion/selfUpdateCommand.gateway.js'
+import type { InstallTypeDetector } from '@/modules/cli-configuration/entities/packageVersion/installTypeDetector.gateway.js'
+
+export const SOURCE_CHECKOUT_MANUAL_COMMAND =
+  'git pull && yarn build && systemctl --user restart reviewflow-app'
 
 export interface TriggerSelfUpdateDependencies {
   selfUpdateCommand: SelfUpdateCommandPort
+  installTypeDetector: InstallTypeDetector
 }
 
 export async function triggerSelfUpdate(
   dependencies: TriggerSelfUpdateDependencies,
 ): Promise<SelfUpdateResult> {
-  const { selfUpdateCommand } = dependencies
+  const { selfUpdateCommand, installTypeDetector } = dependencies
+
+  if (installTypeDetector.detect() === 'source-checkout') {
+    return { status: 'source-checkout', manualCommand: SOURCE_CHECKOUT_MANUAL_COMMAND }
+  }
 
   const updateResult = await selfUpdateCommand.runGlobalUpdate()
 

--- a/src/tests/factories/packageVersion.factory.ts
+++ b/src/tests/factories/packageVersion.factory.ts
@@ -8,6 +8,7 @@ export class PackageVersionFactory {
       latestVersion: '2.0.0',
       updateAvailable: true,
       checkedAt: '2026-03-14T10:00:00Z',
+      installType: 'global-npm',
       ...overrides,
     }
   }

--- a/src/tests/stubs/installTypeDetector.stub.ts
+++ b/src/tests/stubs/installTypeDetector.stub.ts
@@ -1,0 +1,14 @@
+import type { InstallType } from '@/modules/cli-configuration/entities/packageVersion/installType.js'
+import type { InstallTypeDetector } from '@/modules/cli-configuration/entities/packageVersion/installTypeDetector.gateway.js'
+
+export class StubInstallTypeDetector implements InstallTypeDetector {
+  private readonly value: InstallType
+
+  constructor(value: InstallType = 'global-npm') {
+    this.value = value
+  }
+
+  detect(): InstallType {
+    return this.value
+  }
+}

--- a/src/tests/units/dashboard/modules/versionUpdate.test.ts
+++ b/src/tests/units/dashboard/modules/versionUpdate.test.ts
@@ -7,20 +7,41 @@ const translate = (key: string, params?: Record<string, string | number>) =>
 describe('renderVersionUpdateArea', () => {
   it('renders only the current version label when no update is available', () => {
     const html = renderVersionUpdateArea(
-      { currentVersion: '3.10.0', updateAvailable: false, latestVersion: null },
+      { currentVersion: '3.10.0', updateAvailable: false, latestVersion: null, installType: 'global-npm' },
       translate,
     );
     expect(html).toContain('v3.10.0');
     expect(html).not.toContain('version-update-btn');
   });
 
-  it('renders an update button mentioning the latest version when available', () => {
+  it('renders an update button mentioning the latest version when available on a global-npm install', () => {
     const html = renderVersionUpdateArea(
-      { currentVersion: '3.10.0', updateAvailable: true, latestVersion: '4.0.0' },
+      { currentVersion: '3.10.0', updateAvailable: true, latestVersion: '4.0.0', installType: 'global-npm' },
       translate,
     );
     expect(html).toContain('v3.10.0');
     expect(html).toContain('4.0.0');
     expect(html).toContain('version-update-btn');
+  });
+
+  it('renders a source-checkout info button (not an update button) when running from a source checkout', () => {
+    const html = renderVersionUpdateArea(
+      { currentVersion: '3.10.0', updateAvailable: true, latestVersion: '4.0.0', installType: 'source-checkout' },
+      translate,
+    );
+    expect(html).toContain('v3.10.0');
+    expect(html).toContain('4.0.0');
+    expect(html).toContain('version-source-checkout-btn');
+    expect(html).not.toContain('version-update-btn');
+  });
+
+  it('omits any update or info button on a source-checkout install when no update is available', () => {
+    const html = renderVersionUpdateArea(
+      { currentVersion: '3.10.0', updateAvailable: false, latestVersion: null, installType: 'source-checkout' },
+      translate,
+    );
+    expect(html).toContain('v3.10.0');
+    expect(html).not.toContain('version-update-btn');
+    expect(html).not.toContain('version-source-checkout-btn');
   });
 });

--- a/src/tests/units/entities/packageVersion/packageVersion.test.ts
+++ b/src/tests/units/entities/packageVersion/packageVersion.test.ts
@@ -53,6 +53,7 @@ describe('versionCheckResultSchema', () => {
       latestVersion: '2.0.0',
       updateAvailable: true,
       checkedAt: '2026-03-14T10:00:00Z',
+      installType: 'global-npm',
     }
 
     const result = versionCheckResultSchema.safeParse(checkResult)
@@ -66,6 +67,7 @@ describe('versionCheckResultSchema', () => {
       latestVersion: null,
       updateAvailable: false,
       checkedAt: '2026-03-14T10:00:00Z',
+      installType: 'source-checkout',
     }
 
     const result = versionCheckResultSchema.safeParse(checkResult)
@@ -147,12 +149,14 @@ describe('VersionCheckResult type', () => {
       latestVersion: '2.0.0',
       updateAvailable: true,
       checkedAt: '2026-03-14T10:00:00Z',
+      installType: 'global-npm',
     }
 
     expect(result.currentVersion).toBe('1.0.0')
     expect(result.latestVersion).toBe('2.0.0')
     expect(result.updateAvailable).toBe(true)
     expect(result.checkedAt).toBe('2026-03-14T10:00:00Z')
+    expect(result.installType).toBe('global-npm')
   })
 
   it('should allow null latestVersion', () => {
@@ -161,9 +165,11 @@ describe('VersionCheckResult type', () => {
       latestVersion: null,
       updateAvailable: false,
       checkedAt: '2026-03-14T10:00:00Z',
+      installType: 'source-checkout',
     }
 
     expect(result.latestVersion).toBeNull()
+    expect(result.installType).toBe('source-checkout')
   })
 })
 

--- a/src/tests/units/interface-adapters/controllers/http/version.routes.test.ts
+++ b/src/tests/units/interface-adapters/controllers/http/version.routes.test.ts
@@ -5,8 +5,11 @@ import { versionRoutes } from '@/modules/cli-configuration/interface-adapters/co
 import { StubPackageVersionGateway } from '@/tests/stubs/packageVersion.stub.js'
 import { StubVersionCache } from '@/tests/stubs/versionCache.stub.js'
 import { StubSelfUpdateCommand } from '@/tests/stubs/selfUpdate.stub.js'
+import { StubInstallTypeDetector } from '@/tests/stubs/installTypeDetector.stub.js'
 import { checkVersion } from '@/modules/cli-configuration/usecases/version/checkVersion.usecase.js'
 import { triggerSelfUpdate } from '@/modules/cli-configuration/usecases/version/triggerSelfUpdate.usecase.js'
+
+const installTypeDetector = new StubInstallTypeDetector('global-npm')
 
 describe('version routes', () => {
   let application: FastifyInstance
@@ -25,6 +28,7 @@ describe('version routes', () => {
         packageVersionGateway,
         versionCache,
         selfUpdateCommand,
+        installTypeDetector,
         serverPort: 3000,
       })
       await application.ready()
@@ -41,6 +45,27 @@ describe('version routes', () => {
       expect(body.currentVersion).toBe('1.0.0')
       expect(body.latestVersion).toBe('2.0.0')
       expect(body.updateAvailable).toBe(true)
+      expect(body.installType).toBe('global-npm')
+    })
+
+    it('should expose the detected installType in the response', async () => {
+      const sourceCheckout = new StubInstallTypeDetector('source-checkout')
+      const sourceApp = Fastify()
+      await sourceApp.register(versionRoutes, {
+        checkVersion,
+        triggerSelfUpdate,
+        currentVersion: '1.0.0',
+        packageVersionGateway: new StubPackageVersionGateway('2.0.0'),
+        versionCache: new StubVersionCache(null, true),
+        selfUpdateCommand: new StubSelfUpdateCommand(true),
+        installTypeDetector: sourceCheckout,
+        serverPort: 3000,
+      })
+      await sourceApp.ready()
+
+      const response = await sourceApp.inject({ method: 'GET', url: '/api/version/check' })
+      const body = JSON.parse(response.body)
+      expect(body.installType).toBe('source-checkout')
     })
   })
 
@@ -56,6 +81,7 @@ describe('version routes', () => {
         packageVersionGateway: new StubPackageVersionGateway('2.0.0'),
         versionCache: new StubVersionCache(null, true),
         selfUpdateCommand,
+        installTypeDetector,
         serverPort: 3000,
       })
       await application.ready()
@@ -81,6 +107,7 @@ describe('version routes', () => {
         packageVersionGateway: new StubPackageVersionGateway('2.0.0'),
         versionCache: new StubVersionCache(null, true),
         selfUpdateCommand,
+        installTypeDetector,
         serverPort: 3000,
       })
       await application.ready()
@@ -107,6 +134,7 @@ describe('version routes', () => {
         packageVersionGateway: new StubPackageVersionGateway('2.0.0'),
         versionCache: new StubVersionCache(null, true),
         selfUpdateCommand,
+        installTypeDetector,
         serverPort: 3000,
       })
       await application.ready()
@@ -120,6 +148,44 @@ describe('version routes', () => {
       expect(response.statusCode).toBe(403)
       expect(body.status).toBe('permission-denied')
       expect(body.command).toBe('sudo npm update -g reviewflow')
+    })
+
+    it('should return source-checkout status with manual command and never restart the daemon for source installs', async () => {
+      let restartCalled = false
+      const selfUpdateCommand = new StubSelfUpdateCommand(true)
+      Object.defineProperty(selfUpdateCommand, 'restartDaemon', {
+        value: async () => {
+          restartCalled = true
+        },
+        writable: true,
+        configurable: true,
+      })
+
+      application = Fastify()
+      await application.register(versionRoutes, {
+        checkVersion,
+        triggerSelfUpdate,
+        currentVersion: '1.0.0',
+        packageVersionGateway: new StubPackageVersionGateway('2.0.0'),
+        versionCache: new StubVersionCache(null, true),
+        selfUpdateCommand,
+        installTypeDetector: new StubInstallTypeDetector('source-checkout'),
+        serverPort: 3000,
+      })
+      await application.ready()
+
+      const response = await application.inject({
+        method: 'POST',
+        url: '/api/version/update',
+      })
+
+      const body = JSON.parse(response.body)
+      expect(response.statusCode).toBe(200)
+      expect(body.status).toBe('source-checkout')
+      expect(body.manualCommand).toContain('git pull')
+      expect(body.manualCommand).toContain('yarn build')
+      await new Promise((resolve) => setTimeout(resolve, 1100))
+      expect(restartCalled).toBe(false)
     })
   })
 })

--- a/src/tests/units/interface-adapters/gateways/installTypeDetector.fs.gateway.test.ts
+++ b/src/tests/units/interface-adapters/gateways/installTypeDetector.fs.gateway.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { InstallTypeDetectorFsGateway } from '@/modules/cli-configuration/interface-adapters/gateways/installTypeDetector.fs.gateway.js'
+
+describe('InstallTypeDetectorFsGateway', () => {
+  let tempRoot: string
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'install-type-detector-'))
+  })
+
+  afterEach(() => {
+    rmSync(tempRoot, { recursive: true, force: true })
+  })
+
+  it('returns source-checkout when a .git directory exists at the start path', () => {
+    mkdirSync(join(tempRoot, '.git'))
+    const detector = new InstallTypeDetectorFsGateway(tempRoot)
+
+    expect(detector.detect()).toBe('source-checkout')
+  })
+
+  it('returns source-checkout when a .git directory exists in a parent path', () => {
+    mkdirSync(join(tempRoot, '.git'))
+    const startPath = join(tempRoot, 'dist', 'main')
+    mkdirSync(startPath, { recursive: true })
+    const detector = new InstallTypeDetectorFsGateway(startPath)
+
+    expect(detector.detect()).toBe('source-checkout')
+  })
+
+  it('returns source-checkout when .git is a worktree pointer file', () => {
+    writeFileSync(join(tempRoot, '.git'), 'gitdir: /elsewhere/.git/worktrees/x\n')
+    const detector = new InstallTypeDetectorFsGateway(tempRoot)
+
+    expect(detector.detect()).toBe('source-checkout')
+  })
+
+  it('returns global-npm when no .git exists anywhere from the start path up to the filesystem root', () => {
+    const startPath = join(tempRoot, 'lib', 'node_modules', 'reviewflow', 'dist')
+    mkdirSync(startPath, { recursive: true })
+    const detector = new InstallTypeDetectorFsGateway(startPath)
+
+    expect(detector.detect()).toBe('global-npm')
+  })
+})

--- a/src/tests/units/usecases/version/checkVersion.usecase.test.ts
+++ b/src/tests/units/usecases/version/checkVersion.usecase.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect } from 'vitest'
 import { checkVersion } from '@/modules/cli-configuration/usecases/version/checkVersion.usecase.js'
 import { StubPackageVersionGateway } from '@/tests/stubs/packageVersion.stub.js'
 import { StubVersionCache } from '@/tests/stubs/versionCache.stub.js'
+import { StubInstallTypeDetector } from '@/tests/stubs/installTypeDetector.stub.js'
 import { PackageVersionFactory } from '@/tests/factories/packageVersion.factory.js'
+
+const installTypeDetector = new StubInstallTypeDetector('global-npm')
 
 describe('checkVersion usecase', () => {
   it('should return cached result when cache is valid and not force refresh', async () => {
@@ -12,7 +15,7 @@ describe('checkVersion usecase', () => {
 
     const result = await checkVersion(
       { currentVersion: '1.0.0', forceRefresh: false },
-      { packageVersionGateway: gateway, cache },
+      { packageVersionGateway: gateway, cache, installTypeDetector },
     )
 
     expect(result).toEqual(cachedResult)
@@ -24,7 +27,7 @@ describe('checkVersion usecase', () => {
 
     const result = await checkVersion(
       { currentVersion: '1.0.0', forceRefresh: false },
-      { packageVersionGateway: gateway, cache },
+      { packageVersionGateway: gateway, cache, installTypeDetector },
     )
 
     expect(result.currentVersion).toBe('1.0.0')
@@ -42,7 +45,7 @@ describe('checkVersion usecase', () => {
 
     const result = await checkVersion(
       { currentVersion: '1.0.0', forceRefresh: true },
-      { packageVersionGateway: gateway, cache },
+      { packageVersionGateway: gateway, cache, installTypeDetector },
     )
 
     expect(result.latestVersion).toBe('3.0.0')
@@ -55,7 +58,7 @@ describe('checkVersion usecase', () => {
 
     const result = await checkVersion(
       { currentVersion: '1.0.0', forceRefresh: false },
-      { packageVersionGateway: gateway, cache },
+      { packageVersionGateway: gateway, cache, installTypeDetector },
     )
 
     expect(result.updateAvailable).toBe(true)
@@ -67,7 +70,7 @@ describe('checkVersion usecase', () => {
 
     const result = await checkVersion(
       { currentVersion: '1.0.0', forceRefresh: false },
-      { packageVersionGateway: gateway, cache },
+      { packageVersionGateway: gateway, cache, installTypeDetector },
     )
 
     expect(result.updateAvailable).toBe(false)
@@ -79,7 +82,7 @@ describe('checkVersion usecase', () => {
 
     const result = await checkVersion(
       { currentVersion: '1.0.0', forceRefresh: false },
-      { packageVersionGateway: gateway, cache },
+      { packageVersionGateway: gateway, cache, installTypeDetector },
     )
 
     expect(result.latestVersion).toBeNull()
@@ -92,7 +95,7 @@ describe('checkVersion usecase', () => {
 
     await checkVersion(
       { currentVersion: '1.0.0', forceRefresh: false },
-      { packageVersionGateway: gateway, cache },
+      { packageVersionGateway: gateway, cache, installTypeDetector },
     )
 
     const cached = cache.get()
@@ -100,5 +103,18 @@ describe('checkVersion usecase', () => {
     expect(cached?.currentVersion).toBe('1.0.0')
     expect(cached?.latestVersion).toBe('2.0.0')
     expect(cached?.updateAvailable).toBe(true)
+  })
+
+  it('should include installType detected at fetch time', async () => {
+    const cache = new StubVersionCache(null, true)
+    const gateway = new StubPackageVersionGateway('2.0.0')
+    const sourceCheckout = new StubInstallTypeDetector('source-checkout')
+
+    const result = await checkVersion(
+      { currentVersion: '1.0.0', forceRefresh: false },
+      { packageVersionGateway: gateway, cache, installTypeDetector: sourceCheckout },
+    )
+
+    expect(result.installType).toBe('source-checkout')
   })
 })

--- a/src/tests/units/usecases/version/triggerSelfUpdate.usecase.test.ts
+++ b/src/tests/units/usecases/version/triggerSelfUpdate.usecase.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect } from 'vitest'
 import { triggerSelfUpdate } from '@/modules/cli-configuration/usecases/version/triggerSelfUpdate.usecase.js'
 import { StubSelfUpdateCommand } from '@/tests/stubs/selfUpdate.stub.js'
+import { StubInstallTypeDetector } from '@/tests/stubs/installTypeDetector.stub.js'
+
+const globalNpm = new StubInstallTypeDetector('global-npm')
 
 describe('triggerSelfUpdate usecase', () => {
   it('should return started when update succeeds', async () => {
     const selfUpdateCommand = new StubSelfUpdateCommand(true)
 
-    const result = await triggerSelfUpdate({ selfUpdateCommand })
+    const result = await triggerSelfUpdate({ selfUpdateCommand, installTypeDetector: globalNpm })
 
     expect(result).toEqual({ status: 'started' })
   })
@@ -14,7 +17,7 @@ describe('triggerSelfUpdate usecase', () => {
   it('should return failed with error message when update fails', async () => {
     const selfUpdateCommand = new StubSelfUpdateCommand(false, 'npm update failed')
 
-    const result = await triggerSelfUpdate({ selfUpdateCommand })
+    const result = await triggerSelfUpdate({ selfUpdateCommand, installTypeDetector: globalNpm })
 
     expect(result).toEqual({ status: 'failed', error: 'npm update failed' })
   })
@@ -22,7 +25,7 @@ describe('triggerSelfUpdate usecase', () => {
   it('should return failed with default error when no error message provided', async () => {
     const selfUpdateCommand = new StubSelfUpdateCommand(false)
 
-    const result = await triggerSelfUpdate({ selfUpdateCommand })
+    const result = await triggerSelfUpdate({ selfUpdateCommand, installTypeDetector: globalNpm })
 
     expect(result).toEqual({ status: 'failed', error: 'Unknown error' })
   })
@@ -30,8 +33,20 @@ describe('triggerSelfUpdate usecase', () => {
   it('should return permission-denied with command when permission is denied', async () => {
     const selfUpdateCommand = new StubSelfUpdateCommand(false, 'EACCES', true)
 
-    const result = await triggerSelfUpdate({ selfUpdateCommand })
+    const result = await triggerSelfUpdate({ selfUpdateCommand, installTypeDetector: globalNpm })
 
     expect(result).toEqual({ status: 'permission-denied', command: 'sudo npm update -g reviewflow' })
+  })
+
+  it('should short-circuit with source-checkout status and manual command when running from a source checkout', async () => {
+    const selfUpdateCommand = new StubSelfUpdateCommand(true)
+    const sourceCheckout = new StubInstallTypeDetector('source-checkout')
+
+    const result = await triggerSelfUpdate({ selfUpdateCommand, installTypeDetector: sourceCheckout })
+
+    expect(result).toEqual({
+      status: 'source-checkout',
+      manualCommand: 'git pull && yarn build && systemctl --user restart reviewflow-app',
+    })
   })
 })


### PR DESCRIPTION
Closes #156.

## Summary

When ReviewFlow runs as a daemon from a source checkout (systemd service running `node dist/main/cli.js` from a cloned repo), the dashboard "update" button used to run `npm update -g reviewflow` — which updates the unrelated global npm package, never the running daemon. The endpoint returned `status: "started"`, the UI showed "restarting…", and the daemon was relaunched against the same stale `dist/`. Result: an infinite "update available" nag with a falsely-reported restart.

## Detection

- New `InstallTypeDetector` port + filesystem implementation that walks up from the running module to find a `.git` ancestor
- `VersionCheckResult` now carries `installType`, surfaced by the `/api/version/check` endpoint so the dashboard can adapt its UI

## Behavior

- `triggerSelfUpdate` short-circuits with a new `"source-checkout"` status and a `manualCommand` string before ever invoking `npm update -g`
- The `/api/version/update` endpoint never schedules a daemon restart in the source-checkout case

## Test plan

- [x] `yarn verify` passes locally (1493 tests, typecheck + lint OK)
- [ ] On the live systemd daemon: `curl localhost:3847/api/version/check` returns `installType: "source-checkout"`
- [ ] Click the dashboard "update" button → no spurious restart, UI shows the manual command instead of a fake "restarting…"
- [ ] On an npm-global install (if reproducible), the old npm-update path still triggers