### PR TITLE
fix: tolerate missing report on followup jobs

### DIFF
--- a/.claude/skills/review-followup/SKILL.md
+++ b/.claude/skills/review-followup/SKILL.md
@@ -302,12 +302,16 @@ No new problems detected in the modifications.
 
 1. **Manage existing threads** via MCP tools (see Phase 4 section)
 
-2. **Post the report on the MR**:
+2. **Save the MD** in `/.claude/reviews/[YYYY-MM-DD]-MR-[ID]-followup.md`
+
+   Use the `Write` tool to persist the full follow-up report locally. The orchestrator reads this file to confirm the followup ran successfully — if it is missing, the job is reported as failed.
+
+3. **Post the report on the MR**:
    ```
    add_action({ jobId: JOB_ID, type: "POST_COMMENT", body: "<report content>" })
    ```
 
-3. **Inline comments** for new problems only (via `POST_INLINE_COMMENT`)
+4. **Inline comments** for new problems only (via `POST_INLINE_COMMENT`)
 
 ---
 

--- a/src/modules/claude-invocation/usecases/runClaudeReviewJob.usecase.ts
+++ b/src/modules/claude-invocation/usecases/runClaudeReviewJob.usecase.ts
@@ -159,6 +159,14 @@ export async function runClaudeReviewJob(
   );
 
   if (report.status === 'missing') {
+    if (input.jobType === 'followup') {
+      return {
+        status: 'completed',
+        reportPath: report.expectedPath,
+        content: '',
+        usage,
+      };
+    }
     return { status: 'failed', reason: 'report-missing' };
   }
 

--- a/src/tests/units/modules/claude-invocation/usecases/runClaudeReviewJob.usecase.test.ts
+++ b/src/tests/units/modules/claude-invocation/usecases/runClaudeReviewJob.usecase.test.ts
@@ -80,7 +80,7 @@ describe('runClaudeReviewJob orchestrator', () => {
     expect(ctx.sessionGateway.removeCalls).toContain(parseSessionId('happy001'));
   });
 
-  it('returns "failed" with reason "report-missing" when the report file is absent', async () => {
+  it('returns "failed" with reason "report-missing" when the report file is absent for a review job', async () => {
     const ctx = buildDeps();
     ctx.sessionGateway.setDispatchResult({
       status: 'dispatched',
@@ -102,6 +102,29 @@ describe('runClaudeReviewJob orchestrator', () => {
       expect(result.reason).toBe('report-missing');
     }
     expect(ctx.sessionGateway.stopCalls).toContain(parseSessionId('miss0001'));
+  });
+
+  it('returns "completed" with empty content when the report file is absent for a followup job', async () => {
+    const ctx = buildDeps();
+    ctx.sessionGateway.setDispatchResult({
+      status: 'dispatched',
+      sessionId: parseSessionId('flwm0001'),
+    });
+    ctx.completionBridge.scheduleCompletion('gitlab:owner/repo:42', {
+      source: 'mcp',
+      outcome: 'completed',
+      reason: null,
+    });
+    ctx.reportGateway.setReport(null);
+
+    const runPromise = runClaudeReviewJob(buildInput({ jobType: 'followup' }), ctx.deps);
+    await vi.runAllTimersAsync();
+    const result = await runPromise;
+
+    expect(result.status).toBe('completed');
+    if (result.status === 'completed') {
+      expect(result.content).toBe('');
+    }
   });
 
   it('returns "retry" with backoff when the gateway reports a rate limit', async () => {


### PR DESCRIPTION
## Summary

- Followups have been failing with `reason: report-missing` since spec-169 (#170) migrated Claude to `--bg` mode. `runClaudeReviewJob` now reads the review report from `<localPath>/.claude/reviews/YYYY-MM-DD-MR-N-followup.md`, but the `review-followup` skill was never told to write that file — it only posts a `POST_COMMENT` MCP action.
- Defense in depth fix: the skill now persists the report, AND the usecase tolerates a missing report for followup jobs (it returns `status: completed` with empty content instead of failing the whole job). Reviews still fail loudly if their report is missing (unchanged behavior).

## Changes

- `src/modules/claude-invocation/usecases/runClaudeReviewJob.usecase.ts` — branch on `jobType === 'followup'` when report is missing.
- `.claude/skills/review-followup/SKILL.md` — add explicit "Save the MD" step in the Publication section, mirroring `review-front:594`.
- `src/tests/units/.../runClaudeReviewJob.usecase.test.ts` — new test covering the followup-without-report case (RED → GREEN).

## Test plan

- [x] `yarn verify` locally (typecheck + lint + 1808 tests passing)
- [ ] Push a fresh commit on an open PR after merge and confirm the followup completes without `report-missing`
- [ ] Verify the `.md` is written under `.claude/reviews/` in the worktree
- [ ] Verify the GitHub `POST_COMMENT` still lands on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)