### PR TITLE
fix(claude-invocation): add -- terminator so variadic tool flags do not swallow the prompt

### DIFF
--- a/src/modules/claude-invocation/interface-adapters/gateways/claudeSession.cli.gateway.ts
+++ b/src/modules/claude-invocation/interface-adapters/gateways/claudeSession.cli.gateway.ts
@@ -100,6 +100,16 @@ export class ClaudeSessionCliGateway implements ClaudeSessionGateway {
       input.flags.allowedTools,
       '--disallowedTools',
       input.flags.disallowedTools,
+      // `--allowedTools` and `--disallowedTools` are variadic flags that
+      // slurp every following positional arg until the next flag. Without
+      // an explicit `--` terminator, claude CLI swallows the prompt into
+      // the disallowedTools list and the session is dispatched with no
+      // prompt, leaving the background agent idle forever. Verified with
+      // `claude --print ... --allowedTools Read -- "say hi"` (responds)
+      // vs. `claude --print ... --allowedTools Read "say hi"`
+      // (fails: "Input must be provided either through stdin or as a
+      // prompt argument when using --print").
+      '--',
       input.prompt,
     ];
 


### PR DESCRIPTION
## Summary

**Critical fix.** Reviews dispatched via the daemon since PR #170 (--bg migration) silently fail with no error: Claude session is started but the prompt is never executed, leaving the agent idle forever.

## Root cause

`--allowedTools <tools...>` and `--disallowedTools <tools...>` are **variadic** flags in claude CLI. They slurp every following positional arg until the next flag. The daemon's args order:

```
... --allowedTools "Read,..." --disallowedTools "EnterPlanMode,..." "/review-front 182"
```

means `/review-front 182` is added to the disallowed-tools list, and the prompt arg is empty. Claude CLI silently dispatches a session with no prompt, the session sits idle, the MCP completion bridge never fires, the dashboard shows "running" indefinitely.

Reproduction without --bg shows the same parser behaviour:

```bash
$ claude --print --allowedTools "Read" "say hi"
Error: Input must be provided either through stdin or as a prompt argument when using --print

$ claude --print --allowedTools "Read" -- "say hi"
Bonjour ! 👋 [...]
```

## Fix

Insert `--` as a positional-args terminator between the last variadic flag and the prompt in `claudeSession.cli.gateway.ts:dispatch`.

## Test plan

- [x] `yarn verify` — 244 files / 1731 passing
- [ ] Trigger a review on a real MR and watch the daemon logs — the session should go from idle to busy and complete the MCP workflow