### PR TITLE
docs(specs): restore SPEC-168/169/170 for claude -p to --bg migration

### DIFF
--- a/docs/feature-tracker.md
+++ b/docs/feature-tracker.md
@@ -33,3 +33,6 @@
 | Developer & team insights | [125-developer-team-insights](specs/125-developer-team-insights.md) | implemented | 2026-04-01 |
 | Hybrid model routing + token tracking | (no spec — see report) | implemented | 2026-05-14 |
 | Skill templates | [skill-templates](specs/skill-templates.md) | drafted | 2026-03-14 |
+| Validate --bg subscription billing (POC) | [168-validate-bg-subscription-billing](specs/168-validate-bg-subscription-billing.md) | drafted | 2026-05-22 |
+| Migrate Claude invocation -p → --bg | [169-migrate-claude-invocation-to-bg-mode](specs/169-migrate-claude-invocation-to-bg-mode.md) | drafted | 2026-05-22 |
+| Pre-built worktree lifecycle | [170-prebuilt-worktree-lifecycle](specs/170-prebuilt-worktree-lifecycle.md) | drafted | 2026-05-22 |

--- a/docs/specs/168-validate-bg-subscription-billing.md
+++ b/docs/specs/168-validate-bg-subscription-billing.md
@@ -1,0 +1,169 @@
+---
+title: "SPEC-168: Validate --bg Subscription Billing (POC)"
+labels: validation, P1-critical, claude-invocation
+milestone: June 15 Migration
+status: DRAFT
+---
+
+# SPEC-168: Validate `--bg` Subscription Billing (POC)
+
+## Problem Statement
+
+On 2026-06-15, Anthropic will move Claude Code `--print` (`-p`) mode invocations to API-pool billing. Subscription Pro/Max coverage will no longer apply to programmatic `claude -p` usage. ReviewFlow currently spawns `claude -p` from `claudeInvoker.ts` for every review, exposing the project to ~$1,549/month at API rates against a $200/month budget.
+
+The documented replacement path is `claude --bg`, which the official agent-view documentation describes as subscription-billed: *"background sessions consume your subscription usage the same as interactive sessions"*. However, this is a research-preview feature and the claim has not been empirically verified on ReviewFlow's production environment.
+
+Before re-architecting `claudeInvoker.ts` and migrating 620+ reviews/month, the subscription-billing hypothesis must be validated end-to-end on the actual production server. A failed validation invalidates SPEC-169 and SPEC-170 entirely — the whole migration strategy fails.
+
+## User Story
+
+**As** the operator of ReviewFlow,
+**I want** to empirically confirm that `claude --bg` invocations on the production server consume the OAuth claude.ai subscription pool and never the API pool,
+**So that** I can commit to the full migration (SPEC-169) with evidence rather than documentation hopium.
+
+## Scope
+
+### In Scope
+
+| # | Capability | Description |
+|---|------------|-------------|
+| 1 | Single review dispatched via `claude --bg` | One real review (not a fake/test prompt) triggered through ReviewFlow on the prod server, switched from `-p` to `--bg` for this single invocation |
+| 2 | Authentication via OAuth claude.ai | The session runs under the existing `claude /login` OAuth credentials on the prod server. No `ANTHROPIC_API_KEY` env var, no API key anywhere |
+| 3 | Observable proof of subscription billing | Verifiable signal that the consumed quota came from the Pro/Max pool (Anthropic Console usage page, `claude /usage` output, or absence of API charges in the API billing dashboard) |
+| 4 | Observable proof of NO API billing | No new API charge appears on the API billing dashboard during the test window |
+| 5 | Documented GO/NO-GO decision | A short report (`docs/reports/168-validate-bg-subscription-billing.report.md`) capturing the evidence and the decision |
+
+### Out of Scope
+
+| Item | Reason |
+|------|--------|
+| Refactoring `claudeInvoker.ts` for all reviews | That is SPEC-169's job. This spec only switches one invocation |
+| Worktree lifecycle management | SPEC-170 territory |
+| Rate limit measurement / concurrent sessions test | A POC focused on billing, not on capacity |
+| ProgressParser adaptation | This spec accepts that the single test review may have degraded progress reporting |
+| Production deployment of the change | The switched invocation can be a temporary patch, reverted after evidence collection |
+| Multi-project validation | A single project (main-app-v3) is sufficient to prove or disprove the billing model |
+
+## Functional Requirements
+
+### FR-1: Single-Invocation Switch
+
+A single, controlled `claude -p` call in `claudeInvoker.ts` is temporarily replaced by `claude --bg "<prompt>"` for the duration of the test, behind a feature flag or a hardcoded condition (e.g., job ID match). Other reviews continue on `-p` to keep the prod system functional during the experiment.
+
+### FR-2: OAuth-Only Authentication
+
+Before launching the test review, the operator verifies on the prod server:
+- No `ANTHROPIC_API_KEY` environment variable is set in the `reviewflow-app` systemd service environment.
+- `claude auth status` (run as the `reviewflow-app` user) reports a claude.ai OAuth session, not an API key.
+
+If either check fails, the spec is BLOCKED until OAuth-only auth is confirmed.
+
+### FR-3: Test Invocation
+
+The operator triggers one real review on a real MR (production data, not synthetic). The `--bg` session ID is captured. The review runs to completion (or failure) and the result is observed.
+
+### FR-4: Billing Evidence Collection
+
+Within 24 hours of the test invocation, the operator collects:
+- A screenshot or export of the Pro/Max usage page showing the test session's token consumption.
+- A screenshot or export of the API billing dashboard showing **no new charge** for the test window.
+- `claude /usage` output before and after the test (if available).
+
+### FR-5: GO/NO-GO Decision Report
+
+A report at `docs/reports/168-validate-bg-subscription-billing.report.md` is produced with:
+- The evidence collected (FR-4).
+- A binary verdict: **GO** (proceed with SPEC-169) or **NO-GO** (abort migration, escalate).
+- If NO-GO: the observed billing behavior and proposed next step.
+
+## Gherkin Scenarios
+
+```gherkin
+Feature: Empirical validation of --bg subscription billing
+
+  Background:
+    Given the reviewflow-app systemd service runs under a user authenticated via `claude /login`
+    And no ANTHROPIC_API_KEY environment variable is set for that user
+    And `claude --version` reports v2.1.139 or later on the prod server
+
+  Scenario: One review is dispatched via --bg and consumes subscription pool
+    Given ReviewFlow is patched to spawn `claude --bg` for one specific test MR
+    When a real webhook triggers a review on that test MR
+    Then a background session ID is returned by the claude binary
+    And the session completes (or fails) within the normal review timeout
+    And within 24 hours, the Pro/Max usage dashboard shows token consumption attributed to this session
+    And within 24 hours, the API billing dashboard shows zero new charges for the test window
+
+  Scenario: GO decision when subscription billing is confirmed
+    Given the test review completed
+    And evidence shows Pro/Max consumption and zero API charges
+    Then a GO report is written documenting the evidence
+    And SPEC-169 is unblocked
+
+  Scenario: NO-GO decision when API billing is observed
+    Given the test review completed
+    And the API billing dashboard shows any new charge attributable to the test
+    Then a NO-GO report is written documenting the observation
+    And SPEC-169 and SPEC-170 are marked blocked
+    And the operator is alerted to escalate (Anthropic support, alternate strategy)
+
+  Scenario: Prerequisite check fails — OAuth not active
+    Given the reviewflow-app user has no active claude.ai OAuth session
+    Or an ANTHROPIC_API_KEY is set in the service environment
+    Then the test is not run
+    And the spec is blocked pending OAuth setup
+```
+
+## RICE Score
+
+| Criteria | Score | Justification |
+|----------|-------|---------------|
+| Reach | 10 | Validates the entire claude-invocation path for all reviews across the platform |
+| Impact | 3 | Critical — wrong hypothesis = entire migration fails = ReviewFlow unsustainable post-15-juin |
+| Confidence | 80% | Doc strongly suggests subscription billing, but research preview means empirical proof is mandatory |
+| Effort | 1 pt | Small, surgical change. Bulk of effort is evidence collection, not coding |
+| **Score** | **24.0** | |
+
+Priority: **Critical**
+
+## INVEST Validation
+
+| Criterion | Pass | Rationale |
+|-----------|------|-----------|
+| Independent | Yes | Standalone validation. No dependency on SPEC-169 or SPEC-170 (those depend on this) |
+| Negotiable | Yes | The exact patching mechanism (feature flag vs hardcoded condition vs branch deploy) is open |
+| Valuable | Yes | Removes the largest unknown in the migration strategy. Failure here saves days of wasted refactor |
+| Estimable | Yes | ~0.25 jour IA for the code change. Evidence collection is wall-clock time, not effort |
+| Small | Yes | One file touched, one invocation switched, one report produced |
+| Testable | Yes | Binary outcome: Pro/Max usage visible AND zero API charge = GO. Otherwise = NO-GO |
+
+## Definition of Done
+
+- [ ] FR-1 implemented (single `claude --bg` invocation in `claudeInvoker.ts`, gated)
+- [ ] FR-2 verified (OAuth-only auth confirmed on prod server, evidence stored in report)
+- [ ] FR-3 executed (one real review dispatched, session ID captured, completion observed)
+- [ ] FR-4 collected (Pro/Max usage evidence + API billing zero-charge evidence)
+- [ ] FR-5 written (`docs/reports/168-validate-bg-subscription-billing.report.md` with verdict)
+- [ ] Tracker updated: SPEC-168 → status `implemented` after report merged
+- [ ] If GO: SPEC-169 unblocked
+- [ ] If NO-GO: SPEC-169 and SPEC-170 set to status `blocked`, escalation logged
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| `--bg` | Claude Code CLI flag launching an interactive session in background, managed by a per-user supervisor daemon. Documented at https://code.claude.com/docs/en/agent-view |
+| Subscription pool | Token quota covered by an active Claude Pro/Max plan, billed flat-rate monthly |
+| API pool | Per-token billing via an Anthropic API key, separate from subscription |
+| OAuth claude.ai | Authentication method used by `claude /login`, distinct from API key auth |
+| Research preview | Anthropic status indicating a feature is functional but subject to API/contract change |
+| GO/NO-GO | Binary decision gate: GO unblocks downstream specs; NO-GO halts the migration strategy |
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Pro/Max usage page doesn't itemize per-session — billing evidence is ambiguous | Compare aggregate usage before/after; supplement with API dashboard zero-charge |
+| Anthropic changes `--bg` behavior between POC and SPEC-169 production rollout | Run SPEC-169 within 1 week of SPEC-168 completion |
+| The single test review is atypical (small diff, easy review) — billing extrapolation is unreliable | Pick a typical review (~300 lines diff, full agent run) for the test |
+| OAuth session expires mid-test | Verify `claude auth status` before launch and immediately after |

--- a/docs/specs/169-migrate-claude-invocation-to-bg-mode.md
+++ b/docs/specs/169-migrate-claude-invocation-to-bg-mode.md
@@ -1,0 +1,247 @@
+---
+title: "SPEC-169: Migrate Claude Invocation from -p to --bg Mode"
+labels: enhancement, P1-critical, claude-invocation
+milestone: June 15 Migration
+status: DRAFT
+blocked-by: SPEC-168
+---
+
+# SPEC-169: Migrate Claude Invocation from `-p` to `--bg` Mode
+
+## Problem Statement
+
+After SPEC-168 validates the subscription-billing hypothesis, ReviewFlow must permanently replace all `claude -p` invocations with `claude --bg` before 2026-06-15. The current `claudeInvoker.ts` spawns Claude with `-p` and parses `stream-json` output for progress tracking. This entire invocation pattern must be replaced with a background-session model: dispatch via `claude --bg`, track completion through multiple complementary signals, retrieve the review report from a known file, and clean up the session afterwards.
+
+The migration also introduces operational concerns absent in the `-p` model: rate-limit handling (Anthropic Pro/Max subscription quotas may cap concurrent sessions), supervisor process lifecycle (the per-user daemon hosting `--bg` sessions can crash or restart), and billing-regression detection (if Anthropic changes `--bg` behavior post-deployment, the system must alert rather than silently overcharge).
+
+ReviewFlow will never request an Anthropic API key. Authentication is exclusively through `claude /login` OAuth on the operator's account.
+
+## User Story
+
+**As** the operator of ReviewFlow,
+**I want** every review and followup to dispatch via `claude --bg` instead of `claude -p`, with robust completion detection, rate-limit handling, and billing-regression alerting,
+**So that** the system continues operating under subscription billing after 2026-06-15 without per-token charges or silent failures.
+
+## Scope
+
+### In Scope
+
+| # | Capability | Description |
+|---|------------|-------------|
+| 1 | Replace `-p` spawn with `--bg` dispatch | `claudeInvoker.ts` spawns `claude --bg "<prompt>"` for every review/followup, captures the returned session ID |
+| 2 | Triple completion detection | Completion detected via (a) MCP `set_phase("completed")` primary, (b) `claude agents --json` polling fallback every 30s, (c) hard timeout at 15 minutes |
+| 3 | Report retrieval from known file | After completion, the review markdown is read from `.claude/reviews/YYYY-MM-DD-MR-XXXX-review.md` (existing skill convention) |
+| 4 | Session cleanup | After report extraction, the session is stopped (`claude stop <id>`) and removed (`claude rm <id>`) |
+| 5 | Rate-limit handling | If `claude --bg` returns a rate-limit error, the job is re-enqueued with exponential backoff (no job loss) |
+| 6 | Supervisor health monitoring | A supervisor crash (detected via `claude daemon status`) emits a critical log and dashboard alert |
+| 7 | Billing-regression alert | If a session is observed to consume the API pool (detectable via env-var presence or `claude /usage` output), a critical alert is emitted and dispatching is paused |
+| 8 | OAuth-only invocation | The spawned `claude --bg` process runs without `ANTHROPIC_API_KEY` in its environment, ever |
+| 9 | ProgressParser simplification | The `--output-format stream-json` parser is removed or stubbed; progress signal flows exclusively through the existing MCP `review-progress` server |
+| 10 | Zero remaining `-p` invocations | A grep on the codebase confirms `claude -p` and `claude --print` no longer appear in production paths |
+
+### Out of Scope
+
+| Item | Reason |
+|------|--------|
+| Worktree lifecycle pre-management | SPEC-170. This spec lets Claude create its own worktree via `--bg` default behavior |
+| Automatic rollback to `-p` on failure | Operator explicitly declined a rollback flag. Monitoring + manual revert if needed |
+| BYOK or any API-key code path | ReviewFlow never asks for API keys. Out of scope by product principle |
+| Refactoring the MCP `review-progress` server | The MCP contract is unchanged. Only the consumer side of completion signals adapts |
+| Migrating dashboard's manual followup trigger | The same `claudeInvoker.ts` change covers both webhook and manual paths automatically |
+| Multi-tenant subscription pooling | One operator, one Pro/Max account. Multi-tenancy is a separate product question |
+| `--output-format` JSON re-introduction in `--bg` mode | Not needed — MCP review-progress carries all required progress signals |
+
+## Functional Requirements
+
+### FR-1: Background Dispatch
+
+In `claudeInvoker.ts`, the current `spawn('claude', ['-p', ...args])` is replaced by a shell invocation of `claude --bg "<prompt>"` with the same `--model`, `--mcp-config`, `--strict-mcp-config`, `--append-system-prompt`, `--allowedTools`, `--disallowedTools`, `--permission-mode bypassPermissions`, and `--dangerously-skip-permissions` flags. The output is parsed to extract the session short ID (e.g., `7c5dcf5d`).
+
+### FR-2: Triple Completion Detection
+
+Three independent completion signals are evaluated; the first that fires wins:
+
+1. **MCP primary**: The MCP `review-progress` server (already in use) reports `set_phase("completed")` or `set_phase("failed")` for the job. ReviewFlow's MCP listener bridges this to the invocation flow.
+2. **Polling fallback**: Every 30 seconds, `claude agents --json` is run; the entry matching the captured session ID is inspected. Status `completed`, `failed`, or `stopped` triggers completion.
+3. **Hard timeout**: 15 minutes of wall-clock from dispatch without any completion signal triggers a forced stop (`claude stop <id>`), marks the job as failed with reason `timeout`, and emits an error log.
+
+### FR-3: Report Retrieval
+
+After completion (success path), ReviewFlow reads the markdown report from the path produced by the review skill (existing convention: `.claude/reviews/YYYY-MM-DD-MR-XXXX-review.md` for reviews, `.claude/reviews/YYYY-MM-DD-MR-XXXX-followup.md` for followups). If the file is absent after completion, the job is marked failed with reason `report-missing`.
+
+### FR-4: Session Cleanup
+
+After report extraction (or on timeout/failure paths), `claude stop <id>` followed by `claude rm <id>` is invoked. Failures of these cleanup commands are logged as warnings but do not fail the job.
+
+### FR-5: Rate-Limit Handling
+
+If `claude --bg` exits with a rate-limit error (detected via exit code or stderr pattern matching), the job is re-enqueued with an exponential backoff schedule (initial 60s, doubling, max 15min, max 5 retries). No job is silently dropped.
+
+### FR-6: Supervisor Health Monitoring
+
+A background check runs every 5 minutes via `claude daemon status`. If the supervisor is unreachable, a critical log entry is emitted and the dashboard surfaces a "Claude supervisor down" alert. While the supervisor is down, no new dispatches are attempted; in-flight jobs continue to be tracked.
+
+### FR-7: Billing-Regression Detection
+
+Two protective checks:
+
+1. **Pre-dispatch**: Before each `claude --bg` invocation, the process environment is verified free of `ANTHROPIC_API_KEY`. Presence aborts the dispatch with a critical error.
+2. **Periodic billing audit**: Every hour, `claude /usage` (or equivalent diagnostic) is parsed. If the output indicates API-pool consumption, a critical alert is emitted and dispatching is paused pending operator review.
+
+### FR-8: ProgressParser Simplification
+
+The `streamJsonParser.ts` consumer in `claudeInvoker.ts` is removed (or made a no-op for backward compatibility tests). `progressParser.ts` is simplified to only consume MCP-originated events, since `--bg` interactive sessions do not emit `stream-json` to stdout.
+
+### FR-9: Codebase Cleanup
+
+A final check (e.g., a grep in CI) verifies that production source files (`src/**`) contain no remaining `claude -p` or `claude --print` invocations.
+
+## Gherkin Scenarios
+
+```gherkin
+Feature: Migrate every Claude invocation to --bg mode
+
+  Background:
+    Given SPEC-168 has reported GO
+    And the reviewflow-app systemd service runs under a user authenticated via claude /login
+    And no ANTHROPIC_API_KEY environment variable is set in the service environment
+
+  Scenario: Webhook triggers review dispatched via --bg
+    Given a tracked GitLab MR receives a new review-request webhook
+    When the review job is dequeued
+    Then claudeInvoker spawns `claude --bg "<prompt>"` with the configured flags
+    And a session ID is captured from the command output
+    And the job state stores the session ID
+    And no `claude -p` or `claude --print` invocation occurs
+
+  Scenario: Completion detected via MCP primary signal
+    Given a --bg session is dispatched
+    When the MCP review-progress server reports set_phase("completed") for the job
+    Then the review report is read from `.claude/reviews/YYYY-MM-DD-MR-XXXX-review.md`
+    And the session is stopped via `claude stop <id>`
+    And the session is removed via `claude rm <id>`
+    And the job is marked completed
+
+  Scenario: Completion detected via polling fallback
+    Given a --bg session is dispatched
+    And the MCP review-progress server emits no completion signal
+    When `claude agents --json` reports status "completed" for the session ID
+    Then the review report is read from the conventional path
+    And cleanup proceeds as above
+    And the job is marked completed
+
+  Scenario: Hard timeout reached without completion signal
+    Given a --bg session is dispatched
+    And 15 minutes elapse without any completion signal
+    Then `claude stop <id>` is invoked
+    And `claude rm <id>` is invoked
+    And the job is marked failed with reason "timeout"
+    And an error log is emitted
+
+  Scenario: Report file missing after completion
+    Given a --bg session reports completion (via MCP or polling)
+    And the expected report file does not exist
+    Then the job is marked failed with reason "report-missing"
+    And cleanup proceeds as above
+    And an error log is emitted
+
+  Scenario: Rate limit error on dispatch
+    Given the Anthropic subscription rate limit has been hit
+    When claudeInvoker attempts `claude --bg "<prompt>"`
+    And the command exits with a rate-limit error
+    Then the job is re-enqueued with exponential backoff (60s initial)
+    And up to 5 retries are attempted with doubling delay
+    And no job is silently dropped
+
+  Scenario: Supervisor down detection
+    Given the Claude supervisor daemon has crashed
+    When the periodic health check runs `claude daemon status`
+    And the command reports unreachable
+    Then a critical log entry is emitted
+    And the dashboard surfaces a "Claude supervisor down" alert
+    And no new dispatches are attempted until the supervisor recovers
+
+  Scenario: Billing regression detected pre-dispatch
+    Given ANTHROPIC_API_KEY has somehow been set in the service environment
+    When claudeInvoker prepares to dispatch a job
+    Then the dispatch is aborted before invoking claude
+    And a critical alert is emitted
+    And the job is marked failed with reason "billing-regression-prevented"
+
+  Scenario: Periodic billing audit detects API consumption
+    Given the periodic billing audit runs
+    When `claude /usage` indicates API-pool consumption
+    Then a critical alert is emitted
+    And the dispatch queue is paused
+    And the dashboard surfaces a "Billing regression suspected" alert
+
+  Scenario: Followup job uses same --bg dispatch path
+    Given a tracked MR receives a push webhook triggering a followup
+    When the followup job is dequeued
+    Then the same claudeInvoker code path is used
+    And the followup runs via `claude --bg` with the followup skill prompt
+    And completion, cleanup, and report retrieval work identically to a review
+```
+
+## RICE Score
+
+| Criteria | Score | Justification |
+|----------|-------|---------------|
+| Reach | 10 | Every review and followup goes through `claudeInvoker.ts` — entire platform impact |
+| Impact | 3 | Critical — failure blocks all reviews post-15-juin, or causes uncontrolled API billing |
+| Confidence | 80% | Architecture is clear, dependencies on SPEC-168 outcome reduce certainty until POC done |
+| Effort | 3 pts | Multiple files, three completion mechanisms, rate limit + supervisor + billing protections |
+| **Score** | **8.0** | |
+
+Priority: **Critical**
+
+## INVEST Validation
+
+| Criterion | Pass | Rationale |
+|-----------|------|-----------|
+| Independent | WARN | Depends on SPEC-168 outcome. Otherwise standalone (no SPEC-170 dependency) |
+| Negotiable | Yes | Polling interval (30s), timeout (15min), retry policy (60s/5x), audit cadence (hourly) all tunable |
+| Valuable | Yes | Unblocks ReviewFlow's continued operation past 2026-06-15. Existential value |
+| Estimable | Yes | ~0.5-0.75 jour IA. Clear file list, clear mechanisms, no architectural unknowns |
+| Small | WARN | Borderline: ~5-8 files touched. Splitting further (e.g., rate-limit as a separate spec) would slow delivery. Acceptable |
+| Testable | Yes | Each scenario has deterministic inputs/outputs. Mocks for `claude` binary and MCP server enable unit-level coverage |
+
+## Definition of Done
+
+- [ ] FR-1: `claudeInvoker.ts` dispatches via `claude --bg`, no `-p` flag remains in production code
+- [ ] FR-2: Three completion signals implemented (MCP, polling, timeout), first-wins logic verified
+- [ ] FR-3: Report retrieved from `.claude/reviews/YYYY-MM-DD-MR-XXXX-{review,followup}.md`
+- [ ] FR-4: Cleanup (`claude stop` + `claude rm`) runs in all completion paths
+- [ ] FR-5: Rate-limit detection + exponential backoff re-enqueue
+- [ ] FR-6: Supervisor health check every 5min + dashboard alert
+- [ ] FR-7: Pre-dispatch ANTHROPIC_API_KEY check + hourly billing audit
+- [ ] FR-8: `streamJsonParser.ts` removed or no-op; `progressParser.ts` consumes only MCP events
+- [ ] FR-9: CI grep confirms zero `claude -p` / `claude --print` in `src/**`
+- [ ] All scenarios covered by passing tests (unit + integration)
+- [ ] `yarn verify` passes (typecheck + lint + test:ci)
+- [ ] Acceptance test GREEN at `src/tests/acceptance/169-migrate-claude-invocation-to-bg-mode.acceptance.test.ts`
+- [ ] Imports use `@/` alias + `.js` extension
+- [ ] No `any`, no `as Type`, full words in naming
+- [ ] Deployed to prod before 2026-06-10 (5-day safety margin before billing change)
+- [ ] Tracker updated: SPEC-169 → status `implemented`
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| `--bg` | Claude Code background invocation mode, subscription-billed (per SPEC-168 verdict) |
+| Session ID | Short alphanumeric identifier returned by `claude --bg`, used with `claude attach/logs/stop/rm` |
+| Supervisor | Per-user daemon hosting `--bg` sessions, managed by Claude Code, distinct from ReviewFlow process |
+| Completion signal | Any of: MCP `set_phase("completed")`, `claude agents --json` status, or 15-min timeout |
+| Billing regression | Observation that a `--bg` session consumed API pool instead of subscription pool |
+| OAuth claude.ai | The only authentication method ReviewFlow ever uses. No API keys, ever |
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| MCP `set_phase` reliability unknown in `--bg` mode (vs. `-p` where it was tested) | Polling fallback (FR-2.b) plus hard timeout (FR-2.c) compensate |
+| Anthropic rate limits for Pro/Max in `--bg` mode unknown | FR-5 ensures jobs are queued, not dropped. Operator monitors quota dashboards |
+| Supervisor daemon crash during heavy load | FR-6 alert; manual `claude daemon restart` recovers. Sessions resume on supervisor return |
+| Anthropic changes `--bg` behavior between deployment and 15-juin | Deploy ≥5 days before. Operator-led monitoring catches drift |
+| Report file race condition (read before Claude finished writing) | Read only after completion signal; verify file mtime > dispatch time; add small post-completion delay if needed |

--- a/docs/specs/170-prebuilt-worktree-lifecycle.md
+++ b/docs/specs/170-prebuilt-worktree-lifecycle.md
@@ -1,0 +1,265 @@
+---
+title: "SPEC-170: Pre-built Worktree Lifecycle Managed by ReviewFlow"
+labels: enhancement, P2-important, worktree, webhook
+milestone: June 15 Migration
+status: DRAFT
+blocked-by: SPEC-169
+---
+
+# SPEC-170: Pre-built Worktree Lifecycle Managed by ReviewFlow
+
+## Problem Statement
+
+After SPEC-169 migrates the project to `claude --bg`, Claude creates its own worktree on-demand from HEAD of the launch directory, under `.claude/worktrees/`. This default behavior has two limitations for ReviewFlow's review workflow:
+
+1. **Wrong branch**: Claude's worktree starts from the local repo's HEAD, not the MR's source branch. Reviews end up reading "the wrong code" — the system prompt has historically contained a 500-token disclaimer (`buildMcpSystemPrompt`) telling Claude that local state is UNRELIABLE and to fetch the diff via `glab mr diff` / `gh pr diff`. This works but wastes tokens on every review and limits Claude's ability to navigate the actual code.
+2. **No lifecycle management**: Worktrees accumulate without explicit cleanup. Claude's supervisor reclaims idle sessions after ~1 hour, but the worktrees themselves can persist indefinitely. With 100+ concurrent open MRs on a large monorepo, disk usage grows uncontrolled.
+
+By having ReviewFlow pre-create the worktree on the MR's actual source branch and explicitly manage its lifecycle (create on open/push, remove on merge/close, sweep stale after 7 days), three benefits unlock:
+- Claude reads the real branch state — agents like `clean-architecture`, `react-best-practices` become substantially more accurate.
+- The "local state UNRELIABLE" disclaimer disappears from the system prompt (~500 tokens saved per review).
+- Disk usage stays bounded: roughly one worktree per open MR.
+
+## User Story
+
+**As** the operator of ReviewFlow,
+**I want** every review to run inside a pre-built git worktree checked out on the MR's source branch, with lifecycle tied to webhook events (open → create, merge/close → remove) plus a daily sweep for orphans,
+**So that** reviews see the actual code being reviewed, the system prompt is leaner, and disk usage stays bounded over time.
+
+## Scope
+
+### In Scope
+
+| # | Capability | Description |
+|---|------------|-------------|
+| 1 | Worktree creation on first review | When a webhook arrives for an MR with no existing worktree, ReviewFlow runs `git fetch origin <source-branch>` then `git worktree add <path> <source-branch>` before dispatching Claude |
+| 2 | Worktree reuse for followups | Subsequent reviews/followups on the same MR reuse the existing worktree. `git fetch` + `git reset --hard origin/<source-branch>` updates it to the latest commit |
+| 3 | `claude --bg` invoked with worktree as cwd | `claudeInvoker.ts` runs `claude --bg` with the worktree path as the working directory, not the original `localPath` |
+| 4 | Disable Claude auto-worktree | `.claude/settings.json` in the worktree (or in the launched session config) sets `worktree.bgIsolation: "none"` so Claude doesn't create a nested sub-worktree |
+| 5 | MR ↔ worktree path mapping | A persisted mapping (in tracked MR record or a dedicated store) records the worktree path for each open MR |
+| 6 | Cleanup on MR merged/closed | Webhooks for `merged`/`closed` actions trigger `git worktree remove <path>` and clear the mapping |
+| 7 | Daily safety-net sweep | A scheduled job runs daily and removes worktrees whose mapped MR has been closed >24h or whose mtime is >7 days old |
+| 8 | System prompt cleanup | The "local state UNRELIABLE / use glab mr diff / NEVER git diff" section of `buildMcpSystemPrompt` is removed. Claude now sees the right code |
+| 9 | GitHub fork support | When the MR source branch is on a fork (GitHub), `git fetch <fork-remote-url> <branch>` adds the fork as a remote (or uses one-shot fetch) before worktree creation |
+| 10 | Concurrent-followup serialization per MR | Two followups arriving in <30s on the same MR are serialized: the second waits for the first to complete before reusing/updating the worktree |
+
+### Out of Scope
+
+| Item | Reason |
+|------|--------|
+| Migrating MR ↔ worktree mapping to a SQL database | Filesystem-based or in-existing-store mapping is sufficient at current scale |
+| Worktree-per-followup-event (instead of per-MR) | Disk explosion risk. Per-MR reuse with serialization is the right granularity |
+| Disabling worktree isolation for non-MR jobs (e.g., dashboard manual run) | Dashboard manual run still uses worktree if the MR is tracked. Untracked invocations remain on plain `localPath` |
+| Cross-repo worktree sharing | One repo, one worktree base. No fancy sharing |
+| Cleanup of `.claude/worktrees/` created by Claude itself (pre-SPEC-170) | Manual one-time sweep is acceptable. Future cleanups handled by FR-7 |
+| Sandbox / permission isolation per worktree | Standard git worktree isolation is enough. Sandboxing is a separate concern |
+| Branch protection check before worktree creation | If `git fetch` succeeds, the branch is reachable. No extra check |
+
+## Functional Requirements
+
+### FR-1: Worktree Path Convention
+
+For an MR identified by `(platform, project, mrNumber)`, the worktree path is:
+`<localPath>/.reviewflow-worktrees/<platform>-<project-slug>-mr-<mrNumber>`
+
+The directory `.reviewflow-worktrees/` is distinct from Claude's default `.claude/worktrees/` to make ownership unambiguous.
+
+### FR-2: Create-or-Reuse Logic
+
+Before dispatching Claude for any review or followup:
+
+1. Look up the mapping for `(platform, project, mrNumber)`.
+2. If absent: `git fetch origin <source-branch>`, then `git worktree add <path> <source-branch>`, persist the mapping.
+3. If present and path exists: `git fetch origin <source-branch>` (from the worktree), then `git reset --hard origin/<source-branch>`.
+4. If present but path missing (orphan mapping): clear mapping, fall back to creation.
+
+### FR-3: Dispatch from Worktree
+
+`claudeInvoker.ts` invokes `claude --bg` with `cwd: <worktree-path>` instead of `cwd: <localPath>`. All other flags (`--mcp-config`, `--model`, etc.) unchanged. The MCP system prompt is updated per FR-8 (no more disclaimer).
+
+### FR-4: Claude Sub-worktree Disabled
+
+Either:
+- A `.claude/settings.json` in `<worktree-path>` with `{"worktree": {"bgIsolation": "none"}}`, OR
+- The `--bg` invocation passes settings explicitly (`--settings '{"worktree": {"bgIsolation": "none"}}'`).
+
+The first option is preferred (persists across invocations).
+
+### FR-5: Cleanup on Merge/Close
+
+In `gitlab.controller.ts` and `github.controller.ts`, the existing `merged` and `closed` action branches trigger `git worktree remove <path>` then clear the mapping. Errors (e.g., worktree already removed) are logged as warnings, not failures.
+
+### FR-6: Daily Sweep Job
+
+A scheduled task (cron-style, every 24h) iterates all entries in `.reviewflow-worktrees/`. For each:
+- If a mapping exists and the MR is closed/merged >24h ago: remove.
+- If no mapping exists (orphan): remove.
+- If mtime is >7 days old regardless of mapping: remove with a warning log.
+
+### FR-7: System Prompt Slimming
+
+`buildMcpSystemPrompt` removes the section "CRITICAL: Data Source Rules" (the disclaimer about local state being UNRELIABLE and the FORBIDDEN list including `git diff`, `git log`, etc.). The skill prompts can now legitimately use `git diff target..HEAD` and `git log` because the working tree is on the MR branch.
+
+### FR-8: GitHub Fork Handling
+
+When `event.pull_request.head.repo.full_name !== event.pull_request.base.repo.full_name` (cross-fork PR), the source branch lives on a fork. The fetch command becomes:
+`git fetch <fork-clone-url> <source-branch>:refs/remotes/pr-<number>/head`
+followed by `git worktree add <path> refs/remotes/pr-<number>/head`.
+
+### FR-9: Concurrent Followup Serialization
+
+The existing `p-queue` already serializes per-job execution. The MR-level serialization is enforced by keying the queue concurrency on `(platform, project, mrNumber)` for worktree operations specifically, so two followups on the same MR never `git reset --hard` concurrently. Other MRs can still run in parallel.
+
+## Gherkin Scenarios
+
+```gherkin
+Feature: ReviewFlow manages git worktrees over MR lifecycle
+
+  Background:
+    Given SPEC-169 is deployed and reviews run via `claude --bg`
+    And the operator user can run `git worktree` commands in the project directory
+
+  Scenario: First review on a new MR creates a worktree on the source branch
+    Given GitLab MR #4242 opens with source branch "feat/new-feature"
+    And no worktree exists for this MR
+    When the review webhook arrives
+    Then `git fetch origin feat/new-feature` is invoked from the project directory
+    And `git worktree add <localPath>/.reviewflow-worktrees/gitlab-project-mr-4242 feat/new-feature` is invoked
+    And the mapping (gitlab, project, 4242) → <path> is persisted
+    And `claude --bg` runs with cwd = <worktree-path>
+
+  Scenario: Followup on the same MR reuses and updates the worktree
+    Given GitLab MR #4242 has a worktree at <localPath>/.reviewflow-worktrees/gitlab-project-mr-4242
+    And a new push arrives on "feat/new-feature"
+    When the followup webhook fires
+    Then `git fetch origin feat/new-feature` runs from the worktree
+    And `git reset --hard origin/feat/new-feature` runs from the worktree
+    And the worktree is reused (no new worktree created)
+    And `claude --bg` runs with the same cwd
+
+  Scenario: MR is merged and worktree is removed
+    Given GitLab MR #4242 has a worktree
+    When a `merged` webhook is received for MR #4242
+    Then `git worktree remove <path>` is invoked
+    And the mapping is cleared
+    And subsequent webhooks for MR #4242 (if any) would recreate from scratch
+
+  Scenario: MR is closed without merge and worktree is removed
+    Given GitLab MR #4242 has a worktree
+    When a `closed` webhook is received
+    Then the same cleanup as the merge case occurs
+
+  Scenario: Cleanup error is logged but does not block webhook response
+    Given GitLab MR #4242 has a worktree
+    But the worktree directory has been manually deleted
+    When a `merged` webhook is received
+    Then `git worktree remove` fails with "not a working tree"
+    And a warning is logged
+    And the mapping is still cleared
+    And the webhook returns success
+
+  Scenario: Daily sweep removes worktrees whose MR closed >24h ago
+    Given the daily sweep job runs
+    And a worktree exists for MR #4100 whose mapping shows status closed 48h ago
+    Then `git worktree remove` is invoked for that worktree
+    And the mapping is cleared
+
+  Scenario: Daily sweep removes orphan worktrees (no mapping)
+    Given the daily sweep job runs
+    And a worktree exists at `.reviewflow-worktrees/...` with no corresponding mapping
+    Then it is removed with a warning log
+
+  Scenario: Daily sweep removes worktrees idle >7 days regardless of mapping
+    Given a worktree's mtime is 8 days old
+    And the mapped MR is still open
+    Then the worktree is removed with a warning log
+    And the mapping is cleared
+    And the next review on that MR recreates the worktree fresh
+
+  Scenario: GitHub cross-fork PR fetches from fork URL
+    Given GitHub PR #99 is opened from a fork at `https://github.com/contributor/main-app-v3.git`
+    And the source branch is "patch-1"
+    When the review webhook arrives
+    Then `git fetch https://github.com/contributor/main-app-v3.git patch-1:refs/remotes/pr-99/head` is invoked
+    And `git worktree add <path> refs/remotes/pr-99/head` is invoked
+    And the review proceeds normally
+
+  Scenario: Two followups within 5 seconds on same MR are serialized
+    Given two push webhooks arrive 5 seconds apart on MR #4242
+    When the followup jobs are queued
+    Then the second job waits for the first to release the worktree
+    And the worktree is not `git reset --hard` concurrently
+    And both followups complete in order
+
+  Scenario: System prompt no longer warns about local state
+    Given a review is dispatched via claudeInvoker
+    When buildMcpSystemPrompt produces the system prompt
+    Then the prompt contains no "UNRELIABLE" or "FORBIDDEN" disclaimer
+    And the prompt no longer references `glab mr diff` or `gh pr diff` as a substitute for git diff
+    And Claude can use `git diff target..HEAD` and `git log` legitimately
+```
+
+## RICE Score
+
+| Criteria | Score | Justification |
+|----------|-------|---------------|
+| Reach | 7 | Cross-module: webhook controllers (gitlab + github), new worktree usecase, scheduled job, claudeInvoker, MCP prompt builder |
+| Impact | 1.5 | Medium — improves review quality and unbounds disk usage, but doesn't block operation. Quality gains material but not critical |
+| Confidence | 80% | Standard git worktree usage. Lifecycle hooks already exist in webhook controllers. Fork case adds minor uncertainty |
+| Effort | 5 pts | Multiple files, new usecase, cron job, fork branching logic, system prompt update, mapping persistence |
+| **Score** | **1.68** | |
+
+Priority: **Important**
+
+## INVEST Validation
+
+| Criterion | Pass | Rationale |
+|-----------|------|-----------|
+| Independent | WARN | Depends on SPEC-169 being live. Otherwise independent of other in-flight work |
+| Negotiable | Yes | Path convention, sweep frequency, mapping storage, fork-handling strategy all open |
+| Valuable | Yes | Disk bounded + review quality up + system prompt leaner = real operator and review-quality wins |
+| Estimable | Yes | ~1 jour IA. Clear file list, standard git operations, lifecycle wiring on existing webhook paths |
+| Small | WARN | Borderline at 5 pts. Could split into "worktree creation" + "lifecycle cleanup" + "sweep" but coordination overhead exceeds savings |
+| Testable | Yes | Worktree commands mockable; webhook paths already tested; sweep is a pure scheduled task with deterministic input |
+
+## Definition of Done
+
+- [ ] FR-1: Worktree path convention implemented and used consistently
+- [ ] FR-2: Create-or-reuse logic in a new usecase (e.g., `ensureWorktree.usecase.ts`)
+- [ ] FR-3: `claudeInvoker.ts` dispatches with worktree as cwd
+- [ ] FR-4: `worktree.bgIsolation: "none"` set in each created worktree's `.claude/settings.json`
+- [ ] FR-5: Cleanup on merge/close branches in both gitlab/github controllers
+- [ ] FR-6: Daily sweep job implemented and registered in the scheduler
+- [ ] FR-7: `buildMcpSystemPrompt` UNRELIABLE/FORBIDDEN section removed; tests adjusted
+- [ ] FR-8: GitHub fork branching handled (cross-fork PR fetch from fork URL)
+- [ ] FR-9: Per-MR serialization for worktree operations (extend existing queue keying)
+- [ ] All scenarios covered by passing tests (unit + integration on webhook controllers + sweep)
+- [ ] `yarn verify` passes
+- [ ] Acceptance test GREEN at `src/tests/acceptance/170-prebuilt-worktree-lifecycle.acceptance.test.ts`
+- [ ] Imports use `@/` alias + `.js` extension
+- [ ] No `any`, no `as Type`, full words in naming
+- [ ] Manual one-time sweep done on operator's prod server to remove pre-SPEC-170 worktrees
+- [ ] Tracker updated: SPEC-170 → status `implemented`
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| Worktree | Independent working directory tied to a single branch, managed by `git worktree` |
+| Source branch | The branch the MR/PR proposes to merge from (e.g., feature branch) |
+| Target branch | The branch the MR/PR targets (e.g., master/main). Not checked out — the worktree is on source |
+| MR ↔ worktree mapping | Persisted association between a tracked MR/PR and its worktree path on disk |
+| Cross-fork PR | A GitHub PR whose source branch lives on a fork repository, not the main repository |
+| Daily sweep | Scheduled cleanup job removing stale or orphaned worktrees |
+| `bgIsolation` | Claude Code setting controlling whether `--bg` creates a nested worktree inside the cwd |
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| `git worktree add` on a large monorepo is slow (5-15s) | Acceptable: one-time per MR, reused for followups. Measure on first deploy |
+| Disk fills despite sweep (operator forgets to monitor) | Add a daily metric in the dashboard showing total `.reviewflow-worktrees/` size |
+| `git reset --hard` discards local changes if anything ever writes to the worktree | Worktrees are read-only for the review skill. Add documentation in worktree README |
+| Fork URL not resolvable (network, auth, fork deleted) | FR-8 wraps fork fetch in try/catch; fallback to error logged + job marked failed |
+| Webhook for `closed` arrives twice (idempotency) | `git worktree remove` is naturally idempotent (errors logged as warnings, mapping clear is safe to repeat) |
+| Worktrees created before SPEC-170 still consume disk | Manual one-time sweep in DoD; documented in deploy runbook |


### PR DESCRIPTION
## Summary
- Restored 3 draft specs lost when their worktree was auto-cleaned: SPEC-168 (POC --bg billing), SPEC-169 (migrate -p → --bg), SPEC-170 (pre-built worktree lifecycle)
- Source: extracted from session transcript at `~/.claude/projects/.../0d880b32-…jsonl`
- Updated `docs/feature-tracker.md` with the 3 new draft entries (2026-05-22)

## Context
At 2026-06-15, `claude -p` switches to API billing (full token cost, ~$1,549/mo projected vs $200/mo budget cap). Migration to `claude --bg` (subscription-billable per Anthropic docs) is required. SPEC-168 is a GO/NO-GO gate before SPEC-169 implementation.

## Test plan
- [x] `yarn verify` passes (204 files, 1517 tests green)
- [x] All 4 files restored byte-equivalent to the lost worktree
- [x] Tracker entries match the lost-worktree state

🤖 Generated with [Claude Code](https://claude.com/claude-code)