### PR TITLE
feat(dashboard): sidebar layout + Claude economics accordion

### DIFF
--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -128,148 +128,148 @@
 
         <div id="config-info" class="config-info hidden"></div>
 
-    <div id="claude-login-section" class="login-instructions hidden">
-      <strong><i data-lucide="alert-triangle"></i> <span id="i18n-claude-login-title"></span></strong>
-      <p style="margin-top: 0.5rem;" id="i18n-claude-login-instruction"></p>
-      <p style="margin-top: 0.5rem;"><code>claude login</code></p>
-      <p style="margin-top: 0.5rem; font-size: 0.875rem; color: #a1a1aa;" id="i18n-claude-login-reload"></p>
-    </div>
+        <div id="claude-login-section" class="login-instructions hidden">
+          <strong><i data-lucide="alert-triangle"></i> <span id="i18n-claude-login-title"></span></strong>
+          <p style="margin-top: 0.5rem;" id="i18n-claude-login-instruction"></p>
+          <p style="margin-top: 0.5rem;"><code>claude login</code></p>
+          <p style="margin-top: 0.5rem; font-size: 0.875rem; color: #a1a1aa;" id="i18n-claude-login-reload"></p>
+        </div>
 
-    <div id="git-login-section" class="login-instructions hidden">
-      <strong id="git-login-title"><i data-lucide="alert-triangle"></i> <span id="i18n-git-login-title"></span></strong>
-      <div style="margin-top: 0.75rem;" id="git-login-instructions"></div>
-    </div>
+        <div id="git-login-section" class="login-instructions hidden">
+          <strong id="git-login-title"><i data-lucide="alert-triangle"></i> <span id="i18n-git-login-title"></span></strong>
+          <div style="margin-top: 0.75rem;" id="git-login-instructions"></div>
+        </div>
 
-    <div id="logs-section" class="section hidden">
-      <div class="section-header">
-        <i data-lucide="scroll-text"></i> <span id="i18n-section-logs"></span>
-        <span id="error-count" class="badge-count hidden"></span>
-      </div>
-      <div id="logs-content" class="section-content logs">
-        <div class="empty-state" id="i18n-empty-logs"></div>
-      </div>
-    </div>
-
-    <div id="stats-section" class="section hidden">
-      <div class="section-header clickable" onclick="toggleStats()" role="button" tabindex="0" onkeydown="activateOnKeydown(event)">
-        <i data-lucide="bar-chart-3"></i> <span id="i18n-section-stats"></span>
-        <span id="stats-toggle" class="toggle-icon collapsed"><i data-lucide="chevron-down"></i></span>
-        <button id="recalculate-btn" class="btn btn-sm btn-secondary" onclick="event.stopPropagation(); recalculateStats()" style="margin-left: auto; font-size: 0.75rem; padding: 2px 8px;">
-          <i data-lucide="refresh-cw" style="width: 12px; height: 12px;"></i>
-          <span id="recalculate-label"></span>
-        </button>
-        <span id="backfill-progress" class="badge-count hidden" style="margin-left: 4px;"></span>
-      </div>
-      <div id="project-stats" class="section-content stats-grid hidden">
-        <div class="empty-state" id="i18n-empty-stats"></div>
-      </div>
-    </div>
-
-    <div id="team-section" class="section hidden">
-      <div class="section-header clickable" onclick="toggleTeamSection()" role="button" tabindex="0" onkeydown="activateOnKeydown(event)">
-        <i data-lucide="users"></i> <span id="i18n-section-team"></span>
-        <span id="team-toggle" class="toggle-icon collapsed"><i data-lucide="chevron-down"></i></span>
-      </div>
-      <div id="team-tab-content" class="section-content hidden">
-        <div class="empty-state" id="i18n-empty-team"></div>
-      </div>
-    </div>
-
-    <div id="claude-economics-section" class="section">
-      <div class="section-header clickable" onclick="toggleSection('claude-economics-section')" role="button" tabindex="0" onkeydown="activateOnKeydown(event)">
-        <i data-lucide="circuit-board"></i> <span id="i18n-section-claude-economics"></span>
-        <span class="section-toggle collapsed"><i data-lucide="chevron-down"></i></span>
-      </div>
-      <div class="section-content economics-content hidden">
-        <div class="economics-panel">
-          <div class="economics-panel-header">
-            <span class="economics-panel-title" id="i18n-economics-token-usage"></span>
+        <div id="logs-section" class="section hidden">
+          <div class="section-header">
+            <i data-lucide="scroll-text"></i> <span id="i18n-section-logs"></span>
+            <span id="error-count" class="badge-count hidden"></span>
           </div>
-          <div class="economics-panel-body" id="token-usage-content">
-            <div class="empty-state">Loading…</div>
+          <div id="logs-content" class="section-content logs">
+            <div class="empty-state" id="i18n-empty-logs"></div>
           </div>
         </div>
 
-        <div class="economics-panel">
-          <div class="economics-panel-header">
-            <span class="economics-panel-title" id="i18n-economics-monthly-budget"></span>
+        <div id="stats-section" class="section hidden">
+          <div class="section-header clickable" onclick="toggleStats()" role="button" tabindex="0" onkeydown="activateOnKeydown(event)">
+            <i data-lucide="bar-chart-3"></i> <span id="i18n-section-stats"></span>
+            <span id="stats-toggle" class="toggle-icon collapsed"><i data-lucide="chevron-down"></i></span>
+            <button id="recalculate-btn" class="btn btn-sm btn-secondary" onclick="event.stopPropagation(); recalculateStats()" style="margin-left: auto; font-size: 0.75rem; padding: 2px 8px;">
+              <i data-lucide="refresh-cw" style="width: 12px; height: 12px;"></i>
+              <span id="recalculate-label"></span>
+            </button>
+            <span id="backfill-progress" class="badge-count hidden" style="margin-left: 4px;"></span>
           </div>
-          <div class="economics-panel-body">
-            <div id="budget-tile">
-              <div class="empty-state">Loading…</div>
+          <div id="project-stats" class="section-content stats-grid hidden">
+            <div class="empty-state" id="i18n-empty-stats"></div>
+          </div>
+        </div>
+
+        <div id="team-section" class="section hidden">
+          <div class="section-header clickable" onclick="toggleTeamSection()" role="button" tabindex="0" onkeydown="activateOnKeydown(event)">
+            <i data-lucide="users"></i> <span id="i18n-section-team"></span>
+            <span id="team-toggle" class="toggle-icon collapsed"><i data-lucide="chevron-down"></i></span>
+          </div>
+          <div id="team-tab-content" class="section-content hidden">
+            <div class="empty-state" id="i18n-empty-team"></div>
+          </div>
+        </div>
+
+        <div id="claude-economics-section" class="section">
+          <div class="section-header clickable" onclick="toggleSection('claude-economics-section')" role="button" tabindex="0" onkeydown="activateOnKeydown(event)">
+            <i data-lucide="circuit-board"></i> <span id="i18n-section-claude-economics"></span>
+            <span class="section-toggle collapsed"><i data-lucide="chevron-down"></i></span>
+          </div>
+          <div class="section-content economics-content hidden">
+            <div class="economics-panel">
+              <div class="economics-panel-header">
+                <span class="economics-panel-title" id="i18n-economics-token-usage"></span>
+              </div>
+              <div class="economics-panel-body" id="token-usage-content">
+                <div class="empty-state">Loading…</div>
+              </div>
             </div>
-            <div class="budget-slider-row">
-              <label for="budget-slider" id="budget-slider-label">Cap: <span id="budget-slider-value">$200</span></label>
-              <input type="range" id="budget-slider" min="0" max="600" step="10" value="200" />
-              <button id="budget-slider-submit" type="button">Apply</button>
-              <span id="budget-slider-status" class="budget-slider-status"></span>
+
+            <div class="economics-panel">
+              <div class="economics-panel-header">
+                <span class="economics-panel-title" id="i18n-economics-monthly-budget"></span>
+              </div>
+              <div class="economics-panel-body">
+                <div id="budget-tile">
+                  <div class="empty-state">Loading…</div>
+                </div>
+                <div class="budget-slider-row">
+                  <label for="budget-slider" id="budget-slider-label">Cap: <span id="budget-slider-value">$200</span></label>
+                  <input type="range" id="budget-slider" min="0" max="600" step="10" value="200" />
+                  <button id="budget-slider-submit" type="button">Apply</button>
+                  <span id="budget-slider-status" class="budget-slider-status"></span>
+                </div>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-    </div>
 
-    <div class="section" id="active-reviews-section">
-      <div class="section-header">
-        <i data-lucide="file-search"></i> <span id="i18n-section-active-reviews"></span>
-        <span id="active-reviews-count" class="badge-count hidden">0</span>
-      </div>
-      <div id="active-reviews" class="section-content">
-        <div class="empty-state" id="i18n-empty-active-reviews"></div>
-      </div>
-    </div>
+        <div class="section" id="active-reviews-section">
+          <div class="section-header">
+            <i data-lucide="file-search"></i> <span id="i18n-section-active-reviews"></span>
+            <span id="active-reviews-count" class="badge-count hidden">0</span>
+          </div>
+          <div id="active-reviews" class="section-content">
+            <div class="empty-state" id="i18n-empty-active-reviews"></div>
+          </div>
+        </div>
 
-    <div class="section hidden" id="active-followups-section">
-      <div class="section-header clickable" onclick="toggleSection('active-followups-section')" role="button" tabindex="0" onkeydown="activateOnKeydown(event)">
-        <i data-lucide="refresh-cw"></i> <span id="i18n-section-active-followups"></span>
-        <span id="active-followups-count" class="badge-count hidden">0</span>
-        <span class="section-toggle collapsed"><i data-lucide="chevron-down"></i></span>
-      </div>
-      <div id="active-followups" class="section-content">
-        <div class="empty-state" id="i18n-empty-active-followups"></div>
-      </div>
-    </div>
+        <div class="section hidden" id="active-followups-section">
+          <div class="section-header clickable" onclick="toggleSection('active-followups-section')" role="button" tabindex="0" onkeydown="activateOnKeydown(event)">
+            <i data-lucide="refresh-cw"></i> <span id="i18n-section-active-followups"></span>
+            <span id="active-followups-count" class="badge-count hidden">0</span>
+            <span class="section-toggle collapsed"><i data-lucide="chevron-down"></i></span>
+          </div>
+          <div id="active-followups" class="section-content">
+            <div class="empty-state" id="i18n-empty-active-followups"></div>
+          </div>
+        </div>
 
-    <div class="section hidden" id="pending-fix-section">
-      <div class="section-header">
-        <i data-lucide="wrench"></i> <span id="i18n-section-pending-fix"></span>
-        <span id="pending-fix-count" class="badge-count hidden">0</span>
-        <button id="sync-threads-btn" class="btn-icon btn-sync" onclick="syncGitLabThreads()">
-          <i data-lucide="refresh-cw"></i>
-        </button>
-      </div>
-      <div id="pending-fix-reviews" class="section-content">
-        <div class="empty-state" id="i18n-empty-pending-fix"></div>
-      </div>
-    </div>
+        <div class="section hidden" id="pending-fix-section">
+          <div class="section-header">
+            <i data-lucide="wrench"></i> <span id="i18n-section-pending-fix"></span>
+            <span id="pending-fix-count" class="badge-count hidden">0</span>
+            <button id="sync-threads-btn" class="btn-icon btn-sync" onclick="syncGitLabThreads()">
+              <i data-lucide="refresh-cw"></i>
+            </button>
+          </div>
+          <div id="pending-fix-reviews" class="section-content">
+            <div class="empty-state" id="i18n-empty-pending-fix"></div>
+          </div>
+        </div>
 
-    <div class="section hidden" id="pending-approval-section">
-      <div class="section-header clickable" onclick="toggleSection('pending-approval-section')" role="button" tabindex="0" onkeydown="activateOnKeydown(event)">
-        <i data-lucide="circle-check"></i> <span id="i18n-section-pending-approval"></span>
-        <span id="pending-approval-count" class="badge-count hidden">0</span>
-        <span class="section-toggle collapsed"><i data-lucide="chevron-down"></i></span>
-      </div>
-      <div id="pending-approval-reviews" class="section-content">
-        <div class="empty-state" id="i18n-empty-pending-approval"></div>
-      </div>
-    </div>
+        <div class="section hidden" id="pending-approval-section">
+          <div class="section-header clickable" onclick="toggleSection('pending-approval-section')" role="button" tabindex="0" onkeydown="activateOnKeydown(event)">
+            <i data-lucide="circle-check"></i> <span id="i18n-section-pending-approval"></span>
+            <span id="pending-approval-count" class="badge-count hidden">0</span>
+            <span class="section-toggle collapsed"><i data-lucide="chevron-down"></i></span>
+          </div>
+          <div id="pending-approval-reviews" class="section-content">
+            <div class="empty-state" id="i18n-empty-pending-approval"></div>
+          </div>
+        </div>
 
-    <div class="section" id="completed-reviews-section">
-      <div class="section-header clickable" onclick="toggleSection('completed-reviews-section')" role="button" tabindex="0" onkeydown="activateOnKeydown(event)">
-        <i data-lucide="file-check"></i> <span id="i18n-section-completed-reviews"></span>
-        <span class="section-toggle collapsed"><i data-lucide="chevron-down"></i></span>
-      </div>
-      <div id="recent-reviews" class="section-content">
-        <div class="empty-state" id="i18n-empty-loading"></div>
-      </div>
-    </div>
+        <div class="section" id="completed-reviews-section">
+          <div class="section-header clickable" onclick="toggleSection('completed-reviews-section')" role="button" tabindex="0" onkeydown="activateOnKeydown(event)">
+            <i data-lucide="file-check"></i> <span id="i18n-section-completed-reviews"></span>
+            <span class="section-toggle collapsed"><i data-lucide="chevron-down"></i></span>
+          </div>
+          <div id="recent-reviews" class="section-content">
+            <div class="empty-state" id="i18n-empty-loading"></div>
+          </div>
+        </div>
 
-    <div class="section" id="cleanup-section">
-      <div class="section-header">
-        <i data-lucide="trash-2"></i> <span>Nettoyage</span>
-      </div>
-      <div class="section-content" id="cleanup-content"></div>
-    </div>
+        <div class="section" id="cleanup-section">
+          <div class="section-header">
+            <i data-lucide="trash-2"></i> <span>Nettoyage</span>
+          </div>
+          <div class="section-content" id="cleanup-content"></div>
+        </div>
 
         <div class="refresh-info">
           <span id="connection-mode"></span> • <span id="i18n-connection-fallback"></span>

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -66,62 +66,67 @@
           </select>
         </div>
       </div>
-      <div class="card">
-        <div class="card-label" id="i18n-card-language"></div>
-        <div class="card-model">
+    </div>
+
+    <div class="dashboard-layout">
+      <aside class="dashboard-sidebar" aria-label="Project tools">
+        <div class="sidebar-language">
+          <label class="sidebar-language-label" for="language-select" id="i18n-card-language"></label>
           <select id="language-select" class="model-select" onchange="changeLanguage(this.value)">
             <option value="en">English</option>
             <option value="fr">Français</option>
           </select>
         </div>
-      </div>
-    </div>
 
-    <div class="focus-strip">
-      <div class="focus-chip focus-now">
-        <div class="focus-copy">
-          <span class="focus-label" id="i18n-strip-now"></span>
-          <span class="focus-meta" id="i18n-strip-now-meta"></span>
+        <div class="project-loader">
+          <select id="project-select" class="project-input" onchange="onProjectSelect(this.value)">
+            <option value="" id="i18n-project-placeholder"></option>
+          </select>
+          <input type="text" id="project-path-input" class="project-input" value="">
+          <button class="btn btn-primary" onclick="loadProjectConfig()">
+            <i data-lucide="folder-open"></i> <span id="i18n-project-load"></span>
+          </button>
+          <button id="remove-project-btn" class="btn btn-secondary" onclick="removeCurrentProject()">
+            <i data-lucide="trash-2"></i>
+          </button>
+          <span id="config-status" class="config-status hidden"></span>
         </div>
-        <span class="focus-value" id="focus-now-count">-</span>
-      </div>
-      <div class="focus-chip focus-next">
-        <div class="focus-copy">
-          <span class="focus-label" id="i18n-strip-next"></span>
-          <span class="focus-meta" id="i18n-strip-next-meta"></span>
-        </div>
-        <span class="focus-value" id="focus-next-count">-</span>
-      </div>
-      <div class="focus-chip focus-blocked">
-        <div class="focus-copy">
-          <span class="focus-label" id="i18n-strip-blocked"></span>
-          <span class="focus-meta" id="i18n-strip-blocked-meta"></span>
-        </div>
-        <span class="focus-value" id="focus-blocked-count">-</span>
-      </div>
-      <button id="focus-strip-toggle" class="focus-toggle-btn" onclick="toggleFocusStripMode()"></button>
-    </div>
 
-    <div id="data-loading-state" class="data-loading hidden" role="status" aria-live="polite">
-      <i data-lucide="loader-circle"></i>
-      <span id="i18n-loading-data"></span>
-    </div>
+        <div class="focus-strip">
+          <div class="focus-chip focus-now">
+            <div class="focus-copy">
+              <span class="focus-label" id="i18n-strip-now"></span>
+              <span class="focus-meta" id="i18n-strip-now-meta"></span>
+            </div>
+            <span class="focus-value" id="focus-now-count">-</span>
+          </div>
+          <div class="focus-chip focus-next">
+            <div class="focus-copy">
+              <span class="focus-label" id="i18n-strip-next"></span>
+              <span class="focus-meta" id="i18n-strip-next-meta"></span>
+            </div>
+            <span class="focus-value" id="focus-next-count">-</span>
+          </div>
+          <div class="focus-chip focus-blocked">
+            <div class="focus-copy">
+              <span class="focus-label" id="i18n-strip-blocked"></span>
+              <span class="focus-meta" id="i18n-strip-blocked-meta"></span>
+            </div>
+            <span class="focus-value" id="focus-blocked-count">-</span>
+          </div>
+          <button id="focus-strip-toggle" class="focus-toggle-btn" onclick="toggleFocusStripMode()"></button>
+        </div>
 
-    <div class="project-loader">
-      <select id="project-select" class="project-input" style="min-width: 350px;" onchange="onProjectSelect(this.value)">
-        <option value="" id="i18n-project-placeholder"></option>
-      </select>
-      <input type="text" id="project-path-input" class="project-input" style="min-width: 250px;"
-             value="">
-      <button class="btn btn-primary" onclick="loadProjectConfig()">
-        <i data-lucide="folder-open"></i> <span id="i18n-project-load"></span>
-      </button>
-      <button id="remove-project-btn" class="btn btn-secondary" onclick="removeCurrentProject()">
-        <i data-lucide="trash-2"></i>
-      </button>
-      <span id="config-status" class="config-status hidden"></span>
-    </div>
-    <div id="config-info" class="config-info hidden"></div>
+        <section id="worktree-section" aria-label="Worktree pool"></section>
+      </aside>
+
+      <main class="dashboard-main">
+        <div id="data-loading-state" class="data-loading hidden" role="status" aria-live="polite">
+          <i data-lucide="loader-circle"></i>
+          <span id="i18n-loading-data"></span>
+        </div>
+
+        <div id="config-info" class="config-info hidden"></div>
 
     <div id="claude-login-section" class="login-instructions hidden">
       <strong><i data-lucide="alert-triangle"></i> <span id="i18n-claude-login-title"></span></strong>
@@ -170,28 +175,36 @@
       </div>
     </div>
 
-    <div id="token-usage-section" class="section hidden">
-      <div class="section-header">
-        <i data-lucide="coins"></i> <span>Claude token usage</span>
+    <div id="claude-economics-section" class="section">
+      <div class="section-header clickable" onclick="toggleSection('claude-economics-section')" role="button" tabindex="0" onkeydown="activateOnKeydown(event)">
+        <i data-lucide="circuit-board"></i> <span id="i18n-section-claude-economics"></span>
+        <span class="section-toggle collapsed"><i data-lucide="chevron-down"></i></span>
       </div>
-      <div id="token-usage-content" class="section-content">
-        <div class="empty-state">Loading…</div>
-      </div>
-    </div>
-
-    <div id="budget-section" class="section">
-      <div class="section-header">
-        <i data-lucide="wallet"></i> <span>Monthly Claude budget</span>
-      </div>
-      <div class="section-content">
-        <div id="budget-tile">
-          <div class="empty-state">Loading…</div>
+      <div class="section-content economics-content hidden">
+        <div class="economics-panel">
+          <div class="economics-panel-header">
+            <span class="economics-panel-title" id="i18n-economics-token-usage"></span>
+          </div>
+          <div class="economics-panel-body" id="token-usage-content">
+            <div class="empty-state">Loading…</div>
+          </div>
         </div>
-        <div class="budget-slider-row">
-          <label for="budget-slider" id="budget-slider-label">Cap: <span id="budget-slider-value">$200</span></label>
-          <input type="range" id="budget-slider" min="0" max="600" step="10" value="200" />
-          <button id="budget-slider-submit" type="button">Apply</button>
-          <span id="budget-slider-status" class="budget-slider-status"></span>
+
+        <div class="economics-panel">
+          <div class="economics-panel-header">
+            <span class="economics-panel-title" id="i18n-economics-monthly-budget"></span>
+          </div>
+          <div class="economics-panel-body">
+            <div id="budget-tile">
+              <div class="empty-state">Loading…</div>
+            </div>
+            <div class="budget-slider-row">
+              <label for="budget-slider" id="budget-slider-label">Cap: <span id="budget-slider-value">$200</span></label>
+              <input type="range" id="budget-slider" min="0" max="600" step="10" value="200" />
+              <button id="budget-slider-submit" type="button">Apply</button>
+              <span id="budget-slider-status" class="budget-slider-status"></span>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -258,12 +271,12 @@
       <div class="section-content" id="cleanup-content"></div>
     </div>
 
-    <section id="worktree-section" aria-label="Worktree pool"></section>
-
-    <div class="refresh-info">
-      <span id="connection-mode"></span> • <span id="i18n-connection-fallback"></span>
-      <span class="refresh-separator"> • </span>
-      <span id="session-metrics"></span>
+        <div class="refresh-info">
+          <span id="connection-mode"></span> • <span id="i18n-connection-fallback"></span>
+          <span class="refresh-separator"> • </span>
+          <span id="session-metrics"></span>
+        </div>
+      </main>
     </div>
   </div>
 
@@ -348,7 +361,7 @@
     let currentInsightsData = null;
     const loadingState = { status: 0, reviewFiles: 0, stats: 0, mrTracking: 0 };
     let hasLoadedStatusOnce = false;
-    const secondarySections = ['active-followups-section', 'pending-approval-section', 'completed-reviews-section'];
+    const secondarySections = ['active-followups-section', 'pending-approval-section', 'completed-reviews-section', 'claude-economics-section'];
     const sectionExpandedState = Object.fromEntries(secondarySections.map((sectionIdentifier) => [sectionIdentifier, false]));
     const quietRefreshSections = [
       'active-reviews-section',
@@ -2273,7 +2286,6 @@
 
           document.getElementById('stats-section').classList.remove('hidden');
           document.getElementById('team-section').classList.remove('hidden');
-          document.getElementById('token-usage-section').classList.remove('hidden');
 
           const platformIcon = activePlatform === 'gitlab' ? '<i data-lucide="gitlab"></i> GitLab' : '<i data-lucide="github"></i> GitHub';
           info.innerHTML = `
@@ -2551,6 +2563,15 @@
 
       const sectionCompletedReviews = document.getElementById('i18n-section-completed-reviews');
       if (sectionCompletedReviews) sectionCompletedReviews.textContent = t('section.completedReviews');
+
+      const sectionClaudeEconomics = document.getElementById('i18n-section-claude-economics');
+      if (sectionClaudeEconomics) sectionClaudeEconomics.textContent = t('section.claudeEconomics');
+
+      const economicsTokenUsage = document.getElementById('i18n-economics-token-usage');
+      if (economicsTokenUsage) economicsTokenUsage.textContent = t('economics.tokenUsage');
+
+      const economicsMonthlyBudget = document.getElementById('i18n-economics-monthly-budget');
+      if (economicsMonthlyBudget) economicsMonthlyBudget.textContent = t('economics.monthlyBudget');
 
       // Empty states
       const emptyLogs = document.getElementById('i18n-empty-logs');

--- a/src/dashboard/modules/budgetSettings.js
+++ b/src/dashboard/modules/budgetSettings.js
@@ -61,12 +61,11 @@ export function renderBudgetTile(viewModel) {
     ? '<span class="budget-tile-badge budget-tile-badge--exceeded">Budget exceeded</span>'
     : '';
   const gaugeClass = viewModel.exceeded ? 'budget-gauge-fill budget-gauge-fill--exceeded' : 'budget-gauge-fill';
+  const headerSection = viewModel.exceeded ? `<div class="budget-tile-header">${exceededBadge}</div>` : '';
 
   return `
     <div class="budget-tile">
-      <div class="budget-tile-header">
-        ${exceededBadge}
-      </div>
+      ${headerSection}
       <div class="budget-tile-figures">
         <span class="budget-tile-consumed">${escapeHtml(viewModel.consumedUsdFormatted)}</span>
         <span class="budget-tile-separator">/</span>

--- a/src/dashboard/modules/budgetSettings.js
+++ b/src/dashboard/modules/budgetSettings.js
@@ -65,7 +65,6 @@ export function renderBudgetTile(viewModel) {
   return `
     <div class="budget-tile">
       <div class="budget-tile-header">
-        <span class="budget-tile-title">Monthly Claude budget</span>
         ${exceededBadge}
       </div>
       <div class="budget-tile-figures">

--- a/src/dashboard/modules/i18n.js
+++ b/src/dashboard/modules/i18n.js
@@ -145,6 +145,9 @@ const translations = {
     'section.pendingApproval': 'Pending approval',
     'section.queueLanes': 'Priority lanes',
     'section.completedReviews': 'Completed reviews',
+    'section.claudeEconomics': 'Claude economics',
+    'economics.tokenUsage': '// TOKEN USAGE',
+    'economics.monthlyBudget': '// MONTHLY BUDGET',
 
     // Queue lanes
     'queueLane.now': 'Handle now',
@@ -545,6 +548,9 @@ const translations = {
     'section.pendingApproval': "En attente d'approbation",
     'section.queueLanes': 'Priorité',
     'section.completedReviews': 'Reviews terminées',
+    'section.claudeEconomics': 'Économie Claude',
+    'economics.tokenUsage': '// CONSOMMATION TOKENS',
+    'economics.monthlyBudget': '// BUDGET MENSUEL',
 
     // Queue lanes
     'queueLane.now': 'À traiter maintenant',

--- a/src/dashboard/styles.css
+++ b/src/dashboard/styles.css
@@ -114,7 +114,11 @@ body {
   padding: 1.5rem 0;
 }
 
-.container { margin: 68px; }
+.container { margin: 1rem; }
+
+@media (min-width: 1024px) {
+  .container { margin: 68px; }
+}
 
 .dashboard-layout {
   display: grid;
@@ -4115,11 +4119,10 @@ input:focus-visible,
 }
 .budget-tile-header {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
   font-size: 0.875rem;
 }
-.budget-tile-title { font-weight: 600; color: var(--nsc-text-primary); }
 .budget-tile-badge {
   padding: 0.1rem 0.5rem;
   border-radius: 999px;

--- a/src/dashboard/styles.css
+++ b/src/dashboard/styles.css
@@ -111,10 +111,74 @@ body {
     linear-gradient(145deg, var(--nsc-bg-base) 0%, #0e1728 100%);
   color: var(--nsc-text-primary);
   min-height: 100vh;
-  padding: 2rem;
+  padding: 1.5rem 0;
 }
 
-.container { max-width: 900px; margin: 0 auto; }
+.container { margin: 68px; }
+
+.dashboard-layout {
+  display: grid;
+  grid-template-columns: 20% 80%;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.dashboard-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  position: sticky;
+  top: 1rem;
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
+  min-width: 0;
+}
+
+.dashboard-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.dashboard-sidebar .project-loader {
+  flex-direction: column;
+  align-items: stretch;
+  margin-bottom: 0;
+  gap: 0.5rem;
+}
+
+.dashboard-sidebar .project-loader .project-input {
+  min-width: 0;
+  width: 100%;
+}
+
+.dashboard-sidebar .project-loader .btn {
+  width: 100%;
+  justify-content: center;
+}
+
+.dashboard-sidebar .focus-strip {
+  grid-template-columns: 1fr;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.dashboard-sidebar #worktree-section {
+  margin-top: 0;
+}
+
+.sidebar-language {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.sidebar-language-label {
+  font-size: 0.75rem;
+  color: var(--nsc-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
 
 header {
   display: flex;
@@ -1998,11 +2062,22 @@ body.compact-density .quality-trend {
 
 @media (max-width: 980px) {
   body {
-    padding: 1rem;
+    padding: 1rem 0;
   }
 
   .container {
     max-width: 100%;
+  }
+
+  .dashboard-layout {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .dashboard-sidebar {
+    position: static;
+    max-height: none;
+    overflow-y: visible;
   }
 
   .cards {
@@ -2236,9 +2311,6 @@ body::before {
   );
   z-index: 9999;
 }
-
-/* Wider container */
-.container { max-width: 1100px; }
 
 /* Custom scrollbar */
 ::-webkit-scrollbar { width: 6px; height: 6px; }
@@ -4107,6 +4179,85 @@ input:focus-visible,
 .budget-slider-status { font-size: 0.8rem; min-width: 7rem; }
 .budget-slider-status--ok { color: #16a34a; }
 .budget-slider-status--error { color: #dc2626; }
+
+/* ============================================================
+   Claude economics accordion — Agentic OS visual DNA
+   Scoped: #claude-economics-section keeps the theme contained.
+   Mirrors the worktree-section design language (corner brackets,
+   monospace title, // LABEL prefix, reveal animation).
+   ============================================================ */
+
+#claude-economics-section {
+  --eco-bg: #0a0908;
+  --eco-border-faint: rgba(255, 180, 100, 0.12);
+  --eco-border-active: rgba(255, 138, 61, 0.65);
+  --eco-accent: #ff8a3d;
+  --eco-text-primary: #f3eee8;
+  --eco-mono: ui-monospace, "SF Mono", "JetBrains Mono", "Berkeley Mono", monospace;
+}
+
+#claude-economics-section .economics-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-top: 12px;
+}
+
+#claude-economics-section .economics-panel {
+  position: relative;
+  background: var(--eco-bg);
+  border: 1px solid var(--eco-border-faint);
+  padding: 18px 20px 16px;
+  animation: economics-reveal 250ms ease-out;
+  font-family: var(--eco-mono);
+  color: var(--eco-text-primary);
+}
+
+#claude-economics-section .economics-panel::before,
+#claude-economics-section .economics-panel::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  pointer-events: none;
+}
+
+#claude-economics-section .economics-panel::before {
+  top: -1px;
+  left: -1px;
+  border-top: 2px solid var(--eco-border-active);
+  border-left: 2px solid var(--eco-border-active);
+}
+
+#claude-economics-section .economics-panel::after {
+  bottom: -1px;
+  right: -1px;
+  border-bottom: 2px solid var(--eco-border-active);
+  border-right: 2px solid var(--eco-border-active);
+}
+
+@keyframes economics-reveal {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+#claude-economics-section .economics-panel-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 14px;
+}
+
+#claude-economics-section .economics-panel-title {
+  font-family: var(--eco-mono);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  color: var(--eco-accent);
+  text-transform: none;
+}
+
+#claude-economics-section .economics-panel-body {
+  font-family: var(--eco-mono);
+}
 
 /* ============================================================
    SPEC-173 — Worktree Pool ("Agentic OS" visual DNA)


### PR DESCRIPTION
## Summary

- **Two-column layout** — Dashboard split into a 20% sidebar (language selector, project loader, focus strip, worktree pool) and an 80% main panel (review sections + refresh info). Header and status cards remain full-width.
- **Container freed** — Removed the lingering `.container { max-width: 1100px }` override; container now respects the configured `margin: 68px`.
- **Claude economics accordion** — Merges `Claude token usage` and `Monthly Claude budget` into a single collapsed-by-default section. Inner panels reuse the worktree-section *Agentic OS* visual DNA (corner brackets, monospace title with `//` prefix, reveal animation), scoped to `#claude-economics-section` to prevent style leakage.
- **i18n** — Added EN/FR keys for the new accordion title and its two sub-panels (previously hardcoded English). Removed the duplicated tile title that would otherwise overlap the new sub-panel title.

## Test plan

- [x] `yarn verify` — 250 test files / 1805 tests pass
- [ ] Visual: refresh `/dashboard/` — sidebar 20%, main panel 80%, header full-width
- [ ] Sidebar order from top: language → project loader → focus strip → worktree pool
- [ ] `Claude economics` accordion appears collapsed; clicking expands to show both sub-panels with corner-bracket framing and reveal animation
- [ ] Switch language: accordion title + both sub-panel titles update (EN ↔ FR)
- [ ] Resize browser below 980px: layout stacks vertically, sidebar becomes non-sticky

🤖 Generated with [Claude Code](https://claude.com/claude-code)