### PR TITLE
chore: pin yarn package manager via corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,5 +82,6 @@
   },
   "engines": {
     "node": ">=20.0.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
## Summary
- Add `packageManager` field to `package.json` pinning yarn `1.22.22` with integrity hash so Corepack resolves the exact binary across local and CI environments.

## Test plan
- [x] `yarn verify` passes (typecheck + lint + 1805 tests)
- [x] `yarn build` passes
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)