### PR TITLE
fix: #171 trigger followup review on push to reviewed branch

### DIFF
--- a/src/modules/tracking/usecases/tracking/checkFollowupNeeded.usecase.ts
+++ b/src/modules/tracking/usecases/tracking/checkFollowupNeeded.usecase.ts
@@ -14,12 +14,7 @@ export class CheckFollowupNeededUseCase implements UseCase<CheckFollowupNeededIn
     const mr = this.trackingGateway.getByNumber(input.projectPath, input.mrNumber, input.platform);
 
     if (!mr) return false;
-
-    const eligibleForFollowup =
-      mr.state === 'pending-fix' ||
-      (mr.state === 'pending-approval' && mr.totalWarnings > 0);
-
-    if (!eligibleForFollowup) return false;
+    if (mr.state === 'merged' || mr.state === 'closed') return false;
     if (!mr.lastPushAt || !mr.lastReviewAt) return false;
 
     return new Date(mr.lastPushAt).getTime() > new Date(mr.lastReviewAt).getTime();

--- a/src/tests/units/usecases/tracking/checkFollowupNeeded.usecase.test.ts
+++ b/src/tests/units/usecases/tracking/checkFollowupNeeded.usecase.test.ts
@@ -4,7 +4,7 @@ import { InMemoryReviewRequestTrackingGateway } from '../../../stubs/reviewReque
 import { TrackedMrFactory } from '../../../factories/trackedMr.factory.js';
 
 describe('CheckFollowupNeededUseCase', () => {
-  it('should return true when a push happened after the last review', () => {
+  it('should return true when a push happened after the last review (pending-fix)', () => {
     const gateway = new InMemoryReviewRequestTrackingGateway();
     const mr = TrackedMrFactory.create({
       mrNumber: 42,
@@ -25,7 +25,29 @@ describe('CheckFollowupNeededUseCase', () => {
     expect(result).toBe(true);
   });
 
-  it('should return false when MR is not in an eligible state', () => {
+  it('should return true on push after a clean review (pending-approval, no warnings)', () => {
+    const gateway = new InMemoryReviewRequestTrackingGateway();
+    const mr = TrackedMrFactory.create({
+      mrNumber: 42,
+      platform: 'gitlab',
+      state: 'pending-approval',
+      totalWarnings: 0,
+      lastReviewAt: '2024-01-15T10:00:00Z',
+      lastPushAt: '2024-01-15T12:00:00Z',
+    });
+    gateway.create('/project', mr);
+    const useCase = new CheckFollowupNeededUseCase(gateway);
+
+    const result = useCase.execute({
+      projectPath: '/project',
+      mrNumber: 42,
+      platform: 'gitlab',
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('should return true on push after approval (re-review of new commits)', () => {
     const gateway = new InMemoryReviewRequestTrackingGateway();
     const mr = TrackedMrFactory.create({
       mrNumber: 42,
@@ -43,7 +65,7 @@ describe('CheckFollowupNeededUseCase', () => {
       platform: 'gitlab',
     });
 
-    expect(result).toBe(false);
+    expect(result).toBe(true);
   });
 
   it('should return true when pending-approval MR has warnings and push after review', () => {
@@ -68,13 +90,12 @@ describe('CheckFollowupNeededUseCase', () => {
     expect(result).toBe(true);
   });
 
-  it('should return false when pending-approval MR has no warnings', () => {
+  it('should return false on push to a merged MR', () => {
     const gateway = new InMemoryReviewRequestTrackingGateway();
     const mr = TrackedMrFactory.create({
       mrNumber: 42,
       platform: 'gitlab',
-      state: 'pending-approval',
-      totalWarnings: 0,
+      state: 'merged',
       lastReviewAt: '2024-01-15T10:00:00Z',
       lastPushAt: '2024-01-15T12:00:00Z',
     });
@@ -90,15 +111,35 @@ describe('CheckFollowupNeededUseCase', () => {
     expect(result).toBe(false);
   });
 
-  it('should return false when pending-approval MR has warnings but no push after review', () => {
+  it('should return false on push to a closed MR', () => {
     const gateway = new InMemoryReviewRequestTrackingGateway();
     const mr = TrackedMrFactory.create({
       mrNumber: 42,
       platform: 'gitlab',
-      state: 'pending-approval',
-      totalWarnings: 2,
-      lastReviewAt: '2024-01-15T12:00:00Z',
-      lastPushAt: '2024-01-15T10:00:00Z',
+      state: 'closed',
+      lastReviewAt: '2024-01-15T10:00:00Z',
+      lastPushAt: '2024-01-15T12:00:00Z',
+    });
+    gateway.create('/project', mr);
+    const useCase = new CheckFollowupNeededUseCase(gateway);
+
+    const result = useCase.execute({
+      projectPath: '/project',
+      mrNumber: 42,
+      platform: 'gitlab',
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false when no review has happened yet', () => {
+    const gateway = new InMemoryReviewRequestTrackingGateway();
+    const mr = TrackedMrFactory.create({
+      mrNumber: 42,
+      platform: 'gitlab',
+      state: 'pending-review',
+      lastReviewAt: null,
+      lastPushAt: '2024-01-15T12:00:00Z',
     });
     gateway.create('/project', mr);
     const useCase = new CheckFollowupNeededUseCase(gateway);


### PR DESCRIPTION
## Summary

Closes #171.

Push events on a branch with a completed review were not enqueueing a follow-up review. Root cause was an over-restrictive guard in `checkFollowupNeeded` that only allowed followups when state was `pending-fix` or when `pending-approval` had unresolved warnings — clean reviews and approved MRs were silently dropped even when new commits landed.

## Root cause

`src/modules/tracking/usecases/tracking/checkFollowupNeeded.usecase.ts` — the `eligibleForFollowup` filter encoded "do not spam Claude" as a business state check, but the right invariant is simpler: *any push after a review (outside terminal states) deserves a followup*.

## Fix

Replace the state filter with a terminal-state exclusion:

```ts
if (!mr) return false;
if (mr.state === 'merged' || mr.state === 'closed') return false;
if (!mr.lastPushAt || !mr.lastReviewAt) return false;
return new Date(mr.lastPushAt).getTime() > new Date(mr.lastReviewAt).getTime();
```

## Tests

Rewrote `src/tests/units/usecases/tracking/checkFollowupNeeded.usecase.test.ts` (9 tests):

- ✅ returns `true` for push after review in `pending-fix`, `pending-approval` (with/without warnings), `approved`
- ✅ returns `false` in terminal states (`merged`, `closed`)
- ✅ returns `false` when `lastReviewAt` is null (no review yet)
- ✅ returns `false` when MR is not tracked
- ✅ returns `false` when last push predates last review

## Test plan

- [x] `yarn verify` — 250 files / 1807 tests green
- [ ] Smoke test on a real MR: push after a clean review triggers followup
- [ ] Confirm webhook logs `Push event recorded` then `Followup check result: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)