### PR TITLE
docs(specs): draft axe-3 backlog and reactivate SPEC-91

### DIFF
--- a/docs/feature-tracker.md
+++ b/docs/feature-tracker.md
@@ -5,7 +5,7 @@
 | Token budget cap with live indicator | [163-token-budget-cap](specs/163-token-budget-cap.md) | implemented | 2026-05-20 |
 | Token usage summary on dashboard | [126-token-usage-summary-dashboard](specs/126-token-usage-summary-dashboard.md) | implemented | 2026-05-20 |
 | Init project command | [30-init-project-command](specs/30-init-project-command.md) | drafted | 2026-03-14 |
-| Update README quickstart | [32-update-readme-quickstart](specs/32-update-readme-quickstart.md) | drafted | 2026-03-14 |
+| ~~Update README quickstart~~ | [32-update-readme-quickstart](specs/32-update-readme-quickstart.md) | obsolete (npm flow N/A — daemon local) | 2026-03-14 |
 | Zod guard GitLab webhook | [44-zod-guard-gitlab-webhook](specs/44-zod-guard-gitlab-webhook.md) | implemented | 2026-03-14 |
 | GitHub followup review on push | [46-github-followup-review-on-push](specs/46-github-followup-review-on-push.md) | implemented | 2026-05-20 |
 | Capture git diff stats | [47-capture-git-diff-stats](specs/47-capture-git-diff-stats.md) | drafted | 2026-03-14 |
@@ -28,11 +28,11 @@
 | Split stats service | [80-split-stats-service](specs/80-split-stats-service.md) | drafted | 2026-03-14 |
 | EventBus queue state | [82-eventbus-queue-state](specs/82-eventbus-queue-state.md) | implemented | 2026-03-14 |
 | Delete services folder | [83-delete-services-folder](specs/83-delete-services-folder.md) | implemented | 2026-03-14 |
-| Dashboard multi-project overview | [91-dashboard-multi-project-overview](specs/91-dashboard-multi-project-overview.md) | implemented | 2026-03-14 |
+| Dashboard multi-project overview | [91-dashboard-multi-project-overview](specs/91-dashboard-multi-project-overview.md) | re-drafted (UI gap) | 2026-05-24 |
 | Split CLI god file | [92-split-cli-god-file](specs/92-split-cli-god-file.md) | drafted | 2026-03-14 |
 | Developer & team insights | [125-developer-team-insights](specs/125-developer-team-insights.md) | implemented | 2026-04-01 |
 | Hybrid model routing + token tracking | (no spec — see report) | implemented | 2026-05-14 |
-| Skill templates | [skill-templates](specs/skill-templates.md) | drafted | 2026-03-14 |
+| ~~Skill templates~~ | [skill-templates](specs/skill-templates.md) | obsolete (superseded by SPEC-56) | 2026-03-14 |
 | Verify --bg subscription billing (post-deploy) | [168-validate-bg-subscription-billing](specs/168-validate-bg-subscription-billing.md) | verifying | 2026-05-22 |
 | Migrate Claude invocation -p → --bg | [169-migrate-claude-invocation-to-bg-mode](specs/169-migrate-claude-invocation-to-bg-mode.md) | implemented | 2026-05-22 |
 | Pre-built worktree lifecycle | [170-prebuilt-worktree-lifecycle](specs/170-prebuilt-worktree-lifecycle.md) | implemented | 2026-05-23 |
@@ -41,3 +41,5 @@
 | Claude agents supervisor lifecycle | [172-claude-agents-supervisor-lifecycle](specs/172-claude-agents-supervisor-lifecycle.md) | implemented | 2026-05-23 |
 | Dashboard worktree panel | [173-dashboard-worktree-panel](specs/173-dashboard-worktree-panel.md) — [plan](plans/173-dashboard-worktree-panel.plan.md) — [report](reports/173-dashboard-worktree-panel.report.md) | implemented | 2026-05-23 |
 | Semi-automatic review trigger mode | [174-semi-auto-review-trigger-mode](specs/174-semi-auto-review-trigger-mode.md) — [plan](plans/174-semi-auto-review-trigger-mode.plan.md) | implemented | 2026-05-23 |
+| Worktree failure visibility & force-cleanup | [175-worktree-failure-visibility](specs/175-worktree-failure-visibility.md) | drafted | 2026-05-24 |
+| Job history persistence | [176-job-history-persistence](specs/176-job-history-persistence.md) | drafted | 2026-05-24 |

--- a/docs/specs/175-worktree-failure-visibility.md
+++ b/docs/specs/175-worktree-failure-visibility.md
@@ -1,0 +1,100 @@
+# Spec #175 — Make Degraded Worktrees Visible and Cleanable from the Dashboard
+
+**Labels**: enhancement, P2-important, dashboard, worktree
+**Date**: 2026-05-24
+**Status**: drafted
+
+---
+
+## Context
+
+SPEC-170 and SPEC-173 delivered the nominal worktree lifecycle (build, reuse, sweep) and the dashboard panel showing active worktrees. Failures along the way — stale worktrees never collected, orphan git locks, unresolved conflicts, missing build artifacts — are currently logged as warnings only, with no visual surface in the dashboard and no way to act on them without SSH'ing into the host. This forces the operator to discover problems through indirect signals (a review hangs, a job fails mysteriously) instead of seeing the worktree state at a glance.
+
+The dashboard needs to (1) flag degraded worktrees explicitly and (2) offer a force-cleanup action from the UI so the operator can resolve the situation without leaving the dashboard.
+
+---
+
+## Rules
+
+- A worktree in a degraded state must display a visual alert in the dashboard worktree panel
+- Detected degraded states: stale (inactive beyond threshold), orphan git lock, unresolved git conflict, missing build artifacts
+- Stale threshold is configurable (default: 24h)
+- Each degraded worktree shows: reason, detection timestamp, recommended action
+- Force-cleanup action removes the worktree from filesystem AND from git worktree registry (`git worktree prune`)
+- Force-cleanup logs reason, timestamp, and outcome (success or failure)
+- Only one force-cleanup action per worktree may run concurrently
+- Cleanup failures surface as a separate alert and do not silently disappear from the panel
+- Healthy worktrees show no alert and no force-cleanup button
+
+---
+
+## Scenarios
+
+- healthy worktree: {state: "active", lastActivity: "5min"} → status "healthy" + no alert
+- stale detected: {state: "active", lastActivity: "26h", staleThreshold: "24h"} → status "stale" + alert "Worktree inactif depuis 26h"
+- orphan git lock: {gitLockPresent: true, lockAge: "2h"} → status "degraded" + alert "Lock git orphelin depuis 2h"
+- unresolved git conflict: {gitStatus: "conflict"} → status "degraded" + alert "Conflit git non résolu"
+- missing build artifacts: {buildArtifactsPresent: false} → status "degraded" + alert "Artefacts de build manquants"
+- force-cleanup success: {worktree: "stale", action: "force-cleanup"} → removed + log entry "Force cleanup (raison : inactif 26h)"
+- force-cleanup failure: {worktree: "stale", action: "force-cleanup", filesystemError: "EACCES"} → reject "Cleanup échoué : permission refusée" + alert preserved + failure log entry
+- force-cleanup already running: {worktree: "stale", action: "force-cleanup", inProgress: true} → reject "Cleanup déjà en cours sur ce worktree"
+- alert clears after success: {worktree: "stale", action: "force-cleanup", succeeded: true} → alert removed from panel + worktree disappears from list
+- multiple degraded worktrees: {worktrees: 3, allStale: true} → 3 distinct alerts shown + 3 independent force-cleanup buttons
+
+---
+
+## Out of Scope
+
+- Auto-recovery (delete-then-rebuild) — separate spec if real demand emerges
+- Disk pressure / capacity-based proactive cleanup — separate concern
+- Per-MR retry logic on failed worktree creation — already handled by SPEC-170 lifecycle
+- Confirmation dialog before force-cleanup — degraded state implies the operator already saw the alert and decided to act
+- Cross-platform support beyond Linux — ReviewFlow runs on systemd Linux only
+- Email or push notifications on degraded state — dashboard-only for now
+
+---
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| Worktree | Working directory created via `git worktree add` and used as the isolated checkout for a single MR review |
+| Stale | A worktree whose last activity timestamp is older than the configured threshold (default 24h) |
+| Degraded | A worktree in a state preventing its normal lifecycle: stale, orphan lock, conflict, or missing build artifacts |
+| Force-cleanup | An operator-triggered removal of a worktree that bypasses the normal lifecycle checks |
+| Build artifacts | The files produced by the project's build (e.g., `node_modules`, `dist`) whose absence indicates an interrupted setup |
+
+---
+
+## INVEST Evaluation
+
+| Criterion | Status | Note |
+|-----------|--------|------|
+| Independent | OK | SPEC-170 and SPEC-173 are shipped; no new blocker |
+| Negotiable | OK | Detection signals and UI form left to implementation |
+| Valuable | OK | Operator regains visibility and one-click resolution without SSH |
+| Estimable | OK | Bounded: 1 detection gateway, 1 use case, 1 controller route, 1 presenter, dashboard view update |
+| Small | OK | ~10 files, fits 1.5-2j IA |
+| Testable | OK | 10 scenarios, each maps to one observable behavior |
+
+**Verdict**: READY
+
+---
+
+## RICE Score
+
+| Criteria | Score | Justification |
+|----------|-------|---------------|
+| Reach | 3 | Worktree module + dashboard panel |
+| Impact | 1 | Medium — prevents silent worktree leaks, replaces SSH troubleshooting with one click |
+| Confidence | 80% | Detection signals well-understood from SPEC-170/173 code; UI pattern proven by worktree panel |
+| Effort | 3 pts | 1.5-2j IA |
+| **Score** | **0.80** | |
+
+**Priority**: Moderate
+
+---
+
+## Definition of Done
+
+See `.claude/skills/product-manager/rules/dod.md` for the full checklist.

--- a/docs/specs/176-job-history-persistence.md
+++ b/docs/specs/176-job-history-persistence.md
@@ -1,0 +1,103 @@
+# Spec #176 — Persist Completed Job History to Disk
+
+**Labels**: enhancement, P2-important, queue, observability
+**Date**: 2026-05-24
+**Status**: drafted
+
+---
+
+## Context
+
+The job queue keeps only the last 20 completed jobs in memory (`pQueueAdapter.ts`). A daemon restart wipes the entire history, making it impossible to debug an older failure, compute recurrence patterns, or build a meaningful timeline view. The operator currently has no way to answer questions like "how many reviews failed yesterday?" or "did that MR fail because of a timeout last Tuesday?".
+
+This spec adds a simple, file-based persistence layer: every completed job (success, failure, killed, timeout) is appended to a daily JSONL file, with configurable retention. No new dependency, no database, no UI — just a durable trace that unlocks debugging and serves as the foundation for any future analytics or timeline UI.
+
+---
+
+## Rules
+
+- Every job completion (success, failure, killed, timeout) persists one record to disk
+- Records are stored as JSONL (one JSON object per line) for append-only safety
+- Storage path is one file per day: `~/.claude-review/jobs/<YYYY-MM-DD>.jsonl`
+- Each record contains: jobId, projectPath, mergeRequestId, startedAt, completedAt, durationMs, status, exitReason
+- Retention is 7 days by default, configurable
+- Files older than the retention window are deleted on daemon startup
+- At daemon startup, files inside the retention window are loaded into the in-memory recent list
+- Write failures (disk full, permission denied) must not block the job pipeline — warning logged, pipeline continues
+- Concurrent writes from parallel completing jobs must not corrupt the file
+- A malformed line in an existing file is skipped with a warning, the rest of the file remains usable
+
+---
+
+## Scenarios
+
+- nominal write on success: {job: "completed", jobId: "RV-abc", status: "success"} → record appended to today's file
+- write on failure: {job: "completed", status: "failed", exitReason: "claude exit code 1"} → record appended with status "failed"
+- write on killed job: {job: "killed", exitReason: "memory limit exceeded"} → record appended with status "killed"
+- daily rotation at midnight: {currentDate: "2026-05-25", lastWriteDate: "2026-05-24"} → new file created for 2026-05-25, no append to yesterday's file
+- retention sweep on startup: {filesOnDisk: "10 days", retentionDays: 7} → 3 oldest files deleted, 7 remain
+- reload at startup: {filesOnDisk: "7 days", retentionDays: 7} → all 7 days loaded into in-memory recent history
+- write failure best-effort: {diskFull: true, job: "completed"} → pipeline continues + warning "Échec persistance job RV-abc : disque plein"
+- concurrent writes: {2 jobs: "completed simultaneously"} → both records present in file, no corruption
+- malformed line tolerated: {file: "2026-05-20.jsonl", corruptLine: 5} → file kept + warning "Ligne 5 illisible, ignorée" + remaining lines loaded
+- missing storage directory: {path: "~/.claude-review/jobs/", exists: false} → directory created automatically on first write
+
+---
+
+## Out of Scope
+
+- EventBus refactoring (SPEC-82) — separate work; this spec uses the existing completion hook in `pQueueAdapter`
+- UI timeline visualization in dashboard — separate spec if value emerges from the persisted data
+- Real-time streaming of records to clients — persistence concern only
+- Compression of old files — premature optimization, 7 days of JSONL stays small
+- SQLite or any database — JSONL keeps it simple, human-readable, grep-friendly
+- Per-project retention rules — global retention only
+- Backup or rotation policies beyond simple age-based deletion
+- Querying API on top of persisted records — out of scope until a real consumer asks for it
+
+---
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| Job record | A single line in a JSONL file representing one completed job |
+| JSONL | JSON Lines format — one JSON object per line, append-friendly |
+| Retention window | The number of days of history kept on disk; older files are deleted |
+| Best-effort persistence | Persistence failures do not interrupt the main pipeline; a warning is logged |
+| Completion hook | The existing point in `pQueueAdapter` where a job is marked completed and added to the in-memory recent list |
+
+---
+
+## INVEST Evaluation
+
+| Criterion | Status | Note |
+|-----------|--------|------|
+| Independent | OK | No prerequisite spec; the completion hook already exists |
+| Negotiable | OK | Storage format and retention default are open to discussion |
+| Valuable | OK | Debugability + foundation for future timeline / analytics |
+| Estimable | OK | Bounded: 1 gateway, 1 use case, 1 startup loader, 1 retention scheduler |
+| Small | OK | ~8 files, fits 1.5j IA |
+| Testable | OK | 10 scenarios cover nominal, edge, and failure paths |
+
+**Verdict**: READY
+
+---
+
+## RICE Score
+
+| Criteria | Score | Justification |
+|----------|-------|---------------|
+| Reach | 3 | Queue framework + new storage gateway |
+| Impact | 1 | Medium — unlocks debugging and is the foundation for any future observability UI |
+| Confidence | 90% | Pattern simple, no external dependency, no protocol invention |
+| Effort | 3 pts | 1.5j IA |
+| **Score** | **0.90** | |
+
+**Priority**: Moderate
+
+---
+
+## Definition of Done
+
+See `.claude/skills/product-manager/rules/dod.md` for the full checklist.

--- a/docs/specs/91-dashboard-multi-project-overview.md
+++ b/docs/specs/91-dashboard-multi-project-overview.md
@@ -4,6 +4,50 @@
 **Labels**: enhancement, P1-critical, dashboard
 **Milestone**: Dashboard Modularization
 **Date**: 2026-03-14
+**Status**: re-drafted (2026-05-24) — UI layer never delivered despite previous "implemented" mark
+
+---
+
+## Status Update — 2026-05-24
+
+This spec was marked `implemented` in the feature tracker, but a code audit (2026-05-24) revealed only the backend layer was shipped. The UI layer is entirely missing.
+
+### What was shipped (verified)
+
+| Component | Status | Evidence |
+|-----------|--------|----------|
+| `GET /api/stats` multi-project mode | Done | `stats.routes.ts:50-64` returns all projects when no `path` param |
+| `GET /api/reviews` multi-project mode | Done | `reviews.routes.ts:41-46` returns all reviews when no `path` param |
+| WebSocket includes `projectPath` in state messages | Done | `websocket.ts:54` |
+| Job stores `projectPath` | Done | `pQueueAdapter.ts:11` |
+
+### What is missing (delta to deliver)
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Tab bar UI replacing `<select>` dropdown | Missing | `index.html:82` still uses `<select id="project-select">` |
+| Overview tab module (`modules/overview.js`) | Missing | File not present |
+| 3 sections of Overview: Active Reviews, Project Cards, Recent Feed | Missing | No UI rendering |
+| SVG sparklines for last 10 scores per project | Missing | No sparkline utility |
+| Tab state persistence in localStorage | Missing | No client-side state management |
+| Click card → navigate to project tab | Missing | No navigation logic |
+
+### Re-scoped acceptance criteria (delta only)
+
+The 12 Gherkin scenarios below remain valid as the target end-state. To unblock implementation, the work is scoped to the UI layer only, leveraging the backend already in place.
+
+### INVEST re-evaluation (2026-05-24)
+
+| Criterion | Status | Note |
+|-----------|--------|------|
+| Independent | OK | Backend ready, no blocker |
+| Negotiable | OK | UI layout free within constraints |
+| Valuable | OK | Direct UX win for multi-project users |
+| Estimable | OK | Scoped to UI: ~2-3j IA |
+| Small | OK | <15 files: index.html, styles.css, ~3 new JS modules |
+| Testable | OK | 12 scenarios already defined |
+
+**Verdict**: READY — re-drafted, can be picked up by `/implement-feature`.
 
 ---
 


### PR DESCRIPTION
## Summary

- Draft 2 new specs for axis 3 (pipelines & multi-project): SPEC-175 worktree failure visibility, SPEC-176 job history persistence
- Reactivate SPEC-91 (dashboard multi-project overview): only backend routes were shipped, UI layer is missing — status corrected from `implemented` to `re-drafted (UI gap)`
- Tracker cleanup: SPEC-32 and SPEC-003 marked obsolete

## Context

Strategic replan on 2026-05-24 identified axis 3 (worktrees, pipelines, multi-project navigation) as having **zero formalized backlog**, despite recent work (SPEC-170 to SPEC-174) shipped opportunistically. A `/product-manager` session produced this backlog, with each proposed spec challenged against the existing code to avoid duplicates and prerequisite gaps.

## Changes

### `docs/specs/91-dashboard-multi-project-overview.md` — reactivated

Code audit revealed the spec was marked `implemented` but only the backend layer was delivered (`stats.routes.ts`, `reviews.routes.ts`, `websocket.ts` — all multi-project-aware). The UI layer (tab bar, overview module, sparklines, localStorage state) is entirely missing.

Added a "Status Update — 2026-05-24" section in the spec listing what's shipped vs the delta to deliver. The 12 existing Gherkin acceptance criteria remain valid as the target end-state. INVEST re-evaluation: READY.

### `docs/specs/175-worktree-failure-visibility.md` — new

Surfaces degraded worktrees (stale, orphan git locks, unresolved conflicts, missing build artifacts) in the dashboard worktree panel, with a force-cleanup action per row. Scope kept narrow on purpose: no auto-recovery, no disk-pressure monitoring (separate specs if real demand emerges).

- 10 DSL scenarios covering nominal, edge, and failure paths
- RICE: 0.80 (Moderate)
- Effort: 1.5-2 AI-days

### `docs/specs/176-job-history-persistence.md` — new

Persists every completed job (success, failure, killed, timeout) to disk as JSONL (one file per day, 7-day retention configurable). Foundation for any future timeline or analytics UI. Explicitly independent from SPEC-82 (EventBus refactor) — uses the existing completion hook in `pQueueAdapter`.

- 10 DSL scenarios
- RICE: 0.90 (Moderate)
- Effort: 1.5 AI-days

### `docs/feature-tracker.md` — updated

- SPEC-91: `implemented` → `re-drafted (UI gap)` with date 2026-05-24
- SPEC-175 added with status `drafted`
- SPEC-176 added with status `drafted`
- SPEC-32 (README quickstart) marked `obsolete (npm flow N/A — daemon local)` with strikethrough
- SPEC-003 (Skill templates) marked `obsolete (superseded by SPEC-56)` with strikethrough

## Test plan

- [ ] Read SPEC-175 and SPEC-176 — verify scope is narrow enough and aligned with axis 3 intent
- [ ] Read SPEC-91 Status Update section — verify the delta described matches code reality (run `grep -n 'project-select' src/dashboard/index.html` to confirm UI gap)
- [ ] Verify `feature-tracker.md` is consistent (no broken links, statuses align with spec frontmatter)
- [ ] No code changes — no test suite run needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)