### PR TITLE
docs(specs): convert SPEC-168 to post-deploy verification checklist

### DIFF
--- a/docs/feature-tracker.md
+++ b/docs/feature-tracker.md
@@ -33,7 +33,7 @@
 | Developer & team insights | [125-developer-team-insights](specs/125-developer-team-insights.md) | implemented | 2026-04-01 |
 | Hybrid model routing + token tracking | (no spec — see report) | implemented | 2026-05-14 |
 | Skill templates | [skill-templates](specs/skill-templates.md) | drafted | 2026-03-14 |
-| Validate --bg subscription billing (POC) | [168-validate-bg-subscription-billing](specs/168-validate-bg-subscription-billing.md) | drafted | 2026-05-22 |
+| Verify --bg subscription billing (post-deploy) | [168-validate-bg-subscription-billing](specs/168-validate-bg-subscription-billing.md) | verifying | 2026-05-22 |
 | Migrate Claude invocation -p → --bg | [169-migrate-claude-invocation-to-bg-mode](specs/169-migrate-claude-invocation-to-bg-mode.md) | implemented | 2026-05-22 |
 | Pre-built worktree lifecycle | [170-prebuilt-worktree-lifecycle](specs/170-prebuilt-worktree-lifecycle.md) | drafted | 2026-05-22 |
 | Re-enable token usage tracking in --bg mode | [171-bg-token-usage-tracking](specs/171-bg-token-usage-tracking.md) | drafted | 2026-05-22 |

--- a/docs/specs/168-validate-bg-subscription-billing.md
+++ b/docs/specs/168-validate-bg-subscription-billing.md
@@ -1,169 +1,137 @@
 ---
-title: "SPEC-168: Validate --bg Subscription Billing (POC)"
+title: "SPEC-168: Verify --bg Subscription Billing (Post-Deploy Checklist)"
 labels: validation, P1-critical, claude-invocation
 milestone: June 15 Migration
-status: DRAFT
+status: VERIFYING
 ---
 
-# SPEC-168: Validate `--bg` Subscription Billing (POC)
+# SPEC-168: Verify `--bg` Subscription Billing (Post-Deploy Checklist)
 
-## Problem Statement
+> **Note (2026-05-22)** — Originally drafted as a pre-migration POC. POC stage was bypassed: SPEC-169 was migrated and deployed in v3.13.0 without a single-MR experiment. This spec is now a **post-deploy verification checklist** to confirm subscription billing is actually in effect.
 
-On 2026-06-15, Anthropic will move Claude Code `--print` (`-p`) mode invocations to API-pool billing. Subscription Pro/Max coverage will no longer apply to programmatic `claude -p` usage. ReviewFlow currently spawns `claude -p` from `claudeInvoker.ts` for every review, exposing the project to ~$1,549/month at API rates against a $200/month budget.
+## Context
 
-The documented replacement path is `claude --bg`, which the official agent-view documentation describes as subscription-billed: *"background sessions consume your subscription usage the same as interactive sessions"*. However, this is a research-preview feature and the claim has not been empirically verified on ReviewFlow's production environment.
-
-Before re-architecting `claudeInvoker.ts` and migrating 620+ reviews/month, the subscription-billing hypothesis must be validated end-to-end on the actual production server. A failed validation invalidates SPEC-169 and SPEC-170 entirely — the whole migration strategy fails.
+On 2026-06-15, Anthropic moves Claude Code `--print` mode invocations to API-pool billing. ReviewFlow has migrated to `--bg` (SPEC-169, v3.13.0) on the documented assumption that `--bg` consumes the subscription pool. Because the POC was bypassed, the subscription-billing hypothesis must now be verified empirically on the running daemon — a silent misconfiguration (stray API key in the service env) would route every review through API billing without any code-level signal, exposing the project to ~$1,549/month against a $200/month budget.
 
 ## User Story
 
 **As** the operator of ReviewFlow,
-**I want** to empirically confirm that `claude --bg` invocations on the production server consume the OAuth claude.ai subscription pool and never the API pool,
-**So that** I can commit to the full migration (SPEC-169) with evidence rather than documentation hopium.
+**I want** to verify on the running daemon that `claude --bg` invocations consume the OAuth subscription pool and never the API pool,
+**So that** the SPEC-169 migration is operationally validated rather than assumed.
 
 ## Scope
 
 ### In Scope
 
-| # | Capability | Description |
-|---|------------|-------------|
-| 1 | Single review dispatched via `claude --bg` | One real review (not a fake/test prompt) triggered through ReviewFlow on the prod server, switched from `-p` to `--bg` for this single invocation |
-| 2 | Authentication via OAuth claude.ai | The session runs under the existing `claude /login` OAuth credentials on the prod server. No `ANTHROPIC_API_KEY` env var, no API key anywhere |
-| 3 | Observable proof of subscription billing | Verifiable signal that the consumed quota came from the Pro/Max pool (Anthropic Console usage page, `claude /usage` output, or absence of API charges in the API billing dashboard) |
-| 4 | Observable proof of NO API billing | No new API charge appears on the API billing dashboard during the test window |
-| 5 | Documented GO/NO-GO decision | A short report (`docs/reports/168-validate-bg-subscription-billing.report.md`) capturing the evidence and the decision |
+| # | Capability |
+|---|------------|
+| 1 | OAuth-only auth verified on the running daemon |
+| 2 | Subscription pool consumption observed over a monitoring window |
+| 3 | Zero API pool consumption observed over the same window |
+| 4 | Verification report produced with binary verdict |
 
 ### Out of Scope
 
 | Item | Reason |
 |------|--------|
-| Refactoring `claudeInvoker.ts` for all reviews | That is SPEC-169's job. This spec only switches one invocation |
-| Worktree lifecycle management | SPEC-170 territory |
-| Rate limit measurement / concurrent sessions test | A POC focused on billing, not on capacity |
-| ProgressParser adaptation | This spec accepts that the single test review may have degraded progress reporting |
-| Production deployment of the change | The switched invocation can be a temporary patch, reverted after evidence collection |
-| Multi-project validation | A single project (main-app-v3) is sufficient to prove or disprove the billing model |
+| Refactoring the Claude invocation layer | Done by SPEC-169 |
+| Worktree lifecycle | SPEC-170 territory |
+| Rate-limit measurement / concurrency test | Verification focused on billing, not capacity |
+| Single-MR POC patching | Skipped — SPEC-169 already deployed in full |
+| GO/NO-GO gating of SPEC-169 | Decision was taken implicitly by merging SPEC-169 |
 
-## Functional Requirements
+## Rules
 
-### FR-1: Single-Invocation Switch
+- subscription billing requires: active OAuth claude.ai session AND no API key in the daemon environment
+- the verification window is between 48 hours and 7 days after deploy
+- the verdict is binary: `CONFIRMED` (non-zero subscription consumption + zero API charge) or `REGRESSION` (any API charge attributable to the daemon)
+- a `REGRESSION` verdict triggers immediate rollback and pauses downstream specs
+- a silent window (no review traffic) extends the deadline rather than producing a verdict
 
-A single, controlled `claude -p` call in `claudeInvoker.ts` is temporarily replaced by `claude --bg "<prompt>"` for the duration of the test, behind a feature flag or a hardcoded condition (e.g., job ID match). Other reviews continue on `-p` to keep the prod system functional during the experiment.
+## Scenarios
 
-### FR-2: OAuth-Only Authentication
+- OAuth verified: {env: "no API key", auth: "claude.ai + firstParty + max plan"} → FR-2 validated
+- OAuth missing: {env: "no API key", auth: "logged out"} → reject "Session OAuth requise avant déploiement"
+- API key leaked: {env: "API key present", auth: "*"} → reject "Aucune clé API ne doit être présente dans l'environnement du démon"
+- subscription confirmed: {subscription usage: "non-zero", api charge: "zero", window: "48-72h"} → verdict "CONFIRMED"
+- regression detected: {subscription usage: "*", api charge: "non-zero"} → verdict "REGRESSION" + rollback
+- silent window: {subscription usage: "zero", api charge: "zero", reviews in window: "0"} → extend window to 7 days
 
-Before launching the test review, the operator verifies on the prod server:
-- No `ANTHROPIC_API_KEY` environment variable is set in the `reviewflow-app` systemd service environment.
-- `claude auth status` (run as the `reviewflow-app` user) reports a claude.ai OAuth session, not an API key.
+## Acceptance Criteria
 
-If either check fails, the spec is BLOCKED until OAuth-only auth is confirmed.
+- [x] AC-1: Daemon environment contains no API key (verified 2026-05-22)
+- [x] AC-2: `claude auth status` reports `authMethod: claude.ai`, `apiProvider: firstParty`, `subscriptionType: max` (verified 2026-05-22)
+- [ ] AC-3: Within the verification window, the Pro/Max usage dashboard shows non-zero token consumption attributable to ReviewFlow review sessions
+- [ ] AC-4: Within the verification window, the API billing dashboard shows zero new charges
+- [ ] AC-5: `docs/reports/168-verify-bg-subscription-billing.report.md` exists with a binary verdict (CONFIRMED or REGRESSION) and the collected evidence
+- [ ] AC-6: Tracker updated — status `implemented` if CONFIRMED, status `blocked` if REGRESSION (with SPEC-170 also paused)
 
-### FR-3: Test Invocation
+## Operational Notes
 
-The operator triggers one real review on a real MR (production data, not synthetic). The `--bg` session ID is captured. The review runs to completion (or failure) and the result is observed.
+Commands used to collect AC-1 / AC-2 evidence on the running daemon:
 
-### FR-4: Billing Evidence Collection
+```bash
+# AC-1: no API key in service env
+systemctl --user show reviewflow-app -p Environment | grep -i ANTHROPIC
 
-Within 24 hours of the test invocation, the operator collects:
-- A screenshot or export of the Pro/Max usage page showing the test session's token consumption.
-- A screenshot or export of the API billing dashboard showing **no new charge** for the test window.
-- `claude /usage` output before and after the test (if available).
-
-### FR-5: GO/NO-GO Decision Report
-
-A report at `docs/reports/168-validate-bg-subscription-billing.report.md` is produced with:
-- The evidence collected (FR-4).
-- A binary verdict: **GO** (proceed with SPEC-169) or **NO-GO** (abort migration, escalate).
-- If NO-GO: the observed billing behavior and proposed next step.
-
-## Gherkin Scenarios
-
-```gherkin
-Feature: Empirical validation of --bg subscription billing
-
-  Background:
-    Given the reviewflow-app systemd service runs under a user authenticated via `claude /login`
-    And no ANTHROPIC_API_KEY environment variable is set for that user
-    And `claude --version` reports v2.1.139 or later on the prod server
-
-  Scenario: One review is dispatched via --bg and consumes subscription pool
-    Given ReviewFlow is patched to spawn `claude --bg` for one specific test MR
-    When a real webhook triggers a review on that test MR
-    Then a background session ID is returned by the claude binary
-    And the session completes (or fails) within the normal review timeout
-    And within 24 hours, the Pro/Max usage dashboard shows token consumption attributed to this session
-    And within 24 hours, the API billing dashboard shows zero new charges for the test window
-
-  Scenario: GO decision when subscription billing is confirmed
-    Given the test review completed
-    And evidence shows Pro/Max consumption and zero API charges
-    Then a GO report is written documenting the evidence
-    And SPEC-169 is unblocked
-
-  Scenario: NO-GO decision when API billing is observed
-    Given the test review completed
-    And the API billing dashboard shows any new charge attributable to the test
-    Then a NO-GO report is written documenting the observation
-    And SPEC-169 and SPEC-170 are marked blocked
-    And the operator is alerted to escalate (Anthropic support, alternate strategy)
-
-  Scenario: Prerequisite check fails — OAuth not active
-    Given the reviewflow-app user has no active claude.ai OAuth session
-    Or an ANTHROPIC_API_KEY is set in the service environment
-    Then the test is not run
-    And the spec is blocked pending OAuth setup
+# AC-2: OAuth auth status (run as the service user)
+claude auth status
 ```
+
+`claude auth status` output captured 2026-05-22:
+
+```json
+{
+  "loggedIn": true,
+  "authMethod": "claude.ai",
+  "apiProvider": "firstParty",
+  "email": "damien@mentorgoal.com",
+  "subscriptionType": "max"
+}
+```
+
+AC-3 / AC-4 evidence is collected from the Anthropic Console: Pro/Max usage page and API billing dashboard. Window opened 2026-05-22, closes by default 2026-05-25.
 
 ## RICE Score
 
 | Criteria | Score | Justification |
 |----------|-------|---------------|
-| Reach | 10 | Validates the entire claude-invocation path for all reviews across the platform |
-| Impact | 3 | Critical — wrong hypothesis = entire migration fails = ReviewFlow unsustainable post-15-juin |
-| Confidence | 80% | Doc strongly suggests subscription billing, but research preview means empirical proof is mandatory |
-| Effort | 1 pt | Small, surgical change. Bulk of effort is evidence collection, not coding |
-| **Score** | **24.0** | |
+| Reach | 10 | Validates the entire Claude invocation path for all reviews |
+| Impact | 3 | Critical — undetected misconfiguration = silent monthly API bill |
+| Confidence | 90% | AC-1/AC-2 already collected on the live daemon; AC-3/AC-4 are observation, not experiment |
+| Effort | 0.5 pt | Reading two dashboards + writing the report |
+| **Score** | **54.0** | |
 
 Priority: **Critical**
 
 ## INVEST Validation
 
-| Criterion | Pass | Rationale |
-|-----------|------|-----------|
-| Independent | Yes | Standalone validation. No dependency on SPEC-169 or SPEC-170 (those depend on this) |
-| Negotiable | Yes | The exact patching mechanism (feature flag vs hardcoded condition vs branch deploy) is open |
-| Valuable | Yes | Removes the largest unknown in the migration strategy. Failure here saves days of wasted refactor |
-| Estimable | Yes | ~0.25 jour IA for the code change. Evidence collection is wall-clock time, not effort |
-| Small | Yes | One file touched, one invocation switched, one report produced |
-| Testable | Yes | Binary outcome: Pro/Max usage visible AND zero API charge = GO. Otherwise = NO-GO |
-
-## Definition of Done
-
-- [ ] FR-1 implemented (single `claude --bg` invocation in `claudeInvoker.ts`, gated)
-- [ ] FR-2 verified (OAuth-only auth confirmed on prod server, evidence stored in report)
-- [ ] FR-3 executed (one real review dispatched, session ID captured, completion observed)
-- [ ] FR-4 collected (Pro/Max usage evidence + API billing zero-charge evidence)
-- [ ] FR-5 written (`docs/reports/168-validate-bg-subscription-billing.report.md` with verdict)
-- [ ] Tracker updated: SPEC-168 → status `implemented` after report merged
-- [ ] If GO: SPEC-169 unblocked
-- [ ] If NO-GO: SPEC-169 and SPEC-170 set to status `blocked`, escalation logged
+| Criterion | Status | Note |
+|-----------|--------|------|
+| Independent | OK | Verification of an already-deployed change |
+| Negotiable | WARN | Dashboard source is open; verdict criteria is binary |
+| Valuable | OK | Closes the billing risk loop opened by skipping the POC |
+| Estimable | OK | ~0.5 jour IA wall-clock — gated by the monitoring window |
+| Small | OK | Two checks + one report |
+| Testable | OK | CONFIRMED if subscription shows usage AND API shows zero |
 
 ## Glossary
 
 | Term | Definition |
 |------|------------|
-| `--bg` | Claude Code CLI flag launching an interactive session in background, managed by a per-user supervisor daemon. Documented at https://code.claude.com/docs/en/agent-view |
+| `--bg` flag | Claude Code CLI flag launching an interactive session in background, managed by a per-user supervisor daemon |
 | Subscription pool | Token quota covered by an active Claude Pro/Max plan, billed flat-rate monthly |
 | API pool | Per-token billing via an Anthropic API key, separate from subscription |
 | OAuth claude.ai | Authentication method used by `claude /login`, distinct from API key auth |
-| Research preview | Anthropic status indicating a feature is functional but subject to API/contract change |
-| GO/NO-GO | Binary decision gate: GO unblocks downstream specs; NO-GO halts the migration strategy |
+| First-party provider | `apiProvider: firstParty` in `claude auth status` — Anthropic-direct subscription, not third-party gateway |
+| CONFIRMED / REGRESSION | Binary verdict of the post-deploy verification |
+| Verification window | Time range between 48 hours and 7 days after deploy during which billing dashboards are observed |
 
 ## Risks
 
 | Risk | Mitigation |
 |------|------------|
-| Pro/Max usage page doesn't itemize per-session — billing evidence is ambiguous | Compare aggregate usage before/after; supplement with API dashboard zero-charge |
-| Anthropic changes `--bg` behavior between POC and SPEC-169 production rollout | Run SPEC-169 within 1 week of SPEC-168 completion |
-| The single test review is atypical (small diff, easy review) — billing extrapolation is unreliable | Pick a typical review (~300 lines diff, full agent run) for the test |
-| OAuth session expires mid-test | Verify `claude auth status` before launch and immediately after |
+| Pro/Max usage page is aggregate-only | Aggregate is sufficient: any non-zero subscription consumption proves subscription billing is engaged |
+| Low review volume during window | Silent-window rule extends the deadline to 7 days, or operator triggers a representative review manually |
+| Anthropic changes `--bg` behavior before 2026-06-15 cutoff | Repeat AC-3/AC-4 after each Claude Code minor version bump until 2026-06-15 |
+| OAuth session expires silently — daemon could fall back to API key if one is added later | Add a periodic auth-status healthcheck (separate spec) |


### PR DESCRIPTION
## Summary

- SPEC-168 was a POC draft for validating `claude --bg` subscription billing before SPEC-169 migration. The POC stage was bypassed: SPEC-169 was deployed in v3.13.0 without a single-MR experiment.
- This PR reframes SPEC-168 as a **post-deploy verification checklist** with the same evidence requirements, now applied to the running production daemon.
- Rewritten from Gherkin to ReviewFlow custom DSL (Rules + Scenarios + AC-1..AC-6), aligning with SPEC-171 format.

## Status of verification

- [x] **AC-1**: No `ANTHROPIC_API_KEY` in `reviewflow-app` user-service env (verified 2026-05-22)
- [x] **AC-2**: `claude auth status` reports `authMethod: claude.ai`, `apiProvider: firstParty`, `subscriptionType: max` (verified 2026-05-22)
- [ ] **AC-3**: Pro/Max usage dashboard shows non-zero token consumption (pending — window closes 2026-05-25)
- [ ] **AC-4**: API billing dashboard shows zero new charges (pending — window closes 2026-05-25)
- [ ] **AC-5**: `docs/reports/168-verify-bg-subscription-billing.report.md` with binary verdict (CONFIRMED or REGRESSION)
- [ ] **AC-6**: Tracker → `implemented` (CONFIRMED) or `blocked` (REGRESSION)

A second PR will close AC-3..AC-6 once the monitoring window closes.

## Test plan

- [ ] Review the DSL Rules + Scenarios block reads cleanly and stays within the no-jargon constraint
- [ ] Confirm AC-1/AC-2 evidence (JSON output) matches what the operator collected on the live daemon
- [ ] Confirm tracker status `verifying` is appropriate for the intermediate state (2/6 AC validated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)