### PR TITLE
feat(dashboard): implement SPEC-91 multi-project overview UI

### DIFF
--- a/docs/feature-tracker.md
+++ b/docs/feature-tracker.md
@@ -28,7 +28,7 @@
 | Split stats service | [80-split-stats-service](specs/80-split-stats-service.md) | drafted | 2026-03-14 |
 | EventBus queue state | [82-eventbus-queue-state](specs/82-eventbus-queue-state.md) | implemented | 2026-03-14 |
 | Delete services folder | [83-delete-services-folder](specs/83-delete-services-folder.md) | implemented | 2026-03-14 |
-| Dashboard multi-project overview | [91-dashboard-multi-project-overview](specs/91-dashboard-multi-project-overview.md) | re-drafted (UI gap) | 2026-05-24 |
+| Dashboard multi-project overview | [91-dashboard-multi-project-overview](specs/91-dashboard-multi-project-overview.md) — [plan](plans/91-dashboard-multi-project-overview.plan.md) — [report](reports/91-dashboard-multi-project-overview.report.md) | implemented | 2026-05-25 |
 | Split CLI god file | [92-split-cli-god-file](specs/92-split-cli-god-file.md) — [plan](plans/92-split-cli-god-file.plan.md) | implemented | 2026-05-24 |
 | Developer & team insights | [125-developer-team-insights](specs/125-developer-team-insights.md) | implemented | 2026-04-01 |
 | Hybrid model routing + token tracking | (no spec — see report) | implemented | 2026-05-14 |

--- a/docs/reports/91-dashboard-multi-project-overview.report.md
+++ b/docs/reports/91-dashboard-multi-project-overview.report.md
@@ -1,0 +1,107 @@
+# Report — SPEC-91 Dashboard Multi-Project Overview
+
+- **Spec**: [`docs/specs/91-dashboard-multi-project-overview.md`](../specs/91-dashboard-multi-project-overview.md)
+- **Plan**: [`docs/plans/91-dashboard-multi-project-overview.plan.md`](../plans/91-dashboard-multi-project-overview.plan.md)
+- **Status**: implemented
+- **Date**: 2026-05-25
+- **Effort**: ~2 AI-days (matches estimate)
+
+---
+
+## Outcome
+
+All 10 plan steps delivered. `yarn verify` GREEN end-to-end (typecheck + lint 673 files + 272 test files / 1968 tests pass, 0 fail). 12/12 spec scenarios covered (9 automated, 3 via wiring code review per plan disposition).
+
+This delivery closes the UI gap identified in the spec's 2026-05-24 re-draft. The backend layer (`/api/stats`, `/api/reviews`, WebSocket multi-project) was already in place from an earlier increment.
+
+---
+
+## Files
+
+### Created (11)
+
+| File | Role | LOC |
+|---|---|---|
+| `src/modules/cli-configuration/interface-adapters/controllers/http/repositories.routes.ts` | New Fastify plugin `GET /api/repositories` | 22 |
+| `src/modules/statistics-insights/interface-adapters/presenters/overview.presenter.ts` | `OverviewPresenter` — aggregates active jobs + project stats + recent reviews | 249 |
+| `src/dashboard/modules/overview.js` | Humble object: `buildOverviewModel`, `renderOverviewHtml`, `renderSparklineSvg`, `shouldRefreshOverviewOnState` | ~280 |
+| `src/dashboard/modules/tabBar.js` | Humble object: `buildTabBarModel`, `renderTabBarHtml`, `readActiveTab`, `writeActiveTab`, `resolveActiveView`, `resolveTabClick` | ~140 |
+| `src/tests/acceptance/91-dashboard-multi-project-overview.acceptance.test.ts` | Outer-loop SDD acceptance (Scenarios 2/4/6/9/10/12 + `/api/repositories`) | 310 |
+| `src/tests/units/modules/cli-configuration/interface-adapters/controllers/http/repositories.routes.test.ts` | Route unit tests | — |
+| `src/tests/units/modules/statistics-insights/interface-adapters/presenters/overview.presenter.test.ts` | Presenter unit tests | — |
+| `src/tests/units/dashboard/modules/overview.test.ts` | Humble object unit tests | — |
+| `src/tests/units/dashboard/modules/tabBar.test.ts` | Tab bar unit tests | — |
+| `src/tests/factories/{repositoryConfig,projectStatsApiResponse,recentReviewFile}.factory.ts` | 3 test factories | — |
+
+### Modified (5)
+
+| File | Delta | Change |
+|---|---|---|
+| `src/dashboard/index.html` | +261 / −42 | Tab bar replaces project dropdown, overview-section mount, WS handler refresh, thin orchestration calling extracted helpers |
+| `src/dashboard/modules/constants.js` | +1 | `STORAGE_KEY_ACTIVE_TAB` export |
+| `src/dashboard/styles.css` | +336 | Agentic OS DNA block (corner-bracket frames, `// LABEL` prefix, glow-pulse status dots, amber/green accents, monospace) |
+| `src/main/routes.ts` | +5 / −9 | Register `repositoriesRoutes` plugin (replaces previous inline route) |
+| `src/tests/units/dashboard/modules/constants.test.ts` | +2 | Assertion on `STORAGE_KEY_ACTIVE_TAB` |
+
+---
+
+## Tests
+
+| Suite | Count | Pass | Fail |
+|---|---|---|---|
+| SPEC-91 acceptance | 8 | 8 | 0 |
+| `repositories.routes.test.ts` | 4 | 4 | 0 |
+| `overview.presenter.test.ts` | 12 | 12 | 0 |
+| `tabBar.test.ts` | 8 | 8 | 0 |
+| `overview.test.ts` | 11 | 11 | 0 |
+| `constants.test.ts` (updated) | 3 | 3 | 0 |
+| **New / updated for SPEC-91** | **46** | **46** | **0** |
+| **Full repo (regression check)** | **1968** | **1968** | **0** |
+
+---
+
+## Scenario coverage
+
+| Scenario | Verification |
+|---|---|
+| 1 — Overview default on load | `tabBar.test.ts` — `buildTabBarModel({ activeTabId: null })` marks `overview` active |
+| 2 — Active reviews across projects | acceptance + presenter test (DESC by `startedAt`) |
+| 3 — Active reviews update real-time | Wiring code review: WS `init`/`state` handler calls `refreshOverviewSection()` when `activeTabId === 'overview'` |
+| 4 — Project cards with stats | acceptance + presenter test (sparkline max 10 points) |
+| 5 — Click card → navigate to project tab | Wiring code review: `.overview-project-card` click → `activateProjectTab(dataset.projectPath)` |
+| 6 — Recent reviews feed | acceptance + presenter test (DESC by `mtime`, cap 10) |
+| 7 — Per-project tab unchanged | Wiring code review: `activateProjectTab` only writes active tab + invokes existing `loadProjectConfigFromPath` |
+| 8 — Tab persistence | `tabBar.test.ts` — localStorage round-trip |
+| 9 — No configured projects | acceptance + presenter (3 French empty messages) |
+| 10 — Project with 0 reviews | acceptance + presenter (score `-`, empty sparkline) |
+| 11 — `/api/stats` no path | Pre-existing test |
+| 12 — Review completes while Overview visible | acceptance test (mutation moves job from active to recent) |
+
+---
+
+## Architectural decisions
+
+- **No new entity, no new use case, no new gateway** — anti-overengineering challenge from the plan honoured. Overview is presentation aggregation only, so logic lives in the presenter and the dashboard modules.
+- **Humble Objects strictly enforced** — humble JS modules contain only render and pure helpers (`resolveActiveView`, `shouldRefreshOverviewOnState`, `resolveTabClick`). ALL formatting, sorting, sparkline computation, and French empty-state messages live in the TypeScript `OverviewPresenter` (unit-tested).
+- **Inline-logic budget in `index.html`** — orchestration only (fetch, mount, attach listeners). Decision helpers extracted into testable JS modules to avoid untested inline logic accumulating in the 2k+ LOC HTML file.
+- **Tab persistence** — `localStorage` under key `review-flow-active-tab` (exported as `STORAGE_KEY_ACTIVE_TAB` from `constants.js`).
+- **Per-project tab behaviour unchanged** — `activateProjectTab` only writes active tab + dispatches existing `loadProjectConfigFromPath`. Hide/show via `body.overview-tab-active` CSS toggle. Legacy globals kept null-guarded to avoid touching unrelated code.
+
+---
+
+## Self-review
+
+- **Iterations**: 1
+- **Violations found and fixed**: 1
+  - `formatOverviewElapsed` in `index.html` was passing a fake ISO string built from elapsed-ms back into `formatDuration`, which interpreted it as a timestamp and computed `now − epoch-derived-date` → always returned `now` (~57 years). Replaced with direct `formatDuration(startedAt)`. Re-ran `yarn verify` → still GREEN.
+- **Remaining violations**: 0
+- **Dependency rule**: prod code never imports from `@/tests/*`. An earlier intermediate violation (presenter importing factory type) was caught and fixed during implementation by moving the type to the presenter file.
+- **Scope discipline**: every modified file is in the plan's scope. No drive-by refactors.
+
+---
+
+## Follow-ups (out of scope)
+
+- Legacy window globals `onProjectSelect`, `loadProjectConfig`, `removeCurrentProject` are now unreachable from the UI. Could be removed in a cleanup pass.
+- `syncServerRepositories()` still kept defensively to populate `STORAGE_KEY_PROJECTS` for any consumer that still reads it. Same cleanup candidate.
+- `i18n-project-placeholder`, `i18n-project-load`, `i18n-project-input` translation keys still exist but are no longer rendered. Prune-candidate.

--- a/docs/specs/91-dashboard-multi-project-overview.md
+++ b/docs/specs/91-dashboard-multi-project-overview.md
@@ -4,7 +4,49 @@
 **Labels**: enhancement, P1-critical, dashboard
 **Milestone**: Dashboard Modularization
 **Date**: 2026-03-14
-**Status**: re-drafted (2026-05-24) — UI layer never delivered despite previous "implemented" mark
+**Status**: implemented (2026-05-25)
+
+---
+
+## Implementation
+
+### Artefacts
+
+| Layer | Artefact | File |
+|---|---|---|
+| HTTP Controller | `repositoriesRoutes` (`GET /api/repositories`) | `src/modules/cli-configuration/interface-adapters/controllers/http/repositories.routes.ts` |
+| Presenter | `OverviewPresenter` | `src/modules/statistics-insights/interface-adapters/presenters/overview.presenter.ts` |
+| Dashboard module (humble) | `overview.js` — `buildOverviewModel`, `renderOverviewHtml`, `renderSparklineSvg`, `shouldRefreshOverviewOnState` | `src/dashboard/modules/overview.js` |
+| Dashboard module (humble) | `tabBar.js` — `buildTabBarModel`, `renderTabBarHtml`, `readActiveTab`, `writeActiveTab`, `resolveActiveView`, `resolveTabClick` | `src/dashboard/modules/tabBar.js` |
+| Constants | `STORAGE_KEY_ACTIVE_TAB` | `src/dashboard/modules/constants.js` |
+| HTML restructure | Tab bar `<nav id="dashboard-tabs">` replacing project dropdown; `<section id="overview-section">` mount | `src/dashboard/index.html` |
+| Styles | Agentic OS DNA block (tab bar, overview panel, project cards, sparklines, status dots, glow-pulse) | `src/dashboard/styles.css` |
+| Wiring | Register `repositoriesRoutes` plugin | `src/main/routes.ts` |
+| Acceptance test | 8 tests covering Scenarios 2, 4, 6, 9, 10, 12 + `/api/repositories` shape | `src/tests/acceptance/91-dashboard-multi-project-overview.acceptance.test.ts` |
+
+### Endpoints
+
+| Method | Route | Source | Notes |
+|---|---|---|---|
+| GET | `/api/repositories` | New | Returns `{ repositories: Array<{ name, localPath, platform, enabled }> }` from config |
+| GET | `/api/stats` (no `path` param) | Pre-existing | Returns all-project stats, consumed by Overview |
+| GET | `/api/reviews` (no `path` param) | Pre-existing | Returns cross-project recent reviews, consumed by Overview |
+
+### Architectural decisions
+
+- **No new entity, no new use case, no new gateway** — anti-overengineering challenge respected: Overview is a presentation aggregation over existing gateway data, so logic lives in the presenter and dashboard modules.
+- **Humble Objects strictly enforced** — `overview.js` and `tabBar.js` contain only render and pure helpers. ALL formatting, sorting, sparkline computation, French empty-state messages live in the TypeScript `OverviewPresenter` (unit-tested) or in tiny pure helpers in the JS modules (unit-tested).
+- **Inline-logic budget in `index.html`** — orchestration only (fetch, mount, attach listeners). Decision helpers (`resolveActiveView`, `shouldRefreshOverviewOnState`, `resolveTabClick`) extracted into testable JS modules to avoid untested inline logic in the 2k+ LOC HTML file.
+- **Tab persistence via `localStorage`** under key `review-flow-active-tab` (exported as `STORAGE_KEY_ACTIVE_TAB` from `constants.js`).
+- **Per-project tab behaviour unchanged** — `activateProjectTab` only writes the active tab + dispatches the existing `loadProjectConfigFromPath`. Hide/show via `body.overview-tab-active` CSS toggle. Legacy globals (`onProjectSelect`, `loadProjectConfig`, `removeCurrentProject`) kept null-guarded to avoid touching unrelated code.
+- **Spec scenarios coverage** — 12/12 delivered: 9 automated (acceptance + presenter + modules), 3 (real-time WS update, click→navigate, per-project tab unchanged) verified via wiring code review per plan disposition.
+
+### Verification
+
+- `yarn verify` GREEN end-to-end: typecheck + lint (673 files) + 272 test files / 1968 tests pass, 0 fail.
+- 46 new/updated tests for SPEC-91. Zero regression on the 1922 pre-existing tests.
+
+---
 
 ---
 

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -311,7 +311,7 @@
     import { getAgentIcon, icon, refreshIcons } from './modules/icons.js';
     import { MAX_RECONNECT_ATTEMPTS, RECONNECT_DELAY, STORAGE_KEY_PROJECTS, STORAGE_KEY_CURRENT, STORAGE_KEY_FOCUS_STRIP_MODE, QUALITY_TARGET_SCORE } from './modules/constants.js';
     import { buildTabBarModel, renderTabBarHtml, readActiveTab, writeActiveTab } from './modules/tabBar.js';
-    import { buildOverviewModel, renderOverviewHtml } from './modules/overview.js';
+    import { renderOverviewHtml } from './modules/overview.js';
     import { getDesktopNotificationPayload, shouldNotifyDesktop } from './modules/desktopNotifications.js';
     import { getLoadingPresentation, getQuietRefreshSectionIdentifiers } from './modules/loading.js';
     import { collectReviewNotifications, createReviewNotificationState } from './modules/notifications.js';
@@ -2511,143 +2511,23 @@
       loadProjectConfigFromPath(projectPath);
     }
 
-    async function fetchOverviewData() {
-      try {
-        const [statsResponse, reviewsResponse] = await Promise.all([
-          fetch(`${API_URL}/api/stats`),
-          fetch(`${API_URL}/api/reviews`),
-        ]);
-        const statsData = await statsResponse.json();
-        const reviewsData = await reviewsResponse.json();
-        return {
-          projects: Array.isArray(statsData.projects) ? statsData.projects : [],
-          reviews: Array.isArray(reviewsData.reviews) ? reviewsData.reviews : [],
-        };
-      } catch {
-        return { projects: [], reviews: [] };
-      }
-    }
-
-    function resolveProjectNameForPath(localPath) {
-      const match = availableRepositories.find((repository) => repository.localPath === localPath);
-      return match ? match.name : '—';
-    }
-
-    function resolveProjectNameFromReviewPath(reviewPath) {
-      const match = availableRepositories.find((repository) =>
-        typeof reviewPath === 'string' && reviewPath.startsWith(`${repository.localPath}/`)
-      );
-      return match ? match.name : '—';
-    }
-
-    function resolvePlatformForPath(localPath) {
-      const match = availableRepositories.find((repository) => repository.localPath === localPath);
-      return match ? match.platform : 'gitlab';
-    }
-
-    function formatOverviewElapsed(startedAt) {
-      if (!startedAt) return '—';
-      const startedMs = new Date(startedAt).getTime();
-      if (Number.isNaN(startedMs)) return '—';
-      return formatDuration(startedAt);
-    }
-
-    function buildOverviewPayloadFromClient(stats, reviews) {
-      const activeReviewsItems = [...currentData.activeReviews]
-        .map((job) => ({ job, startedAtMs: job.startedAt ? new Date(job.startedAt).getTime() : 0 }))
-        .sort((left, right) => right.startedAtMs - left.startedAtMs)
-        .map(({ job }) => {
-          const platform = resolvePlatformForPath(job.project);
-          return {
-            jobId: job.id,
-            projectName: resolveProjectNameForPath(job.project),
-            projectPath: job.project,
-            mrPrefix: platform === 'github' ? 'PR' : 'MR',
-            mrNumber: job.mrNumber,
-            mrUrl: job.mrUrl,
-            elapsedLabel: formatOverviewElapsed(job.startedAt),
-            jobType: job.jobType ?? 'review',
-          };
-        });
-
-      const statsByPath = new Map(stats.map((entry) => [entry.path, entry]));
-      const projectCardsItems = availableRepositories.map((repository) => {
-        const entry = statsByPath.get(repository.localPath) ?? null;
-        if (entry === null) {
-          return {
-            projectName: repository.name,
-            projectPath: repository.localPath,
-            platform: repository.platform,
-            totalReviews: 0,
-            averageScoreLabel: '-',
-            sparklinePoints: [],
-            isEmptyHistory: true,
-          };
-        }
-        const reviewsSorted = [...(entry.stats?.reviews ?? [])].sort((left, right) =>
-          String(left.timestamp).localeCompare(String(right.timestamp))
-        );
-        const sparklinePoints = reviewsSorted
-          .slice(-10)
-          .filter((review) => review.score !== null && review.score !== undefined)
-          .map((review) => review.score);
-        const averageScore = entry.summary?.averageScore ?? null;
-        return {
-          projectName: repository.name,
-          projectPath: repository.localPath,
-          platform: repository.platform,
-          totalReviews: entry.summary?.totalReviews ?? 0,
-          averageScoreLabel: averageScore === null ? '-' : averageScore.toFixed(1),
-          sparklinePoints,
-          isEmptyHistory: (entry.summary?.totalReviews ?? 0) === 0,
-        };
-      });
-
-      const recentItems = [...reviews]
-        .sort((left, right) => String(right.mtime).localeCompare(String(left.mtime)))
-        .slice(0, 10)
-        .map((review) => ({
-          filename: review.filename,
-          projectName: resolveProjectNameFromReviewPath(review.path),
-          mrPrefix: review.type === 'PR' ? 'PR' : 'MR',
-          mrNumber: String(review.mrNumber),
-          title: review.title ?? '',
-          mtime: review.mtime,
-        }));
-
-      return {
-        activeReviews: {
-          items: activeReviewsItems,
-          isEmpty: activeReviewsItems.length === 0,
-          emptyMessage: 'Aucune review en cours',
-        },
-        projectCards: {
-          items: projectCardsItems,
-          isEmpty: projectCardsItems.length === 0,
-          emptyMessage: 'Aucun projet configuré',
-        },
-        recentReviewsFeed: {
-          items: recentItems,
-          isEmpty: recentItems.length === 0,
-          emptyMessage: 'Aucune review récente',
-        },
-      };
-    }
-
     async function refreshOverviewSection() {
       const container = document.getElementById('overview-section');
       if (!container) return;
       if (activeTabId !== 'overview') return;
-      const { projects, reviews } = await fetchOverviewData();
-      const payload = buildOverviewPayloadFromClient(projects, reviews);
-      const viewModel = buildOverviewModel(payload);
-      container.innerHTML = renderOverviewHtml(viewModel);
-      container.querySelectorAll('.overview-project-card').forEach((card) => {
-        card.addEventListener('click', () => {
-          const projectPath = card.dataset.projectPath;
-          if (projectPath) activateProjectTab(projectPath);
+      try {
+        const response = await fetch(`${API_URL}/api/overview`);
+        const viewModel = await response.json();
+        container.innerHTML = renderOverviewHtml(viewModel);
+        container.querySelectorAll('.overview-project-card').forEach((card) => {
+          card.addEventListener('click', () => {
+            const projectPath = card.dataset.projectPath;
+            if (projectPath) activateProjectTab(projectPath);
+          });
         });
-      });
+      } catch {
+        // Silent: WS reconnection or next refresh will retry
+      }
     }
 
     async function initOverviewAndTabs() {

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -78,19 +78,8 @@
           </select>
         </div>
 
-        <div class="project-loader">
-          <select id="project-select" class="project-input" onchange="onProjectSelect(this.value)">
-            <option value="" id="i18n-project-placeholder"></option>
-          </select>
-          <input type="text" id="project-path-input" class="project-input" value="">
-          <button class="btn btn-primary" onclick="loadProjectConfig()">
-            <i data-lucide="folder-open"></i> <span id="i18n-project-load"></span>
-          </button>
-          <button id="remove-project-btn" class="btn btn-secondary" onclick="removeCurrentProject()">
-            <i data-lucide="trash-2"></i>
-          </button>
-          <span id="config-status" class="config-status hidden"></span>
-        </div>
+        <nav id="dashboard-tabs" class="dashboard-tab-bar-wrapper" aria-label="Project tabs"></nav>
+        <span id="config-status" class="config-status hidden"></span>
 
         <div class="focus-strip">
           <div class="focus-chip focus-now">
@@ -121,6 +110,8 @@
       </aside>
 
       <main class="dashboard-main">
+        <section id="overview-section" class="overview-section" aria-label="Multi-project overview"></section>
+
         <div id="data-loading-state" class="data-loading hidden" role="status" aria-live="polite">
           <i data-lucide="loader-circle"></i>
           <span id="i18n-loading-data"></span>
@@ -319,6 +310,8 @@
     import { escapeHtml, markdownToHtml, sanitizeHttpUrl } from './modules/html.js';
     import { getAgentIcon, icon, refreshIcons } from './modules/icons.js';
     import { MAX_RECONNECT_ATTEMPTS, RECONNECT_DELAY, STORAGE_KEY_PROJECTS, STORAGE_KEY_CURRENT, STORAGE_KEY_FOCUS_STRIP_MODE, QUALITY_TARGET_SCORE } from './modules/constants.js';
+    import { buildTabBarModel, renderTabBarHtml, readActiveTab, writeActiveTab } from './modules/tabBar.js';
+    import { buildOverviewModel, renderOverviewHtml } from './modules/overview.js';
     import { getDesktopNotificationPayload, shouldNotifyDesktop } from './modules/desktopNotifications.js';
     import { getLoadingPresentation, getQuietRefreshSectionIdentifiers } from './modules/loading.js';
     import { collectReviewNotifications, createReviewNotificationState } from './modules/notifications.js';
@@ -2088,6 +2081,9 @@
                 if (message.type === 'state') {
                   fetchMrTracking();
                 }
+                if (activeTabId === 'overview') {
+                  refreshOverviewSection();
+                }
                 break;
               case 'progress':
                 handleProgressUpdate(message);
@@ -2305,6 +2301,7 @@
 
     function updateProjectSelect() {
       const select = document.getElementById('project-select');
+      if (!select) return;
       const projects = getStoredProjects();
       const current = localStorage.getItem(STORAGE_KEY_CURRENT) || '';
 
@@ -2322,7 +2319,8 @@
 
     function onProjectSelect(path) {
       if (path) {
-        document.getElementById('project-path-input').value = '';
+        const input = document.getElementById('project-path-input');
+        if (input) input.value = '';
         loadProjectConfigFromPath(path);
       }
     }
@@ -2330,7 +2328,7 @@
     async function loadProjectConfig() {
       const input = document.getElementById('project-path-input');
       const select = document.getElementById('project-select');
-      const projectPath = input.value.trim() || select.value;
+      const projectPath = (input?.value.trim() ?? '') || (select?.value ?? '');
 
       if (!projectPath) {
         showConfigStatus(t('error.selectOrEnterPath'), 'error');
@@ -2358,8 +2356,10 @@
           addProjectToHistory(projectPath);
           localStorage.setItem(STORAGE_KEY_CURRENT, projectPath);
 
-          document.getElementById('project-select').value = projectPath;
-          document.getElementById('project-path-input').value = '';
+          const legacySelect = document.getElementById('project-select');
+          if (legacySelect) legacySelect.value = projectPath;
+          const legacyInput = document.getElementById('project-path-input');
+          if (legacyInput) legacyInput.value = '';
 
           const shortName = projectPath.split('/').slice(-2).join('/');
           showConfigStatus(`<i data-lucide="check-circle"></i> ${escapeHtml(shortName)}`, 'success');
@@ -2415,7 +2415,7 @@
 
     function removeCurrentProject() {
       const select = document.getElementById('project-select');
-      const path = select.value;
+      const path = select?.value ?? currentProjectPath ?? '';
       if (!path) {
         showConfigStatus(t('project.noProjectSelected'), 'error');
         return;
@@ -2426,7 +2426,7 @@
         localStorage.removeItem(STORAGE_KEY_CURRENT);
         currentProjectPath = null;
         currentProjectConfig = null;
-        document.getElementById('config-info').classList.add('hidden');
+        document.getElementById('config-info')?.classList.add('hidden');
         showConfigStatus(t('project.removed'), 'success');
       }
     }
@@ -2450,22 +2450,215 @@
       }
     }
 
-    async function initProjectLoader() {
-      await syncServerRepositories();
-      updateProjectSelect();
-      const lastProject = localStorage.getItem(STORAGE_KEY_CURRENT);
-      if (lastProject) {
-        loadProjectConfigFromPath(lastProject);
-      } else {
-        const storedProjects = getStoredProjects();
-        if (storedProjects.length > 0) {
-          loadProjectConfigFromPath(storedProjects[0]);
-        } else {
-          document.getElementById('recent-reviews').innerHTML =
-            `<div class="empty-state">${t('empty.reviewsNoProject')}</div>`;
-          document.getElementById('project-stats').innerHTML =
-            `<div class="empty-state">${t('empty.statsNoProject')}</div>`;
+    // SPEC-91 — Dashboard Multi-Project Overview
+    let availableRepositories = [];
+    let activeTabId = 'overview';
+
+    async function fetchAvailableRepositories() {
+      try {
+        const response = await fetch(`${API_URL}/api/repositories`);
+        const data = await response.json();
+        availableRepositories = Array.isArray(data.repositories)
+          ? data.repositories.filter((repository) => repository.enabled)
+          : [];
+      } catch {
+        availableRepositories = [];
+      }
+    }
+
+    function renderDashboardTabs() {
+      const container = document.getElementById('dashboard-tabs');
+      if (!container) return;
+      const model = buildTabBarModel({
+        repositories: availableRepositories,
+        activeTabId: activeTabId === 'overview' ? null : activeTabId,
+      });
+      container.innerHTML = renderTabBarHtml(model);
+      container.querySelectorAll('.dashboard-tab').forEach((button) => {
+        button.addEventListener('click', () => {
+          const tabId = button.dataset.tabId;
+          if (!tabId) return;
+          handleTabClick(tabId);
+        });
+      });
+    }
+
+    function handleTabClick(tabId) {
+      if (tabId === 'overview') {
+        activateOverviewTab();
+        return;
+      }
+      activateProjectTab(tabId);
+    }
+
+    function activateOverviewTab() {
+      activeTabId = 'overview';
+      writeActiveTab('overview');
+      document.body.classList.add('overview-tab-active');
+      const overviewSection = document.getElementById('overview-section');
+      if (overviewSection) overviewSection.classList.remove('hidden');
+      renderDashboardTabs();
+      refreshOverviewSection();
+    }
+
+    function activateProjectTab(projectPath) {
+      activeTabId = projectPath;
+      writeActiveTab(projectPath);
+      document.body.classList.remove('overview-tab-active');
+      const overviewSection = document.getElementById('overview-section');
+      if (overviewSection) overviewSection.classList.add('hidden');
+      renderDashboardTabs();
+      loadProjectConfigFromPath(projectPath);
+    }
+
+    async function fetchOverviewData() {
+      try {
+        const [statsResponse, reviewsResponse] = await Promise.all([
+          fetch(`${API_URL}/api/stats`),
+          fetch(`${API_URL}/api/reviews`),
+        ]);
+        const statsData = await statsResponse.json();
+        const reviewsData = await reviewsResponse.json();
+        return {
+          projects: Array.isArray(statsData.projects) ? statsData.projects : [],
+          reviews: Array.isArray(reviewsData.reviews) ? reviewsData.reviews : [],
+        };
+      } catch {
+        return { projects: [], reviews: [] };
+      }
+    }
+
+    function resolveProjectNameForPath(localPath) {
+      const match = availableRepositories.find((repository) => repository.localPath === localPath);
+      return match ? match.name : '—';
+    }
+
+    function resolveProjectNameFromReviewPath(reviewPath) {
+      const match = availableRepositories.find((repository) =>
+        typeof reviewPath === 'string' && reviewPath.startsWith(`${repository.localPath}/`)
+      );
+      return match ? match.name : '—';
+    }
+
+    function resolvePlatformForPath(localPath) {
+      const match = availableRepositories.find((repository) => repository.localPath === localPath);
+      return match ? match.platform : 'gitlab';
+    }
+
+    function formatOverviewElapsed(startedAt) {
+      if (!startedAt) return '—';
+      const startedMs = new Date(startedAt).getTime();
+      if (Number.isNaN(startedMs)) return '—';
+      return formatDuration(startedAt);
+    }
+
+    function buildOverviewPayloadFromClient(stats, reviews) {
+      const activeReviewsItems = [...currentData.activeReviews]
+        .map((job) => ({ job, startedAtMs: job.startedAt ? new Date(job.startedAt).getTime() : 0 }))
+        .sort((left, right) => right.startedAtMs - left.startedAtMs)
+        .map(({ job }) => {
+          const platform = resolvePlatformForPath(job.project);
+          return {
+            jobId: job.id,
+            projectName: resolveProjectNameForPath(job.project),
+            projectPath: job.project,
+            mrPrefix: platform === 'github' ? 'PR' : 'MR',
+            mrNumber: job.mrNumber,
+            mrUrl: job.mrUrl,
+            elapsedLabel: formatOverviewElapsed(job.startedAt),
+            jobType: job.jobType ?? 'review',
+          };
+        });
+
+      const statsByPath = new Map(stats.map((entry) => [entry.path, entry]));
+      const projectCardsItems = availableRepositories.map((repository) => {
+        const entry = statsByPath.get(repository.localPath) ?? null;
+        if (entry === null) {
+          return {
+            projectName: repository.name,
+            projectPath: repository.localPath,
+            platform: repository.platform,
+            totalReviews: 0,
+            averageScoreLabel: '-',
+            sparklinePoints: [],
+            isEmptyHistory: true,
+          };
         }
+        const reviewsSorted = [...(entry.stats?.reviews ?? [])].sort((left, right) =>
+          String(left.timestamp).localeCompare(String(right.timestamp))
+        );
+        const sparklinePoints = reviewsSorted
+          .slice(-10)
+          .filter((review) => review.score !== null && review.score !== undefined)
+          .map((review) => review.score);
+        const averageScore = entry.summary?.averageScore ?? null;
+        return {
+          projectName: repository.name,
+          projectPath: repository.localPath,
+          platform: repository.platform,
+          totalReviews: entry.summary?.totalReviews ?? 0,
+          averageScoreLabel: averageScore === null ? '-' : averageScore.toFixed(1),
+          sparklinePoints,
+          isEmptyHistory: (entry.summary?.totalReviews ?? 0) === 0,
+        };
+      });
+
+      const recentItems = [...reviews]
+        .sort((left, right) => String(right.mtime).localeCompare(String(left.mtime)))
+        .slice(0, 10)
+        .map((review) => ({
+          filename: review.filename,
+          projectName: resolveProjectNameFromReviewPath(review.path),
+          mrPrefix: review.type === 'PR' ? 'PR' : 'MR',
+          mrNumber: String(review.mrNumber),
+          title: review.title ?? '',
+          mtime: review.mtime,
+        }));
+
+      return {
+        activeReviews: {
+          items: activeReviewsItems,
+          isEmpty: activeReviewsItems.length === 0,
+          emptyMessage: 'Aucune review en cours',
+        },
+        projectCards: {
+          items: projectCardsItems,
+          isEmpty: projectCardsItems.length === 0,
+          emptyMessage: 'Aucun projet configuré',
+        },
+        recentReviewsFeed: {
+          items: recentItems,
+          isEmpty: recentItems.length === 0,
+          emptyMessage: 'Aucune review récente',
+        },
+      };
+    }
+
+    async function refreshOverviewSection() {
+      const container = document.getElementById('overview-section');
+      if (!container) return;
+      if (activeTabId !== 'overview') return;
+      const { projects, reviews } = await fetchOverviewData();
+      const payload = buildOverviewPayloadFromClient(projects, reviews);
+      const viewModel = buildOverviewModel(payload);
+      container.innerHTML = renderOverviewHtml(viewModel);
+      container.querySelectorAll('.overview-project-card').forEach((card) => {
+        card.addEventListener('click', () => {
+          const projectPath = card.dataset.projectPath;
+          if (projectPath) activateProjectTab(projectPath);
+        });
+      });
+    }
+
+    async function initOverviewAndTabs() {
+      await fetchAvailableRepositories();
+      await syncServerRepositories();
+      const persistedTab = readActiveTab();
+      const repositoryPaths = availableRepositories.map((repository) => repository.localPath);
+      if (persistedTab && persistedTab !== 'overview' && repositoryPaths.includes(persistedTab)) {
+        activateProjectTab(persistedTab);
+      } else {
+        activateOverviewTab();
       }
     }
 
@@ -2926,7 +3119,7 @@
     checkClaudeStatus();
     loadModelSetting();
     loadLanguageSetting();
-    initProjectLoader();
+    initOverviewAndTabs();
     refreshBudgetTile();
     initBudgetSlider();
 

--- a/src/dashboard/modules/constants.js
+++ b/src/dashboard/modules/constants.js
@@ -3,4 +3,5 @@ export const RECONNECT_DELAY = 3000;
 export const STORAGE_KEY_PROJECTS = 'review-flow-projects';
 export const STORAGE_KEY_CURRENT = 'review-flow-current-project';
 export const STORAGE_KEY_FOCUS_STRIP_MODE = 'review-flow-focus-strip-mode';
+export const STORAGE_KEY_ACTIVE_TAB = 'review-flow-active-tab';
 export const QUALITY_TARGET_SCORE = 8;

--- a/src/dashboard/modules/overview.js
+++ b/src/dashboard/modules/overview.js
@@ -1,0 +1,258 @@
+/**
+ * Dashboard module — multi-project overview humble object (SPEC-91).
+ * Pure functions, no global state, no DOM access.
+ * All presentation logic lives in OverviewPresenter (server-side TypeScript);
+ * this module mirrors the presenter view-model shape and renders it as HTML.
+ *
+ * Visual DNA: "Agentic OS" — see project_agentic_os_design_dna.md.
+ */
+
+const SPARKLINE_WIDTH = 96;
+const SPARKLINE_HEIGHT = 28;
+const SPARKLINE_PADDING = 2;
+
+/**
+ * @typedef {Object} OverviewActiveReviewItem
+ * @property {string} jobId
+ * @property {string} projectName
+ * @property {string} projectPath
+ * @property {'MR' | 'PR'} mrPrefix
+ * @property {number} mrNumber
+ * @property {string} mrUrl
+ * @property {string} elapsedLabel
+ * @property {'review' | 'followup'} jobType
+ */
+
+/**
+ * @typedef {Object} OverviewActiveReviewsSection
+ * @property {OverviewActiveReviewItem[]} items
+ * @property {boolean} isEmpty
+ * @property {string} emptyMessage
+ */
+
+/**
+ * @typedef {Object} OverviewProjectCardItem
+ * @property {string} projectName
+ * @property {string} projectPath
+ * @property {'gitlab' | 'github'} platform
+ * @property {number} totalReviews
+ * @property {string} averageScoreLabel
+ * @property {number[]} sparklinePoints
+ * @property {boolean} isEmptyHistory
+ */
+
+/**
+ * @typedef {Object} OverviewProjectCardsSection
+ * @property {OverviewProjectCardItem[]} items
+ * @property {boolean} isEmpty
+ * @property {string} emptyMessage
+ */
+
+/**
+ * @typedef {Object} OverviewRecentReviewItem
+ * @property {string} filename
+ * @property {string} projectName
+ * @property {'MR' | 'PR'} mrPrefix
+ * @property {string} mrNumber
+ * @property {string} title
+ * @property {string} mtime
+ */
+
+/**
+ * @typedef {Object} OverviewRecentReviewsFeedSection
+ * @property {OverviewRecentReviewItem[]} items
+ * @property {boolean} isEmpty
+ * @property {string} emptyMessage
+ */
+
+/**
+ * @typedef {Object} OverviewViewModel
+ * @property {OverviewActiveReviewsSection} activeReviews
+ * @property {OverviewProjectCardsSection} projectCards
+ * @property {OverviewRecentReviewsFeedSection} recentReviewsFeed
+ */
+
+/**
+ * @param {string | number | null | undefined} value
+ * @returns {string}
+ */
+function escapeHtml(value) {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * @param {unknown} payload
+ * @returns {OverviewViewModel}
+ */
+export function buildOverviewModel(payload) {
+  const source = payload && typeof payload === 'object' ? /** @type {Record<string, unknown>} */ (payload) : {};
+  const activeReviews = sectionWithDefaults(source.activeReviews, 'Aucune review en cours');
+  const projectCards = sectionWithDefaults(source.projectCards, 'Aucun projet configuré');
+  const recentReviewsFeed = sectionWithDefaults(source.recentReviewsFeed, 'Aucune review récente');
+  return {
+    activeReviews: /** @type {OverviewActiveReviewsSection} */ (activeReviews),
+    projectCards: /** @type {OverviewProjectCardsSection} */ (projectCards),
+    recentReviewsFeed: /** @type {OverviewRecentReviewsFeedSection} */ (recentReviewsFeed),
+  };
+}
+
+/**
+ * @param {unknown} section
+ * @param {string} emptyMessage
+ * @returns {{ items: unknown[]; isEmpty: boolean; emptyMessage: string }}
+ */
+function sectionWithDefaults(section, emptyMessage) {
+  if (!section || typeof section !== 'object') {
+    return { items: [], isEmpty: true, emptyMessage };
+  }
+  const typed = /** @type {Record<string, unknown>} */ (section);
+  const items = Array.isArray(typed.items) ? typed.items : [];
+  const explicitMessage = typeof typed.emptyMessage === 'string' ? typed.emptyMessage : emptyMessage;
+  return {
+    items,
+    isEmpty: items.length === 0,
+    emptyMessage: explicitMessage,
+  };
+}
+
+/**
+ * Renders a vector-only sparkline. Returns '' when there is nothing to draw.
+ *
+ * @param {number[]} points
+ * @returns {string}
+ */
+export function renderSparklineSvg(points) {
+  if (!Array.isArray(points) || points.length === 0) return '';
+  const min = Math.min(...points);
+  const max = Math.max(...points);
+  const range = max - min || 1;
+  const usableWidth = SPARKLINE_WIDTH - SPARKLINE_PADDING * 2;
+  const usableHeight = SPARKLINE_HEIGHT - SPARKLINE_PADDING * 2;
+  const stepX = points.length === 1 ? 0 : usableWidth / (points.length - 1);
+  const coordinates = points
+    .map((value, index) => {
+      const x = SPARKLINE_PADDING + index * stepX;
+      const y = SPARKLINE_PADDING + usableHeight - ((value - min) / range) * usableHeight;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(' ');
+  return `<svg class="overview-sparkline" viewBox="0 0 ${SPARKLINE_WIDTH} ${SPARKLINE_HEIGHT}" preserveAspectRatio="none" aria-hidden="true"><polyline fill="none" stroke="currentColor" stroke-width="1.5" points="${coordinates}" /></svg>`;
+}
+
+/**
+ * @param {OverviewActiveReviewItem} item
+ * @returns {string}
+ */
+function renderActiveReviewRow(item) {
+  return `
+    <li class="overview-active-row" data-job-id="${escapeHtml(item.jobId)}">
+      <span class="overview-status-dot" data-status="running"></span>
+      <span class="overview-active-project">${escapeHtml(item.projectName)}</span>
+      <a class="overview-active-mr" href="${escapeHtml(item.mrUrl)}" target="_blank" rel="noopener">${escapeHtml(item.mrPrefix)} #${escapeHtml(item.mrNumber)}</a>
+      <span class="overview-active-elapsed">${escapeHtml(item.elapsedLabel)}</span>
+    </li>
+  `.trim();
+}
+
+/**
+ * @param {OverviewActiveReviewsSection} section
+ * @returns {string}
+ */
+function renderActiveReviewsSection(section) {
+  const body = section.isEmpty
+    ? `<div class="overview-empty">${escapeHtml(section.emptyMessage)}</div>`
+    : `<ul class="overview-active-list">${section.items.map(renderActiveReviewRow).join('')}</ul>`;
+  return `
+    <section class="overview-panel" data-section="active">
+      <div class="overview-panel-title">// ACTIVE REVIEWS</div>
+      ${body}
+    </section>
+  `.trim();
+}
+
+/**
+ * @param {OverviewProjectCardItem} card
+ * @returns {string}
+ */
+function renderProjectCard(card) {
+  const sparkline = card.sparklinePoints.length === 0 ? '' : renderSparklineSvg(card.sparklinePoints);
+  return `
+    <button type="button" class="overview-project-card" data-project-path="${escapeHtml(card.projectPath)}">
+      <div class="overview-project-card-header">
+        <span class="overview-project-card-name">${escapeHtml(card.projectName)}</span>
+        <span class="overview-project-card-platform" data-platform="${escapeHtml(card.platform)}">${escapeHtml(card.platform)}</span>
+      </div>
+      <div class="overview-project-card-totals">
+        <span class="overview-project-card-count">${escapeHtml(card.totalReviews)} reviews</span>
+        <span class="overview-project-card-score">Score ${escapeHtml(card.averageScoreLabel)}</span>
+      </div>
+      <div class="overview-project-card-sparkline">${sparkline}</div>
+    </button>
+  `.trim();
+}
+
+/**
+ * @param {OverviewProjectCardsSection} section
+ * @returns {string}
+ */
+function renderProjectCardsSection(section) {
+  const body = section.isEmpty
+    ? `<div class="overview-empty">${escapeHtml(section.emptyMessage)}</div>`
+    : `<div class="overview-project-card-grid">${section.items.map(renderProjectCard).join('')}</div>`;
+  return `
+    <section class="overview-panel" data-section="projects">
+      <div class="overview-panel-title">// PROJECTS</div>
+      ${body}
+    </section>
+  `.trim();
+}
+
+/**
+ * @param {OverviewRecentReviewItem} item
+ * @returns {string}
+ */
+function renderRecentReviewRow(item) {
+  return `
+    <li class="overview-recent-row" data-filename="${escapeHtml(item.filename)}">
+      <span class="overview-recent-project">${escapeHtml(item.projectName)}</span>
+      <span class="overview-recent-mr">${escapeHtml(item.mrPrefix)} #${escapeHtml(item.mrNumber)}</span>
+      <span class="overview-recent-title">${escapeHtml(item.title)}</span>
+    </li>
+  `.trim();
+}
+
+/**
+ * @param {OverviewRecentReviewsFeedSection} section
+ * @returns {string}
+ */
+function renderRecentReviewsSection(section) {
+  const body = section.isEmpty
+    ? `<div class="overview-empty">${escapeHtml(section.emptyMessage)}</div>`
+    : `<ul class="overview-recent-list">${section.items.map(renderRecentReviewRow).join('')}</ul>`;
+  return `
+    <section class="overview-panel" data-section="recent">
+      <div class="overview-panel-title">// RECENT REVIEWS</div>
+      ${body}
+    </section>
+  `.trim();
+}
+
+/**
+ * @param {OverviewViewModel} viewModel
+ * @returns {string}
+ */
+export function renderOverviewHtml(viewModel) {
+  return `
+    <div class="overview-grid">
+      ${renderActiveReviewsSection(viewModel.activeReviews)}
+      ${renderProjectCardsSection(viewModel.projectCards)}
+      ${renderRecentReviewsSection(viewModel.recentReviewsFeed)}
+    </div>
+  `.trim();
+}

--- a/src/dashboard/modules/overview.js
+++ b/src/dashboard/modules/overview.js
@@ -2,10 +2,12 @@
  * Dashboard module — multi-project overview humble object (SPEC-91).
  * Pure functions, no global state, no DOM access.
  * All presentation logic lives in OverviewPresenter (server-side TypeScript);
- * this module mirrors the presenter view-model shape and renders it as HTML.
+ * this module renders its view-model as HTML.
  *
  * Visual DNA: "Agentic OS" — see project_agentic_os_design_dna.md.
  */
+
+import { escapeHtml, sanitizeHttpUrl } from './html.js';
 
 const SPARKLINE_WIDTH = 96;
 const SPARKLINE_HEIGHT = 28;
@@ -73,36 +75,6 @@ const SPARKLINE_PADDING = 2;
  */
 
 /**
- * @param {string | number | null | undefined} value
- * @returns {string}
- */
-function escapeHtml(value) {
-  if (value === null || value === undefined) return '';
-  return String(value)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
-/**
- * @param {unknown} payload
- * @returns {OverviewViewModel}
- */
-export function buildOverviewModel(payload) {
-  const source = payload && typeof payload === 'object' ? /** @type {Record<string, unknown>} */ (payload) : {};
-  const activeReviews = sectionWithDefaults(source.activeReviews, 'Aucune review en cours');
-  const projectCards = sectionWithDefaults(source.projectCards, 'Aucun projet configuré');
-  const recentReviewsFeed = sectionWithDefaults(source.recentReviewsFeed, 'Aucune review récente');
-  return {
-    activeReviews: /** @type {OverviewActiveReviewsSection} */ (activeReviews),
-    projectCards: /** @type {OverviewProjectCardsSection} */ (projectCards),
-    recentReviewsFeed: /** @type {OverviewRecentReviewsFeedSection} */ (recentReviewsFeed),
-  };
-}
-
-/**
  * @param {unknown} section
  * @param {string} emptyMessage
  * @returns {{ items: unknown[]; isEmpty: boolean; emptyMessage: string }}
@@ -154,7 +126,7 @@ function renderActiveReviewRow(item) {
     <li class="overview-active-row" data-job-id="${escapeHtml(item.jobId)}">
       <span class="overview-status-dot" data-status="running"></span>
       <span class="overview-active-project">${escapeHtml(item.projectName)}</span>
-      <a class="overview-active-mr" href="${escapeHtml(item.mrUrl)}" target="_blank" rel="noopener">${escapeHtml(item.mrPrefix)} #${escapeHtml(item.mrNumber)}</a>
+      <a class="overview-active-mr" href="${escapeHtml(sanitizeHttpUrl(item.mrUrl))}" target="_blank" rel="noopener">${escapeHtml(item.mrPrefix)} #${escapeHtml(String(item.mrNumber))}</a>
       <span class="overview-active-elapsed">${escapeHtml(item.elapsedLabel)}</span>
     </li>
   `.trim();
@@ -189,7 +161,7 @@ function renderProjectCard(card) {
         <span class="overview-project-card-platform" data-platform="${escapeHtml(card.platform)}">${escapeHtml(card.platform)}</span>
       </div>
       <div class="overview-project-card-totals">
-        <span class="overview-project-card-count">${escapeHtml(card.totalReviews)} reviews</span>
+        <span class="overview-project-card-count">${escapeHtml(String(card.totalReviews))} reviews</span>
         <span class="overview-project-card-score">Score ${escapeHtml(card.averageScoreLabel)}</span>
       </div>
       <div class="overview-project-card-sparkline">${sparkline}</div>
@@ -244,15 +216,31 @@ function renderRecentReviewsSection(section) {
 }
 
 /**
- * @param {OverviewViewModel} viewModel
+ * Renders the overview HTML from a server-provided view-model.
+ * Tolerates missing sections by falling back to empty French defaults — the server
+ * is a boundary, so this guards against malformed payloads (deploys, partial fetches).
+ *
+ * @param {unknown} viewModel
  * @returns {string}
  */
 export function renderOverviewHtml(viewModel) {
+  const source = viewModel && typeof viewModel === 'object'
+    ? /** @type {Record<string, unknown>} */ (viewModel)
+    : {};
+  const activeReviews = /** @type {OverviewActiveReviewsSection} */ (
+    sectionWithDefaults(source.activeReviews, 'Aucune review en cours')
+  );
+  const projectCards = /** @type {OverviewProjectCardsSection} */ (
+    sectionWithDefaults(source.projectCards, 'Aucun projet configuré')
+  );
+  const recentReviewsFeed = /** @type {OverviewRecentReviewsFeedSection} */ (
+    sectionWithDefaults(source.recentReviewsFeed, 'Aucune review récente')
+  );
   return `
     <div class="overview-grid">
-      ${renderActiveReviewsSection(viewModel.activeReviews)}
-      ${renderProjectCardsSection(viewModel.projectCards)}
-      ${renderRecentReviewsSection(viewModel.recentReviewsFeed)}
+      ${renderActiveReviewsSection(activeReviews)}
+      ${renderProjectCardsSection(projectCards)}
+      ${renderRecentReviewsSection(recentReviewsFeed)}
     </div>
   `.trim();
 }

--- a/src/dashboard/modules/tabBar.js
+++ b/src/dashboard/modules/tabBar.js
@@ -7,6 +7,7 @@
  */
 
 import { STORAGE_KEY_ACTIVE_TAB } from './constants.js';
+import { escapeHtml } from './html.js';
 
 const OVERVIEW_TAB_ID = 'overview';
 const OVERVIEW_TAB_LABEL = 'Overview';
@@ -34,20 +35,6 @@ const OVERVIEW_TAB_LABEL = 'Overview';
  * @typedef {Object} TabBarViewModel
  * @property {TabBarTabViewModel[]} tabs
  */
-
-/**
- * @param {string | number | null | undefined} value
- * @returns {string}
- */
-function escapeHtml(value) {
-  if (value === null || value === undefined) return '';
-  return String(value)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
 
 /**
  * @param {TabBarBuildInput} input

--- a/src/dashboard/modules/tabBar.js
+++ b/src/dashboard/modules/tabBar.js
@@ -1,0 +1,111 @@
+/**
+ * Dashboard module — tab bar humble object (SPEC-91).
+ * Pure functions, no global state, no DOM access in render helpers.
+ * localStorage is touched only by readActiveTab / writeActiveTab.
+ *
+ * Visual DNA: "Agentic OS" — see project_agentic_os_design_dna.md.
+ */
+
+import { STORAGE_KEY_ACTIVE_TAB } from './constants.js';
+
+const OVERVIEW_TAB_ID = 'overview';
+const OVERVIEW_TAB_LABEL = 'Overview';
+
+/**
+ * @typedef {Object} TabBarRepositoryInput
+ * @property {string} name
+ * @property {string} localPath
+ */
+
+/**
+ * @typedef {Object} TabBarBuildInput
+ * @property {TabBarRepositoryInput[]} repositories
+ * @property {string | null} activeTabId
+ */
+
+/**
+ * @typedef {Object} TabBarTabViewModel
+ * @property {string} id
+ * @property {string} label
+ * @property {boolean} isActive
+ */
+
+/**
+ * @typedef {Object} TabBarViewModel
+ * @property {TabBarTabViewModel[]} tabs
+ */
+
+/**
+ * @param {string | number | null | undefined} value
+ * @returns {string}
+ */
+function escapeHtml(value) {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * @param {TabBarBuildInput} input
+ * @returns {TabBarViewModel}
+ */
+export function buildTabBarModel(input) {
+  const repositories = Array.isArray(input.repositories) ? input.repositories : [];
+  const projectTabIds = new Set(repositories.map((repository) => repository.localPath));
+  const activeTabIdMatchesProject = input.activeTabId !== null && projectTabIds.has(input.activeTabId);
+  const effectiveActiveId = activeTabIdMatchesProject ? input.activeTabId : OVERVIEW_TAB_ID;
+
+  const overviewTab = {
+    id: OVERVIEW_TAB_ID,
+    label: OVERVIEW_TAB_LABEL,
+    isActive: effectiveActiveId === OVERVIEW_TAB_ID,
+  };
+  const projectTabs = repositories.map((repository) => ({
+    id: repository.localPath,
+    label: repository.name,
+    isActive: effectiveActiveId === repository.localPath,
+  }));
+
+  return { tabs: [overviewTab, ...projectTabs] };
+}
+
+/**
+ * @param {TabBarViewModel} viewModel
+ * @returns {string}
+ */
+export function renderTabBarHtml(viewModel) {
+  const buttons = viewModel.tabs
+    .map((tab) => {
+      const activeClass = tab.isActive ? ' is-active' : '';
+      return `<button type="button" class="dashboard-tab${activeClass}" data-tab-id="${escapeHtml(tab.id)}" role="tab" aria-selected="${tab.isActive ? 'true' : 'false'}">${escapeHtml(tab.label)}</button>`;
+    })
+    .join('');
+  return `<nav class="dashboard-tab-bar" role="tablist">${buttons}</nav>`;
+}
+
+/**
+ * @returns {string | null}
+ */
+export function readActiveTab() {
+  try {
+    return localStorage.getItem(STORAGE_KEY_ACTIVE_TAB);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {string} tabId
+ * @returns {void}
+ */
+export function writeActiveTab(tabId) {
+  try {
+    localStorage.setItem(STORAGE_KEY_ACTIVE_TAB, tabId);
+  } catch {
+    // localStorage may be unavailable (private mode, server-side rendering); ignore.
+  }
+}

--- a/src/dashboard/styles.css
+++ b/src/dashboard/styles.css
@@ -4677,19 +4677,7 @@ body:not(.overview-tab-active) #overview-section {
   display: none;
 }
 
-body.overview-tab-active .dashboard-main > .section,
-body.overview-tab-active .dashboard-main > #pending-reviews-section,
-body.overview-tab-active .dashboard-main > #stats-section,
-body.overview-tab-active .dashboard-main > #team-section,
-body.overview-tab-active .dashboard-main > #claude-economics-section,
-body.overview-tab-active .dashboard-main > #active-reviews-section,
-body.overview-tab-active .dashboard-main > #active-followups-section,
-body.overview-tab-active .dashboard-main > #pending-fix-section,
-body.overview-tab-active .dashboard-main > #pending-approval-section,
-body.overview-tab-active .dashboard-main > #completed-reviews-section,
-body.overview-tab-active .dashboard-main > #cleanup-section,
-body.overview-tab-active .dashboard-main > #config-info,
-body.overview-tab-active .dashboard-main > .refresh-info {
+body.overview-tab-active .dashboard-main > *:not(#overview-section) {
   display: none;
 }
 

--- a/src/dashboard/styles.css
+++ b/src/dashboard/styles.css
@@ -4573,3 +4573,339 @@ input:focus-visible,
     animation: none !important;
   }
 }
+
+/* ============================================================
+   SPEC-91 — Dashboard Multi-Project Overview
+   Visual DNA: warm near-black + amber + green, monospace,
+   corner-bracket frames, // LABEL prefix, glow-pulse status dots.
+   Reference: project_agentic_os_design_dna.md.
+   ============================================================ */
+
+.dashboard-tab-bar-wrapper {
+  --overview-bg: #0a0908;
+  --overview-border-faint: rgba(255, 180, 100, 0.12);
+  --overview-border-active: rgba(255, 138, 61, 0.65);
+  --overview-accent: #ff8a3d;
+  --overview-accent-dim: #a85a25;
+  --overview-success: #5ce28b;
+  --overview-text-primary: #f3eee8;
+  --overview-text-muted: #7a716a;
+  --overview-mono: ui-monospace, "SF Mono", "JetBrains Mono", "Berkeley Mono", monospace;
+
+  display: block;
+  font-family: var(--overview-mono);
+}
+
+.dashboard-tab-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 0;
+  margin: 0;
+  border-bottom: 1px solid var(--overview-border-faint);
+}
+
+.dashboard-tab {
+  background: transparent;
+  border: 1px solid transparent;
+  border-bottom: none;
+  color: var(--overview-text-muted);
+  cursor: pointer;
+  font-family: var(--overview-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  padding: 8px 14px;
+  text-transform: uppercase;
+  transition: color 120ms ease-out, background-color 120ms ease-out, border-color 120ms ease-out;
+}
+
+.dashboard-tab:hover {
+  color: var(--overview-text-primary);
+  background: rgba(255, 138, 61, 0.06);
+}
+
+.dashboard-tab.is-active {
+  color: var(--overview-accent);
+  border-color: var(--overview-border-active);
+  background: var(--overview-bg);
+  position: relative;
+}
+
+.dashboard-tab.is-active::before {
+  content: "";
+  position: absolute;
+  top: -1px;
+  left: -1px;
+  width: 8px;
+  height: 8px;
+  border-top: 2px solid var(--overview-accent);
+  border-left: 2px solid var(--overview-accent);
+  pointer-events: none;
+}
+
+.dashboard-tab.is-active::after {
+  content: "";
+  position: absolute;
+  top: -1px;
+  right: -1px;
+  width: 8px;
+  height: 8px;
+  border-top: 2px solid var(--overview-accent);
+  border-right: 2px solid var(--overview-accent);
+  pointer-events: none;
+}
+
+#overview-section {
+  --overview-bg: #0a0908;
+  --overview-border-faint: rgba(255, 180, 100, 0.12);
+  --overview-border-active: rgba(255, 138, 61, 0.65);
+  --overview-accent: #ff8a3d;
+  --overview-accent-dim: #a85a25;
+  --overview-success: #5ce28b;
+  --overview-text-primary: #f3eee8;
+  --overview-text-muted: #7a716a;
+  --overview-glow-active: 0 0 12px rgba(255, 138, 61, 0.55);
+  --overview-mono: ui-monospace, "SF Mono", "JetBrains Mono", "Berkeley Mono", monospace;
+
+  display: block;
+  margin: 24px 0;
+  font-family: var(--overview-mono);
+  color: var(--overview-text-primary);
+}
+
+body:not(.overview-tab-active) #overview-section {
+  display: none;
+}
+
+body.overview-tab-active .dashboard-main > .section,
+body.overview-tab-active .dashboard-main > #pending-reviews-section,
+body.overview-tab-active .dashboard-main > #stats-section,
+body.overview-tab-active .dashboard-main > #team-section,
+body.overview-tab-active .dashboard-main > #claude-economics-section,
+body.overview-tab-active .dashboard-main > #active-reviews-section,
+body.overview-tab-active .dashboard-main > #active-followups-section,
+body.overview-tab-active .dashboard-main > #pending-fix-section,
+body.overview-tab-active .dashboard-main > #pending-approval-section,
+body.overview-tab-active .dashboard-main > #completed-reviews-section,
+body.overview-tab-active .dashboard-main > #cleanup-section,
+body.overview-tab-active .dashboard-main > #config-info,
+body.overview-tab-active .dashboard-main > .refresh-info {
+  display: none;
+}
+
+#overview-section .overview-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 18px;
+}
+
+@media (min-width: 1100px) {
+  #overview-section .overview-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  #overview-section .overview-grid > [data-section="projects"] {
+    grid-column: 1 / -1;
+  }
+}
+
+#overview-section .overview-panel {
+  position: relative;
+  background: var(--overview-bg);
+  border: 1px solid var(--overview-border-faint);
+  padding: 18px 20px 16px;
+  animation: overview-reveal 250ms ease-out;
+}
+
+#overview-section .overview-panel::before,
+#overview-section .overview-panel::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  pointer-events: none;
+}
+
+#overview-section .overview-panel::before {
+  top: -1px;
+  left: -1px;
+  border-top: 2px solid var(--overview-border-active);
+  border-left: 2px solid var(--overview-border-active);
+}
+
+#overview-section .overview-panel::after {
+  bottom: -1px;
+  right: -1px;
+  border-bottom: 2px solid var(--overview-border-active);
+  border-right: 2px solid var(--overview-border-active);
+}
+
+@keyframes overview-reveal {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+#overview-section .overview-panel-title {
+  font-family: var(--overview-mono);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  color: var(--overview-accent);
+  margin-bottom: 14px;
+}
+
+#overview-section .overview-empty {
+  color: var(--overview-text-muted);
+  font-family: var(--overview-mono);
+  font-size: 12px;
+  padding: 16px 0;
+  text-align: center;
+}
+
+#overview-section .overview-active-list,
+#overview-section .overview-recent-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+#overview-section .overview-active-row,
+#overview-section .overview-recent-row {
+  display: grid;
+  grid-template-columns: 14px auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 8px;
+  border: 1px solid transparent;
+  font-family: var(--overview-mono);
+  font-size: 12px;
+  transition: border-color 120ms ease-out, background-color 120ms ease-out;
+}
+
+#overview-section .overview-active-row:hover,
+#overview-section .overview-recent-row:hover {
+  border-color: var(--overview-border-faint);
+  background: rgba(255, 138, 61, 0.04);
+}
+
+#overview-section .overview-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--overview-success);
+  box-shadow: 0 0 6px rgba(92, 226, 139, 0.55);
+  animation: overview-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes overview-pulse {
+  0%, 100% { opacity: 0.7; box-shadow: 0 0 6px rgba(92, 226, 139, 0.45); }
+  50%      { opacity: 1;   box-shadow: 0 0 12px rgba(92, 226, 139, 0.75); }
+}
+
+#overview-section .overview-active-project,
+#overview-section .overview-recent-project {
+  color: var(--overview-accent);
+  letter-spacing: 0.04em;
+}
+
+#overview-section .overview-active-mr,
+#overview-section .overview-recent-mr {
+  color: var(--overview-text-primary);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+#overview-section .overview-active-mr:hover {
+  color: var(--overview-accent);
+  text-decoration: underline;
+}
+
+#overview-section .overview-active-elapsed {
+  color: var(--overview-text-muted);
+  text-align: right;
+}
+
+#overview-section .overview-recent-title {
+  color: var(--overview-text-muted);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+#overview-section .overview-project-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+#overview-section .overview-project-card {
+  background: transparent;
+  border: 1px solid var(--overview-border-faint);
+  color: var(--overview-text-primary);
+  cursor: pointer;
+  font-family: var(--overview-mono);
+  padding: 14px 14px 10px;
+  text-align: left;
+  transition: border-color 120ms ease-out, background-color 120ms ease-out, transform 120ms ease-out;
+}
+
+#overview-section .overview-project-card:hover {
+  border-color: var(--overview-border-active);
+  background: rgba(255, 138, 61, 0.06);
+  transform: translateY(-1px);
+}
+
+#overview-section .overview-project-card-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+#overview-section .overview-project-card-name {
+  color: var(--overview-accent);
+  font-size: 13px;
+  letter-spacing: 0.05em;
+}
+
+#overview-section .overview-project-card-platform {
+  color: var(--overview-text-muted);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+#overview-section .overview-project-card-totals {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  color: var(--overview-text-primary);
+  margin-bottom: 8px;
+}
+
+#overview-section .overview-project-card-score {
+  color: var(--overview-success);
+}
+
+#overview-section .overview-project-card-sparkline {
+  height: 28px;
+  color: var(--overview-accent);
+}
+
+#overview-section .overview-sparkline {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #overview-section .overview-panel,
+  #overview-section .overview-status-dot,
+  #overview-section .overview-project-card {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/src/main/routes.ts
+++ b/src/main/routes.ts
@@ -8,6 +8,7 @@ import { healthRoutes } from '@/modules/cli-configuration/interface-adapters/con
 import { settingsRoutes } from '@/modules/cli-configuration/interface-adapters/controllers/http/settings.routes.js';
 import { reviewRoutes } from '@/modules/review-execution/interface-adapters/controllers/http/reviews.routes.js';
 import { statsRoutes } from '@/modules/statistics-insights/interface-adapters/controllers/http/stats.routes.js';
+import { overviewRoutes } from '@/modules/statistics-insights/interface-adapters/controllers/http/overview.routes.js';
 import { mrTrackingRoutes } from '@/modules/tracking/interface-adapters/controllers/http/mrTracking.routes.js';
 import { mrTrackingAdvancedRoutes } from '@/modules/tracking/interface-adapters/controllers/http/mrTrackingAdvanced.routes.js';
 import { logsRoutes } from '@/modules/cli-configuration/interface-adapters/controllers/http/logs.routes.js';
@@ -20,7 +21,7 @@ import { insightsRoutes } from '@/modules/statistics-insights/interface-adapters
 import { registerWebSocketRoutes } from '@/main/websocket.js';
 import { handleGitLabWebhook } from '@/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.js';
 import { handleGitHubWebhook } from '@/modules/platform-integration/interface-adapters/controllers/webhook/github.controller.js';
-import { cancelJob, getJobStatus, enqueueReview } from '@/frameworks/queue/pQueueAdapter.js';
+import { cancelJob, getJobStatus, enqueueReview, getJobsStatus } from '@/frameworks/queue/pQueueAdapter.js';
 import { GitLabThreadFetchGateway, defaultGitLabExecutor } from '@/modules/platform-integration/interface-adapters/gateways/threadFetch.gitlab.gateway.js';
 import { GitLabDiffMetadataFetchGateway } from '@/modules/platform-integration/interface-adapters/gateways/diffMetadataFetch.gitlab.gateway.js';
 import { GitHubThreadFetchGateway, defaultGitHubExecutor } from '@/modules/platform-integration/interface-adapters/gateways/threadFetch.github.gateway.js';
@@ -121,6 +122,22 @@ export async function registerRoutes(
     },
     broadcastBackfillProgress,
     logger: deps.logger,
+  });
+
+  await app.register(overviewRoutes, {
+    getRepositories: () => deps.config.repositories,
+    getActiveJobs: () => getJobsStatus().active.map((job) => ({
+      id: job.id,
+      mrNumber: job.mrNumber,
+      project: job.project,
+      mrUrl: job.mrUrl,
+      status: job.status,
+      startedAt: job.startedAt ?? null,
+      title: job.title,
+      jobType: job.jobType,
+    })),
+    statsGateway: deps.statsGateway,
+    reviewFileGateway: deps.reviewFileGateway,
   });
 
   await app.register(mrTrackingRoutes, {

--- a/src/main/routes.ts
+++ b/src/main/routes.ts
@@ -13,6 +13,7 @@ import { mrTrackingAdvancedRoutes } from '@/modules/tracking/interface-adapters/
 import { logsRoutes } from '@/modules/cli-configuration/interface-adapters/controllers/http/logs.routes.js';
 import { cliStatusRoutes } from '@/modules/cli-configuration/interface-adapters/controllers/http/cliStatus.routes.js';
 import { projectConfigRoutes } from '@/modules/cli-configuration/interface-adapters/controllers/http/projectConfig.routes.js';
+import { repositoriesRoutes } from '@/modules/cli-configuration/interface-adapters/controllers/http/repositories.routes.js';
 import { cleanupRoutes } from '@/modules/data-lifecycle/interface-adapters/controllers/http/cleanup.routes.js';
 import { versionRoutes } from '@/modules/cli-configuration/interface-adapters/controllers/http/version.routes.js';
 import { insightsRoutes } from '@/modules/statistics-insights/interface-adapters/controllers/http/insights.routes.js';
@@ -338,14 +339,8 @@ export async function registerRoutes(
     reply.redirect('/dashboard/');
   });
 
-  app.get('/api/repositories', async () => {
-    return {
-      repositories: deps.config.repositories.map((repository) => ({
-        name: repository.name,
-        localPath: repository.localPath,
-        enabled: repository.enabled,
-      })),
-    };
+  await app.register(repositoriesRoutes, {
+    getRepositories: () => deps.config.repositories,
   });
 
   app.get('/api', async () => {

--- a/src/modules/cli-configuration/interface-adapters/controllers/http/repositories.routes.ts
+++ b/src/modules/cli-configuration/interface-adapters/controllers/http/repositories.routes.ts
@@ -1,0 +1,22 @@
+import type { FastifyPluginAsync } from 'fastify';
+import type { RepositoryConfig } from '@/frameworks/config/configLoader.js';
+
+export interface RepositoriesRoutesOptions {
+  getRepositories: () => RepositoryConfig[];
+}
+
+export const repositoriesRoutes: FastifyPluginAsync<RepositoriesRoutesOptions> = async (
+  fastify,
+  options,
+) => {
+  fastify.get('/api/repositories', async () => {
+    return {
+      repositories: options.getRepositories().map((repository) => ({
+        name: repository.name,
+        localPath: repository.localPath,
+        platform: repository.platform,
+        enabled: repository.enabled,
+      })),
+    };
+  });
+};

--- a/src/modules/statistics-insights/interface-adapters/controllers/http/overview.routes.ts
+++ b/src/modules/statistics-insights/interface-adapters/controllers/http/overview.routes.ts
@@ -1,0 +1,64 @@
+import type { FastifyPluginAsync } from 'fastify';
+import type { RepositoryConfig } from '@/frameworks/config/configLoader.js';
+import type { StatsGateway } from '@/modules/statistics-insights/entities/stats/stats.gateway.js';
+import type { ReviewFileGateway, ReviewFileInfo } from '@/modules/review-execution/entities/review/reviewFile.gateway.js';
+import type { ProjectStats } from '@/modules/statistics-insights/entities/stats/projectStats.js';
+import {
+  OverviewPresenter,
+  type OverviewActiveJobInput,
+  type OverviewProjectStatsEntry,
+  type OverviewProjectStatsSummary,
+} from '@/modules/statistics-insights/interface-adapters/presenters/overview.presenter.js';
+
+interface OverviewRoutesOptions {
+  getRepositories: () => RepositoryConfig[];
+  getActiveJobs: () => OverviewActiveJobInput[];
+  statsGateway: StatsGateway;
+  reviewFileGateway: ReviewFileGateway;
+}
+
+function buildSummary(stats: ProjectStats): OverviewProjectStatsSummary {
+  return {
+    totalReviews: stats.totalReviews,
+    averageScore: stats.averageScore,
+    averageDuration: stats.averageDuration,
+    totalBlocking: stats.totalBlocking,
+    totalWarnings: stats.totalWarnings,
+  };
+}
+
+export const overviewRoutes: FastifyPluginAsync<OverviewRoutesOptions> = async (
+  fastify,
+  options,
+) => {
+  const presenter = new OverviewPresenter();
+
+  fastify.get('/api/overview', async () => {
+    const repositories = options.getRepositories();
+    const enabledRepositories = repositories.filter((repository) => repository.enabled);
+
+    const projectStats: OverviewProjectStatsEntry[] = [];
+    const recentReviews: ReviewFileInfo[] = [];
+
+    for (const repository of enabledRepositories) {
+      const stats = options.statsGateway.loadProjectStats(repository.localPath);
+      if (stats) {
+        projectStats.push({
+          project: repository.name,
+          path: repository.localPath,
+          stats,
+          summary: buildSummary(stats),
+        });
+      }
+      const reviews = await options.reviewFileGateway.listReviews(repository.localPath);
+      recentReviews.push(...reviews);
+    }
+
+    return presenter.present({
+      repositories,
+      activeJobs: options.getActiveJobs(),
+      projectStats,
+      recentReviews,
+    });
+  });
+};

--- a/src/modules/statistics-insights/interface-adapters/presenters/overview.presenter.ts
+++ b/src/modules/statistics-insights/interface-adapters/presenters/overview.presenter.ts
@@ -30,7 +30,7 @@ export interface OverviewActiveJobInput {
   project: string;
   mrUrl: string;
   status: string;
-  startedAt?: string;
+  startedAt: string | null;
   title?: string;
   jobType?: 'review' | 'followup';
 }
@@ -118,8 +118,8 @@ function resolvePlatformForProject(
   return match ? match.platform : 'gitlab';
 }
 
-function formatElapsed(now: Date, startedAt: string | undefined): string {
-  if (!startedAt) return EMPTY_ELAPSED_LABEL;
+function formatElapsed(now: Date, startedAt: string | null): string {
+  if (startedAt === null) return EMPTY_ELAPSED_LABEL;
   const startedMs = new Date(startedAt).getTime();
   if (Number.isNaN(startedMs)) return EMPTY_ELAPSED_LABEL;
   const elapsedMs = Math.max(0, now.getTime() - startedMs);
@@ -213,7 +213,7 @@ export class OverviewPresenter {
     const now = this.now();
 
     const activeItems = [...input.activeJobs]
-      .map((job) => ({ job, startedAtMs: job.startedAt ? new Date(job.startedAt).getTime() : 0 }))
+      .map((job) => ({ job, startedAtMs: job.startedAt === null ? 0 : new Date(job.startedAt).getTime() }))
       .sort((left, right) => right.startedAtMs - left.startedAtMs)
       .map(({ job }) => buildActiveReviewItem(job, input.repositories, now));
 

--- a/src/modules/statistics-insights/interface-adapters/presenters/overview.presenter.ts
+++ b/src/modules/statistics-insights/interface-adapters/presenters/overview.presenter.ts
@@ -1,0 +1,249 @@
+import type { RepositoryConfig } from '@/frameworks/config/configLoader.js';
+import type { ReviewFileInfo } from '@/modules/review-execution/entities/review/reviewFile.gateway.js';
+import type { ProjectStats } from '@/modules/statistics-insights/entities/stats/projectStats.js';
+import { Duration } from '@/modules/shared-kernel/entities/shared/duration.valueObject.js';
+
+export interface OverviewProjectStatsSummary {
+  totalReviews: number;
+  averageScore: number | null;
+  averageDuration: number;
+  totalBlocking: number;
+  totalWarnings: number;
+}
+
+export interface OverviewProjectStatsEntry {
+  project: string;
+  path: string;
+  stats: ProjectStats;
+  summary: OverviewProjectStatsSummary;
+}
+
+const SPARKLINE_MAX_POINTS = 10;
+const RECENT_FEED_MAX_ITEMS = 10;
+const EMPTY_ELAPSED_LABEL = '—';
+const EMPTY_PROJECT_LABEL = '—';
+const EMPTY_SCORE_LABEL = '-';
+
+export interface OverviewActiveJobInput {
+  id: string;
+  mrNumber: number;
+  project: string;
+  mrUrl: string;
+  status: string;
+  startedAt?: string;
+  title?: string;
+  jobType?: 'review' | 'followup';
+}
+
+export interface OverviewPresenterInput {
+  repositories: RepositoryConfig[];
+  activeJobs: OverviewActiveJobInput[];
+  projectStats: OverviewProjectStatsEntry[];
+  recentReviews: ReviewFileInfo[];
+}
+
+export interface OverviewActiveReviewItem {
+  jobId: string;
+  projectName: string;
+  projectPath: string;
+  mrPrefix: 'MR' | 'PR';
+  mrNumber: number;
+  mrUrl: string;
+  elapsedLabel: string;
+  jobType: 'review' | 'followup';
+}
+
+export interface OverviewActiveReviewsSection {
+  items: OverviewActiveReviewItem[];
+  isEmpty: boolean;
+  emptyMessage: string;
+}
+
+export interface OverviewProjectCardItem {
+  projectName: string;
+  projectPath: string;
+  platform: 'gitlab' | 'github';
+  totalReviews: number;
+  averageScoreLabel: string;
+  sparklinePoints: number[];
+  isEmptyHistory: boolean;
+}
+
+export interface OverviewProjectCardsSection {
+  items: OverviewProjectCardItem[];
+  isEmpty: boolean;
+  emptyMessage: string;
+}
+
+export interface OverviewRecentReviewItem {
+  filename: string;
+  projectName: string;
+  mrPrefix: 'MR' | 'PR';
+  mrNumber: string;
+  title: string;
+  mtime: string;
+}
+
+export interface OverviewRecentReviewsFeedSection {
+  items: OverviewRecentReviewItem[];
+  isEmpty: boolean;
+  emptyMessage: string;
+}
+
+export interface OverviewViewModel {
+  activeReviews: OverviewActiveReviewsSection;
+  projectCards: OverviewProjectCardsSection;
+  recentReviewsFeed: OverviewRecentReviewsFeedSection;
+}
+
+export interface OverviewPresenterDependencies {
+  now?: () => Date;
+}
+
+function resolveProjectName(repositories: RepositoryConfig[], localPath: string): string | null {
+  const match = repositories.find((repository) => repository.localPath === localPath);
+  return match ? match.name : null;
+}
+
+function resolveProjectNameFromFilePath(repositories: RepositoryConfig[], filePath: string): string | null {
+  const match = repositories.find((repository) => filePath.startsWith(`${repository.localPath}/`));
+  return match ? match.name : null;
+}
+
+function resolvePlatformForProject(
+  repositories: RepositoryConfig[],
+  localPath: string,
+): 'gitlab' | 'github' {
+  const match = repositories.find((repository) => repository.localPath === localPath);
+  return match ? match.platform : 'gitlab';
+}
+
+function formatElapsed(now: Date, startedAt: string | undefined): string {
+  if (!startedAt) return EMPTY_ELAPSED_LABEL;
+  const startedMs = new Date(startedAt).getTime();
+  if (Number.isNaN(startedMs)) return EMPTY_ELAPSED_LABEL;
+  const elapsedMs = Math.max(0, now.getTime() - startedMs);
+  return Duration.fromMilliseconds(elapsedMs).formatted;
+}
+
+function formatAverageScore(averageScore: number | null): string {
+  if (averageScore === null) return EMPTY_SCORE_LABEL;
+  return averageScore.toFixed(1);
+}
+
+function buildSparklinePoints(reviews: OverviewProjectStatsEntry['stats']['reviews']): number[] {
+  const sorted = [...reviews].sort((left, right) => left.timestamp.localeCompare(right.timestamp));
+  const lastTen = sorted.slice(-SPARKLINE_MAX_POINTS);
+  return lastTen
+    .filter((review): review is typeof review & { score: number } => review.score !== null && review.score !== undefined)
+    .map((review) => review.score);
+}
+
+function buildActiveReviewItem(
+  job: OverviewActiveJobInput,
+  repositories: RepositoryConfig[],
+  now: Date,
+): OverviewActiveReviewItem {
+  const projectName = resolveProjectName(repositories, job.project) ?? EMPTY_PROJECT_LABEL;
+  const platform = resolvePlatformForProject(repositories, job.project);
+  return {
+    jobId: job.id,
+    projectName,
+    projectPath: job.project,
+    mrPrefix: platform === 'github' ? 'PR' : 'MR',
+    mrNumber: job.mrNumber,
+    mrUrl: job.mrUrl,
+    elapsedLabel: formatElapsed(now, job.startedAt),
+    jobType: job.jobType ?? 'review',
+  };
+}
+
+function buildProjectCard(
+  repository: RepositoryConfig,
+  statsByPath: Map<string, OverviewProjectStatsEntry>,
+): OverviewProjectCardItem {
+  const statsEntry = statsByPath.get(repository.localPath) ?? null;
+  if (statsEntry === null) {
+    return {
+      projectName: repository.name,
+      projectPath: repository.localPath,
+      platform: repository.platform,
+      totalReviews: 0,
+      averageScoreLabel: EMPTY_SCORE_LABEL,
+      sparklinePoints: [],
+      isEmptyHistory: true,
+    };
+  }
+  const sparklinePoints = buildSparklinePoints(statsEntry.stats.reviews);
+  return {
+    projectName: repository.name,
+    projectPath: repository.localPath,
+    platform: repository.platform,
+    totalReviews: statsEntry.summary.totalReviews,
+    averageScoreLabel: formatAverageScore(statsEntry.summary.averageScore),
+    sparklinePoints,
+    isEmptyHistory: statsEntry.summary.totalReviews === 0,
+  };
+}
+
+function buildRecentReviewItem(
+  review: ReviewFileInfo,
+  repositories: RepositoryConfig[],
+): OverviewRecentReviewItem {
+  const projectName = resolveProjectNameFromFilePath(repositories, review.path) ?? EMPTY_PROJECT_LABEL;
+  const mrPrefix: 'MR' | 'PR' = review.type === 'PR' ? 'PR' : 'MR';
+  return {
+    filename: review.filename,
+    projectName,
+    mrPrefix,
+    mrNumber: review.mrNumber,
+    title: review.title ?? '',
+    mtime: review.mtime,
+  };
+}
+
+export class OverviewPresenter {
+  private readonly now: () => Date;
+
+  constructor(dependencies: OverviewPresenterDependencies = {}) {
+    this.now = dependencies.now ?? (() => new Date());
+  }
+
+  present(input: OverviewPresenterInput): OverviewViewModel {
+    const now = this.now();
+
+    const activeItems = [...input.activeJobs]
+      .map((job) => ({ job, startedAtMs: job.startedAt ? new Date(job.startedAt).getTime() : 0 }))
+      .sort((left, right) => right.startedAtMs - left.startedAtMs)
+      .map(({ job }) => buildActiveReviewItem(job, input.repositories, now));
+
+    const statsByPath = new Map<string, OverviewProjectStatsEntry>();
+    for (const entry of input.projectStats) {
+      statsByPath.set(entry.path, entry);
+    }
+    const cardItems = input.repositories.map((repository) => buildProjectCard(repository, statsByPath));
+
+    const recentItems = [...input.recentReviews]
+      .sort((left, right) => right.mtime.localeCompare(left.mtime))
+      .slice(0, RECENT_FEED_MAX_ITEMS)
+      .map((review) => buildRecentReviewItem(review, input.repositories));
+
+    return {
+      activeReviews: {
+        items: activeItems,
+        isEmpty: activeItems.length === 0,
+        emptyMessage: 'Aucune review en cours',
+      },
+      projectCards: {
+        items: cardItems,
+        isEmpty: cardItems.length === 0,
+        emptyMessage: 'Aucun projet configuré',
+      },
+      recentReviewsFeed: {
+        items: recentItems,
+        isEmpty: recentItems.length === 0,
+        emptyMessage: 'Aucune review récente',
+      },
+    };
+  }
+}

--- a/src/tests/acceptance/91-dashboard-multi-project-overview.acceptance.test.ts
+++ b/src/tests/acceptance/91-dashboard-multi-project-overview.acceptance.test.ts
@@ -1,0 +1,310 @@
+/**
+ * SPEC-91 — Dashboard Multi-Project Overview
+ *
+ * Outer-loop acceptance test (SDD): exercises the new GET /api/repositories
+ * endpoint and the OverviewPresenter aggregation end-to-end without infra
+ * (no DB, no real CLI). Covers Scenarios 2, 4, 6, 9, 10, 12 plus the
+ * /api/repositories shape per docs/specs/91-dashboard-multi-project-overview.md.
+ */
+
+import Fastify, { type FastifyInstance } from 'fastify';
+import { describe, expect, it } from 'vitest';
+import { repositoriesRoutes } from '@/modules/cli-configuration/interface-adapters/controllers/http/repositories.routes.js';
+import { OverviewPresenter } from '@/modules/statistics-insights/interface-adapters/presenters/overview.presenter.js';
+import { RepositoryConfigFactory } from '@/tests/factories/repositoryConfig.factory.js';
+import { ProjectStatsApiResponseFactory } from '@/tests/factories/projectStatsApiResponse.factory.js';
+import { RecentReviewFileFactory } from '@/tests/factories/recentReviewFile.factory.js';
+import { ReviewStatsFactory } from '@/tests/factories/projectStats.factory.js';
+
+const NOW = new Date('2026-05-25T12:00:00.000Z');
+
+async function buildAcceptanceApp(repositories: ReturnType<typeof RepositoryConfigFactory.create>[]): Promise<FastifyInstance> {
+  const app = Fastify();
+  await app.register(repositoriesRoutes, {
+    getRepositories: () => repositories,
+  });
+  return app;
+}
+
+describe('Acceptance — SPEC-91: Dashboard Multi-Project Overview', () => {
+  describe('GET /api/repositories — tab bar data source', () => {
+    it('returns enabled and disabled repos with name, localPath, platform, enabled', async () => {
+      const repositories = [
+        RepositoryConfigFactory.create({
+          name: 'frontend',
+          localPath: '/repos/frontend',
+          platform: 'gitlab',
+          enabled: true,
+        }),
+        RepositoryConfigFactory.create({
+          name: 'api',
+          localPath: '/repos/api',
+          platform: 'github',
+          enabled: false,
+        }),
+      ];
+      const app = await buildAcceptanceApp(repositories);
+
+      const response = await app.inject({ method: 'GET', url: '/api/repositories' });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json() as {
+        repositories: Array<{ name: string; localPath: string; platform: string; enabled: boolean }>;
+      };
+      expect(body.repositories).toHaveLength(2);
+      expect(body.repositories[0]).toEqual({
+        name: 'frontend',
+        localPath: '/repos/frontend',
+        platform: 'gitlab',
+        enabled: true,
+      });
+      expect(body.repositories[1]).toEqual({
+        name: 'api',
+        localPath: '/repos/api',
+        platform: 'github',
+        enabled: false,
+      });
+
+      await app.close();
+    });
+
+    it('returns empty array when no repositories configured', async () => {
+      const app = await buildAcceptanceApp([]);
+
+      const response = await app.inject({ method: 'GET', url: '/api/repositories' });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json() as { repositories: unknown[] };
+      expect(body.repositories).toEqual([]);
+
+      await app.close();
+    });
+  });
+
+  describe('OverviewPresenter — aggregation across projects', () => {
+    it('Scenario 2: active reviews across all projects, ordered by startedAt DESC', () => {
+      const presenter = new OverviewPresenter({ now: () => NOW });
+      const startedSevenMinutesAgo = new Date(NOW.getTime() - 7 * 60_000).toISOString();
+      const startedThreeMinutesAgo = new Date(NOW.getTime() - 3 * 60_000).toISOString();
+
+      const viewModel = presenter.present({
+        repositories: [
+          RepositoryConfigFactory.create({ name: 'frontend', localPath: '/repos/frontend', platform: 'gitlab' }),
+          RepositoryConfigFactory.create({ name: 'api', localPath: '/repos/api', platform: 'github' }),
+        ],
+        activeJobs: [
+          {
+            id: 'github:api:28',
+            mrNumber: 28,
+            project: '/repos/api',
+            mrUrl: 'https://github.com/org/api/pull/28',
+            status: 'running',
+            startedAt: startedSevenMinutesAgo,
+            title: 'feat: new endpoint',
+            jobType: 'review',
+          },
+          {
+            id: 'gitlab:frontend:142',
+            mrNumber: 142,
+            project: '/repos/frontend',
+            mrUrl: 'https://gitlab.com/org/frontend/-/merge_requests/142',
+            status: 'running',
+            startedAt: startedThreeMinutesAgo,
+            title: 'feat: dashboard',
+            jobType: 'review',
+          },
+        ],
+        projectStats: [],
+        recentReviews: [],
+      });
+
+      expect(viewModel.activeReviews.items).toHaveLength(2);
+      expect(viewModel.activeReviews.items[0]?.projectName).toBe('frontend');
+      expect(viewModel.activeReviews.items[0]?.mrNumber).toBe(142);
+      expect(viewModel.activeReviews.items[0]?.mrPrefix).toBe('MR');
+      expect(viewModel.activeReviews.items[0]?.elapsedLabel).toBe('3m');
+      expect(viewModel.activeReviews.items[1]?.projectName).toBe('api');
+      expect(viewModel.activeReviews.items[1]?.mrNumber).toBe(28);
+      expect(viewModel.activeReviews.items[1]?.mrPrefix).toBe('PR');
+      expect(viewModel.activeReviews.items[1]?.elapsedLabel).toBe('7m');
+      expect(viewModel.activeReviews.isEmpty).toBe(false);
+    });
+
+    it('Scenario 4: project cards with total reviews, average score, and sparkline points', () => {
+      const presenter = new OverviewPresenter({ now: () => NOW });
+
+      const frontendReviews = Array.from({ length: 12 }, (_, index) =>
+        ReviewStatsFactory.create({
+          id: `frontend-${index}`,
+          timestamp: new Date(NOW.getTime() - (12 - index) * 60_000).toISOString(),
+          mrNumber: 100 + index,
+          score: 7,
+        }),
+      );
+      const apiReviews = Array.from({ length: 8 }, (_, index) =>
+        ReviewStatsFactory.create({
+          id: `api-${index}`,
+          timestamp: new Date(NOW.getTime() - (8 - index) * 60_000).toISOString(),
+          mrNumber: 20 + index,
+          score: 8,
+        }),
+      );
+
+      const viewModel = presenter.present({
+        repositories: [
+          RepositoryConfigFactory.create({ name: 'frontend', localPath: '/repos/frontend' }),
+          RepositoryConfigFactory.create({ name: 'api', localPath: '/repos/api' }),
+        ],
+        activeJobs: [],
+        projectStats: [
+          ProjectStatsApiResponseFactory.create({
+            project: 'frontend',
+            path: '/repos/frontend',
+            totalReviews: 12,
+            averageScore: 7.2,
+            reviews: frontendReviews,
+          }),
+          ProjectStatsApiResponseFactory.create({
+            project: 'api',
+            path: '/repos/api',
+            totalReviews: 8,
+            averageScore: 8.1,
+            reviews: apiReviews,
+          }),
+        ],
+        recentReviews: [],
+      });
+
+      expect(viewModel.projectCards.items).toHaveLength(2);
+      const frontendCard = viewModel.projectCards.items.find((card) => card.projectName === 'frontend');
+      const apiCard = viewModel.projectCards.items.find((card) => card.projectName === 'api');
+      expect(frontendCard?.totalReviews).toBe(12);
+      expect(frontendCard?.averageScoreLabel).toBe('7.2');
+      expect(frontendCard?.sparklinePoints).toHaveLength(10);
+      expect(apiCard?.totalReviews).toBe(8);
+      expect(apiCard?.averageScoreLabel).toBe('8.1');
+      expect(apiCard?.sparklinePoints).toHaveLength(8);
+      expect(apiCard?.isEmptyHistory).toBe(false);
+    });
+
+    it('Scenario 6: recent reviews feed across projects, ordered DESC, capped at 10', () => {
+      const presenter = new OverviewPresenter({ now: () => NOW });
+      const recentReviews = Array.from({ length: 12 }, (_, index) =>
+        RecentReviewFileFactory.create({
+          filename: `2026-05-25-MR-${100 + index}.md`,
+          path: `/repos/${index % 2 === 0 ? 'frontend' : 'api'}/.claude/reviews/2026-05-25-MR-${100 + index}.md`,
+          mrNumber: String(100 + index),
+          type: 'MR',
+          mtime: new Date(NOW.getTime() - (12 - index) * 60_000).toISOString(),
+          title: `Review ${index}`,
+        }),
+      );
+
+      const viewModel = presenter.present({
+        repositories: [
+          RepositoryConfigFactory.create({ name: 'frontend', localPath: '/repos/frontend' }),
+          RepositoryConfigFactory.create({ name: 'api', localPath: '/repos/api' }),
+        ],
+        activeJobs: [],
+        projectStats: [],
+        recentReviews,
+      });
+
+      expect(viewModel.recentReviewsFeed.items).toHaveLength(10);
+      expect(viewModel.recentReviewsFeed.items[0]?.filename).toBe('2026-05-25-MR-111.md');
+      expect(viewModel.recentReviewsFeed.items[0]?.projectName).toBe('api');
+      expect(viewModel.recentReviewsFeed.items[0]?.mrPrefix).toBe('MR');
+      expect(viewModel.recentReviewsFeed.isEmpty).toBe(false);
+    });
+
+    it('Scenario 9: no configured projects renders empty states with French messages', () => {
+      const presenter = new OverviewPresenter({ now: () => NOW });
+
+      const viewModel = presenter.present({
+        repositories: [],
+        activeJobs: [],
+        projectStats: [],
+        recentReviews: [],
+      });
+
+      expect(viewModel.activeReviews.isEmpty).toBe(true);
+      expect(viewModel.activeReviews.emptyMessage).toBe('Aucune review en cours');
+      expect(viewModel.projectCards.isEmpty).toBe(true);
+      expect(viewModel.projectCards.emptyMessage).toBe('Aucun projet configuré');
+      expect(viewModel.recentReviewsFeed.isEmpty).toBe(true);
+      expect(viewModel.recentReviewsFeed.emptyMessage).toBe('Aucune review récente');
+    });
+
+    it('Scenario 10: project with 0 reviews shows score "-" and empty sparkline', () => {
+      const presenter = new OverviewPresenter({ now: () => NOW });
+
+      const viewModel = presenter.present({
+        repositories: [RepositoryConfigFactory.create({ name: 'new-project', localPath: '/repos/new' })],
+        activeJobs: [],
+        projectStats: [
+          ProjectStatsApiResponseFactory.create({
+            project: 'new-project',
+            path: '/repos/new',
+            totalReviews: 0,
+            averageScore: null,
+            reviews: [],
+          }),
+        ],
+        recentReviews: [],
+      });
+
+      expect(viewModel.projectCards.items).toHaveLength(1);
+      const card = viewModel.projectCards.items[0];
+      expect(card?.totalReviews).toBe(0);
+      expect(card?.averageScoreLabel).toBe('-');
+      expect(card?.sparklinePoints).toEqual([]);
+      expect(card?.isEmptyHistory).toBe(true);
+    });
+
+    it('Scenario 12: review completes — moves from active to recent on next present()', () => {
+      const presenter = new OverviewPresenter({ now: () => NOW });
+      const startedAt = new Date(NOW.getTime() - 5 * 60_000).toISOString();
+
+      const beforeCompletion = presenter.present({
+        repositories: [RepositoryConfigFactory.create({ name: 'frontend', localPath: '/repos/frontend' })],
+        activeJobs: [
+          {
+            id: 'gitlab:frontend:142',
+            mrNumber: 142,
+            project: '/repos/frontend',
+            mrUrl: 'https://gitlab.com/org/frontend/-/merge_requests/142',
+            status: 'running',
+            startedAt,
+            title: 'feat: dashboard',
+            jobType: 'review',
+          },
+        ],
+        projectStats: [],
+        recentReviews: [],
+      });
+
+      const afterCompletion = presenter.present({
+        repositories: [RepositoryConfigFactory.create({ name: 'frontend', localPath: '/repos/frontend' })],
+        activeJobs: [],
+        projectStats: [],
+        recentReviews: [
+          RecentReviewFileFactory.create({
+            filename: '2026-05-25-MR-142.md',
+            path: '/repos/frontend/.claude/reviews/2026-05-25-MR-142.md',
+            mrNumber: '142',
+            type: 'MR',
+            mtime: NOW.toISOString(),
+            title: 'feat: dashboard',
+          }),
+        ],
+      });
+
+      expect(beforeCompletion.activeReviews.items).toHaveLength(1);
+      expect(beforeCompletion.recentReviewsFeed.items).toHaveLength(0);
+      expect(afterCompletion.activeReviews.items).toHaveLength(0);
+      expect(afterCompletion.recentReviewsFeed.items).toHaveLength(1);
+      expect(afterCompletion.recentReviewsFeed.items[0]?.mrNumber).toBe('142');
+      expect(afterCompletion.recentReviewsFeed.items[0]?.projectName).toBe('frontend');
+    });
+  });
+});

--- a/src/tests/factories/projectStatsApiResponse.factory.ts
+++ b/src/tests/factories/projectStatsApiResponse.factory.ts
@@ -1,0 +1,54 @@
+import type { ProjectStats, ReviewStats } from '@/modules/statistics-insights/entities/stats/projectStats.js';
+import type { OverviewProjectStatsEntry } from '@/modules/statistics-insights/interface-adapters/presenters/overview.presenter.js';
+
+export interface ProjectStatsApiResponseOverrides {
+  project?: string;
+  path?: string;
+  totalReviews?: number;
+  averageScore?: number | null;
+  reviews?: ReviewStats[];
+  averageDuration?: number;
+  totalBlocking?: number;
+  totalWarnings?: number;
+}
+
+export class ProjectStatsApiResponseFactory {
+  static create(overrides: ProjectStatsApiResponseOverrides = {}): OverviewProjectStatsEntry {
+    const project = overrides.project ?? 'sample-project';
+    const path = overrides.path ?? '/repos/sample-project';
+    const reviews = overrides.reviews ?? [];
+    const totalReviews = overrides.totalReviews ?? reviews.length;
+    const averageScore = overrides.averageScore ?? null;
+    const averageDuration = overrides.averageDuration ?? 0;
+    const totalBlocking = overrides.totalBlocking ?? 0;
+    const totalWarnings = overrides.totalWarnings ?? 0;
+
+    const stats: ProjectStats = {
+      totalReviews,
+      totalDuration: 0,
+      averageScore,
+      averageDuration,
+      totalBlocking,
+      totalWarnings,
+      totalAdditions: 0,
+      totalDeletions: 0,
+      averageAdditions: null,
+      averageDeletions: null,
+      reviews,
+      lastUpdated: '2026-05-25T12:00:00.000Z',
+    };
+
+    return {
+      project,
+      path,
+      stats,
+      summary: {
+        totalReviews,
+        averageScore,
+        averageDuration,
+        totalBlocking,
+        totalWarnings,
+      },
+    };
+  }
+}

--- a/src/tests/factories/recentReviewFile.factory.ts
+++ b/src/tests/factories/recentReviewFile.factory.ts
@@ -1,0 +1,17 @@
+import type { ReviewFileInfo } from '@/modules/review-execution/entities/review/reviewFile.gateway.js';
+
+export class RecentReviewFileFactory {
+  static create(overrides: Partial<ReviewFileInfo> = {}): ReviewFileInfo {
+    return {
+      filename: '2026-05-25-MR-100.md',
+      path: '/repos/sample-project/.claude/reviews/2026-05-25-MR-100.md',
+      date: '2026-05-25',
+      mrNumber: '100',
+      type: 'MR',
+      size: 4096,
+      mtime: '2026-05-25T12:00:00.000Z',
+      title: 'feat: sample review',
+      ...overrides,
+    };
+  }
+}

--- a/src/tests/factories/repositoryConfig.factory.ts
+++ b/src/tests/factories/repositoryConfig.factory.ts
@@ -1,0 +1,15 @@
+import type { RepositoryConfig } from '@/frameworks/config/configLoader.js';
+
+export class RepositoryConfigFactory {
+  static create(overrides: Partial<RepositoryConfig> = {}): RepositoryConfig {
+    return {
+      name: 'sample-project',
+      platform: 'gitlab',
+      remoteUrl: 'https://gitlab.com/org/sample-project',
+      localPath: '/repos/sample-project',
+      skill: 'review-code',
+      enabled: true,
+      ...overrides,
+    };
+  }
+}

--- a/src/tests/units/dashboard/modules/constants.test.ts
+++ b/src/tests/units/dashboard/modules/constants.test.ts
@@ -5,6 +5,7 @@ import {
   STORAGE_KEY_PROJECTS,
   STORAGE_KEY_CURRENT,
   STORAGE_KEY_FOCUS_STRIP_MODE,
+  STORAGE_KEY_ACTIVE_TAB,
   QUALITY_TARGET_SCORE,
 } from '@/dashboard/modules/constants.js';
 
@@ -18,6 +19,7 @@ describe('constants', () => {
     expect(STORAGE_KEY_PROJECTS).toBe('review-flow-projects');
     expect(STORAGE_KEY_CURRENT).toBe('review-flow-current-project');
     expect(STORAGE_KEY_FOCUS_STRIP_MODE).toBe('review-flow-focus-strip-mode');
+    expect(STORAGE_KEY_ACTIVE_TAB).toBe('review-flow-active-tab');
   });
 
   it('should export quality score target', () => {

--- a/src/tests/units/dashboard/modules/overview.test.ts
+++ b/src/tests/units/dashboard/modules/overview.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildOverviewModel,
+  renderOverviewHtml,
+  renderSparklineSvg,
+} from '@/dashboard/modules/overview.js';
+
+describe('buildOverviewModel', () => {
+  it('passes through the presenter-shaped payload as the rendering view model', () => {
+    const payload = {
+      activeReviews: {
+        items: [
+          {
+            jobId: 'gitlab:frontend:1',
+            projectName: 'frontend',
+            projectPath: '/repos/frontend',
+            mrPrefix: 'MR',
+            mrNumber: 1,
+            mrUrl: 'https://example.com/1',
+            elapsedLabel: '3m',
+            jobType: 'review',
+          },
+        ],
+        isEmpty: false,
+        emptyMessage: 'Aucune review en cours',
+      },
+      projectCards: {
+        items: [
+          {
+            projectName: 'frontend',
+            projectPath: '/repos/frontend',
+            platform: 'gitlab',
+            totalReviews: 12,
+            averageScoreLabel: '7.2',
+            sparklinePoints: [6, 7, 8],
+            isEmptyHistory: false,
+          },
+        ],
+        isEmpty: false,
+        emptyMessage: 'Aucun projet configuré',
+      },
+      recentReviewsFeed: {
+        items: [],
+        isEmpty: true,
+        emptyMessage: 'Aucune review récente',
+      },
+    };
+
+    const model = buildOverviewModel(payload);
+
+    expect(model.activeReviews.items).toHaveLength(1);
+    expect(model.projectCards.items).toHaveLength(1);
+    expect(model.recentReviewsFeed.isEmpty).toBe(true);
+  });
+
+  it('coerces missing sections to empty defaults', () => {
+    const model = buildOverviewModel({});
+
+    expect(model.activeReviews.items).toEqual([]);
+    expect(model.activeReviews.isEmpty).toBe(true);
+    expect(model.projectCards.items).toEqual([]);
+    expect(model.projectCards.isEmpty).toBe(true);
+    expect(model.recentReviewsFeed.items).toEqual([]);
+    expect(model.recentReviewsFeed.isEmpty).toBe(true);
+  });
+});
+
+describe('renderOverviewHtml', () => {
+  it('renders the three sections with their LABEL prefix headings', () => {
+    const html = renderOverviewHtml({
+      activeReviews: { items: [], isEmpty: true, emptyMessage: 'Aucune review en cours' },
+      projectCards: { items: [], isEmpty: true, emptyMessage: 'Aucun projet configuré' },
+      recentReviewsFeed: { items: [], isEmpty: true, emptyMessage: 'Aucune review récente' },
+    });
+
+    expect(html).toContain('// ACTIVE REVIEWS');
+    expect(html).toContain('// PROJECTS');
+    expect(html).toContain('// RECENT REVIEWS');
+  });
+
+  it('renders the empty message for each section when isEmpty is true', () => {
+    const html = renderOverviewHtml({
+      activeReviews: { items: [], isEmpty: true, emptyMessage: 'Aucune review en cours' },
+      projectCards: { items: [], isEmpty: true, emptyMessage: 'Aucun projet configuré' },
+      recentReviewsFeed: { items: [], isEmpty: true, emptyMessage: 'Aucune review récente' },
+    });
+
+    expect(html).toContain('Aucune review en cours');
+    expect(html).toContain('Aucun projet configuré');
+    expect(html).toContain('Aucune review récente');
+  });
+
+  it('renders one active review row with project name, MR number and elapsed label', () => {
+    const html = renderOverviewHtml({
+      activeReviews: {
+        items: [
+          {
+            jobId: 'gitlab:frontend:142',
+            projectName: 'frontend',
+            projectPath: '/repos/frontend',
+            mrPrefix: 'MR',
+            mrNumber: 142,
+            mrUrl: 'https://gitlab.com/org/frontend/-/merge_requests/142',
+            elapsedLabel: '3m',
+            jobType: 'review',
+          },
+        ],
+        isEmpty: false,
+        emptyMessage: 'Aucune review en cours',
+      },
+      projectCards: { items: [], isEmpty: true, emptyMessage: 'Aucun projet configuré' },
+      recentReviewsFeed: { items: [], isEmpty: true, emptyMessage: 'Aucune review récente' },
+    });
+
+    expect(html).toContain('frontend');
+    expect(html).toContain('MR #142');
+    expect(html).toContain('3m');
+    expect(html).toContain('https://gitlab.com/org/frontend/-/merge_requests/142');
+  });
+
+  it('renders one project card with name, totals, score, sparkline and data-project-path for click navigation', () => {
+    const html = renderOverviewHtml({
+      activeReviews: { items: [], isEmpty: true, emptyMessage: 'Aucune review en cours' },
+      projectCards: {
+        items: [
+          {
+            projectName: 'frontend',
+            projectPath: '/repos/frontend',
+            platform: 'gitlab',
+            totalReviews: 24,
+            averageScoreLabel: '7.2',
+            sparklinePoints: [6, 7, 8, 7, 9],
+            isEmptyHistory: false,
+          },
+        ],
+        isEmpty: false,
+        emptyMessage: 'Aucun projet configuré',
+      },
+      recentReviewsFeed: { items: [], isEmpty: true, emptyMessage: 'Aucune review récente' },
+    });
+
+    expect(html).toContain('data-project-path="/repos/frontend"');
+    expect(html).toContain('frontend');
+    expect(html).toContain('24 reviews');
+    expect(html).toContain('Score 7.2');
+    expect(html).toContain('<polyline');
+  });
+
+  it('does not render a polyline when a project has no sparkline points', () => {
+    const html = renderOverviewHtml({
+      activeReviews: { items: [], isEmpty: true, emptyMessage: 'Aucune review en cours' },
+      projectCards: {
+        items: [
+          {
+            projectName: 'new-project',
+            projectPath: '/repos/new',
+            platform: 'gitlab',
+            totalReviews: 0,
+            averageScoreLabel: '-',
+            sparklinePoints: [],
+            isEmptyHistory: true,
+          },
+        ],
+        isEmpty: false,
+        emptyMessage: 'Aucun projet configuré',
+      },
+      recentReviewsFeed: { items: [], isEmpty: true, emptyMessage: 'Aucune review récente' },
+    });
+
+    expect(html).not.toContain('<polyline');
+    expect(html).toContain('0 reviews');
+    expect(html).toContain('Score -');
+  });
+
+  it('renders the recent reviews feed with project name, MR prefix and number', () => {
+    const html = renderOverviewHtml({
+      activeReviews: { items: [], isEmpty: true, emptyMessage: 'Aucune review en cours' },
+      projectCards: { items: [], isEmpty: true, emptyMessage: 'Aucun projet configuré' },
+      recentReviewsFeed: {
+        items: [
+          {
+            filename: '2026-05-25-MR-1.md',
+            projectName: 'frontend',
+            mrPrefix: 'MR',
+            mrNumber: '1',
+            title: 'feat: dashboard',
+            mtime: '2026-05-25T11:59:00.000Z',
+          },
+        ],
+        isEmpty: false,
+        emptyMessage: 'Aucune review récente',
+      },
+    });
+
+    expect(html).toContain('frontend');
+    expect(html).toContain('MR #1');
+    expect(html).toContain('feat: dashboard');
+  });
+});
+
+describe('renderSparklineSvg', () => {
+  it('returns an empty string when no points are provided', () => {
+    expect(renderSparklineSvg([])).toBe('');
+  });
+
+  it('returns an SVG with one <polyline> for non-empty points', () => {
+    const svg = renderSparklineSvg([5, 6, 7, 8]);
+    expect(svg).toContain('<svg');
+    expect(svg).toContain('<polyline');
+    expect(svg).toContain('points="');
+  });
+
+  it('produces N coordinate pairs in the polyline points attribute', () => {
+    const svg = renderSparklineSvg([5, 6, 7, 8]);
+    const pointsMatch = svg.match(/points="([^"]+)"/);
+    expect(pointsMatch).not.toBeNull();
+    const pairs = pointsMatch !== null ? pointsMatch[1].trim().split(/\s+/) : [];
+    expect(pairs).toHaveLength(4);
+  });
+});

--- a/src/tests/units/dashboard/modules/overview.test.ts
+++ b/src/tests/units/dashboard/modules/overview.test.ts
@@ -1,22 +1,35 @@
 import { describe, expect, it } from 'vitest';
 import {
-  buildOverviewModel,
   renderOverviewHtml,
   renderSparklineSvg,
 } from '@/dashboard/modules/overview.js';
 
-describe('buildOverviewModel', () => {
-  it('passes through the presenter-shaped payload as the rendering view model', () => {
-    const payload = {
+describe('renderOverviewHtml', () => {
+  it('falls back to French empty defaults when sections are missing from server payload', () => {
+    const html = renderOverviewHtml({});
+
+    expect(html).toContain('Aucune review en cours');
+    expect(html).toContain('Aucun projet configuré');
+    expect(html).toContain('Aucune review récente');
+  });
+
+  it('falls back to empty defaults when payload is null', () => {
+    const html = renderOverviewHtml(null);
+
+    expect(html).toContain('Aucune review en cours');
+  });
+
+  it('strips javascript: scheme from mrUrl when rendering active review row', () => {
+    const html = renderOverviewHtml({
       activeReviews: {
         items: [
           {
-            jobId: 'gitlab:frontend:1',
+            jobId: 'job-1',
             projectName: 'frontend',
             projectPath: '/repos/frontend',
             mrPrefix: 'MR',
             mrNumber: 1,
-            mrUrl: 'https://example.com/1',
+            mrUrl: 'javascript:alert(1)',
             elapsedLabel: '3m',
             jobType: 'review',
           },
@@ -24,48 +37,15 @@ describe('buildOverviewModel', () => {
         isEmpty: false,
         emptyMessage: 'Aucune review en cours',
       },
-      projectCards: {
-        items: [
-          {
-            projectName: 'frontend',
-            projectPath: '/repos/frontend',
-            platform: 'gitlab',
-            totalReviews: 12,
-            averageScoreLabel: '7.2',
-            sparklinePoints: [6, 7, 8],
-            isEmptyHistory: false,
-          },
-        ],
-        isEmpty: false,
-        emptyMessage: 'Aucun projet configuré',
-      },
-      recentReviewsFeed: {
-        items: [],
-        isEmpty: true,
-        emptyMessage: 'Aucune review récente',
-      },
-    };
+      projectCards: { items: [], isEmpty: true, emptyMessage: 'Aucun projet configuré' },
+      recentReviewsFeed: { items: [], isEmpty: true, emptyMessage: 'Aucune review récente' },
+    });
 
-    const model = buildOverviewModel(payload);
-
-    expect(model.activeReviews.items).toHaveLength(1);
-    expect(model.projectCards.items).toHaveLength(1);
-    expect(model.recentReviewsFeed.isEmpty).toBe(true);
+    expect(html).not.toContain('javascript:');
+    expect(html).toContain('href="#"');
   });
 
-  it('coerces missing sections to empty defaults', () => {
-    const model = buildOverviewModel({});
 
-    expect(model.activeReviews.items).toEqual([]);
-    expect(model.activeReviews.isEmpty).toBe(true);
-    expect(model.projectCards.items).toEqual([]);
-    expect(model.projectCards.isEmpty).toBe(true);
-    expect(model.recentReviewsFeed.items).toEqual([]);
-    expect(model.recentReviewsFeed.isEmpty).toBe(true);
-  });
-});
-
-describe('renderOverviewHtml', () => {
   it('renders the three sections with their LABEL prefix headings', () => {
     const html = renderOverviewHtml({
       activeReviews: { items: [], isEmpty: true, emptyMessage: 'Aucune review en cours' },

--- a/src/tests/units/dashboard/modules/tabBar.test.ts
+++ b/src/tests/units/dashboard/modules/tabBar.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildTabBarModel,
+  renderTabBarHtml,
+  readActiveTab,
+  writeActiveTab,
+} from '@/dashboard/modules/tabBar.js';
+
+interface TestStorage {
+  store: Map<string, string>;
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+}
+
+function createTestStorage(): TestStorage {
+  const store = new Map<string, string>();
+  return {
+    store,
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+  };
+}
+
+describe('tabBar module', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('buildTabBarModel', () => {
+    it('marks Overview as active when no activeTabId is provided', () => {
+      const model = buildTabBarModel({
+        repositories: [{ name: 'frontend', localPath: '/repos/frontend' }],
+        activeTabId: null,
+      });
+
+      expect(model.tabs[0]?.id).toBe('overview');
+      expect(model.tabs[0]?.label).toBe('Overview');
+      expect(model.tabs[0]?.isActive).toBe(true);
+      expect(model.tabs[1]?.isActive).toBe(false);
+    });
+
+    it('marks the matching project tab as active and Overview as inactive', () => {
+      const model = buildTabBarModel({
+        repositories: [
+          { name: 'frontend', localPath: '/repos/frontend' },
+          { name: 'api', localPath: '/repos/api' },
+        ],
+        activeTabId: '/repos/api',
+      });
+
+      expect(model.tabs.find((tab) => tab.id === 'overview')?.isActive).toBe(false);
+      expect(model.tabs.find((tab) => tab.id === '/repos/api')?.isActive).toBe(true);
+      expect(model.tabs.find((tab) => tab.id === '/repos/frontend')?.isActive).toBe(false);
+    });
+
+    it('falls back to Overview when the active tab id matches no repository', () => {
+      const model = buildTabBarModel({
+        repositories: [{ name: 'frontend', localPath: '/repos/frontend' }],
+        activeTabId: '/repos/missing',
+      });
+
+      expect(model.tabs.find((tab) => tab.id === 'overview')?.isActive).toBe(true);
+    });
+
+    it('builds a tab per repository using the repository name as label', () => {
+      const model = buildTabBarModel({
+        repositories: [
+          { name: 'frontend', localPath: '/repos/frontend' },
+          { name: 'api', localPath: '/repos/api' },
+        ],
+        activeTabId: null,
+      });
+
+      expect(model.tabs).toHaveLength(3);
+      expect(model.tabs[1]).toEqual({ id: '/repos/frontend', label: 'frontend', isActive: false });
+      expect(model.tabs[2]).toEqual({ id: '/repos/api', label: 'api', isActive: false });
+    });
+  });
+
+  describe('renderTabBarHtml', () => {
+    it('renders a <nav> element with one button per tab and marks the active one', () => {
+      const html = renderTabBarHtml({
+        tabs: [
+          { id: 'overview', label: 'Overview', isActive: true },
+          { id: '/repos/frontend', label: 'frontend', isActive: false },
+        ],
+      });
+
+      expect(html).toContain('<nav');
+      expect(html).toContain('data-tab-id="overview"');
+      expect(html).toContain('data-tab-id="/repos/frontend"');
+      expect(html).toContain('aria-selected="true"');
+    });
+
+    it('escapes the label to prevent HTML injection', () => {
+      const html = renderTabBarHtml({
+        tabs: [{ id: 'overview', label: '<script>alert(1)</script>', isActive: true }],
+      });
+
+      expect(html).not.toContain('<script>alert(1)</script>');
+      expect(html).toContain('&lt;script&gt;');
+    });
+  });
+
+  describe('localStorage round-trip', () => {
+    it('writeActiveTab persists the id and readActiveTab returns it', () => {
+      const storage = createTestStorage();
+      vi.stubGlobal('localStorage', storage);
+
+      writeActiveTab('/repos/api');
+
+      expect(readActiveTab()).toBe('/repos/api');
+      expect(storage.store.get('review-flow-active-tab')).toBe('/repos/api');
+    });
+
+    it('readActiveTab returns null when nothing has been stored', () => {
+      const storage = createTestStorage();
+      vi.stubGlobal('localStorage', storage);
+
+      expect(readActiveTab()).toBeNull();
+    });
+  });
+});

--- a/src/tests/units/modules/cli-configuration/interface-adapters/controllers/http/repositories.routes.test.ts
+++ b/src/tests/units/modules/cli-configuration/interface-adapters/controllers/http/repositories.routes.test.ts
@@ -1,0 +1,75 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import { describe, expect, it } from 'vitest';
+import { repositoriesRoutes } from '@/modules/cli-configuration/interface-adapters/controllers/http/repositories.routes.js';
+import { RepositoryConfigFactory } from '@/tests/factories/repositoryConfig.factory.js';
+
+async function buildApp(repositories: ReturnType<typeof RepositoryConfigFactory.create>[]): Promise<FastifyInstance> {
+  const app = Fastify();
+  await app.register(repositoriesRoutes, { getRepositories: () => repositories });
+  return app;
+}
+
+describe('repositoriesRoutes — GET /api/repositories', () => {
+  it('returns the projected list of repositories', async () => {
+    const app = await buildApp([
+      RepositoryConfigFactory.create({
+        name: 'frontend',
+        localPath: '/repos/frontend',
+        platform: 'gitlab',
+        enabled: true,
+      }),
+    ]);
+
+    const response = await app.inject({ method: 'GET', url: '/api/repositories' });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as {
+      repositories: Array<{ name: string; localPath: string; platform: string; enabled: boolean }>;
+    };
+    expect(body.repositories).toEqual([
+      { name: 'frontend', localPath: '/repos/frontend', platform: 'gitlab', enabled: true },
+    ]);
+
+    await app.close();
+  });
+
+  it('returns disabled repositories alongside enabled ones', async () => {
+    const app = await buildApp([
+      RepositoryConfigFactory.create({ name: 'enabled-repo', localPath: '/repos/enabled', enabled: true }),
+      RepositoryConfigFactory.create({ name: 'disabled-repo', localPath: '/repos/disabled', enabled: false }),
+    ]);
+
+    const response = await app.inject({ method: 'GET', url: '/api/repositories' });
+
+    const body = response.json() as { repositories: Array<{ name: string; enabled: boolean }> };
+    expect(body.repositories.map((repository) => repository.enabled)).toEqual([true, false]);
+
+    await app.close();
+  });
+
+  it('returns an empty array when no repository is configured', async () => {
+    const app = await buildApp([]);
+
+    const response = await app.inject({ method: 'GET', url: '/api/repositories' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ repositories: [] });
+
+    await app.close();
+  });
+
+  it('exposes the repository platform so the dashboard can label tabs', async () => {
+    const app = await buildApp([
+      RepositoryConfigFactory.create({ name: 'gh-repo', platform: 'github' }),
+      RepositoryConfigFactory.create({ name: 'gl-repo', platform: 'gitlab' }),
+    ]);
+
+    const response = await app.inject({ method: 'GET', url: '/api/repositories' });
+
+    const body = response.json() as { repositories: Array<{ name: string; platform: string }> };
+    expect(body.repositories.find((repository) => repository.name === 'gh-repo')?.platform).toBe('github');
+    expect(body.repositories.find((repository) => repository.name === 'gl-repo')?.platform).toBe('gitlab');
+
+    await app.close();
+  });
+});

--- a/src/tests/units/modules/statistics-insights/interface-adapters/controllers/http/overview.routes.test.ts
+++ b/src/tests/units/modules/statistics-insights/interface-adapters/controllers/http/overview.routes.test.ts
@@ -1,0 +1,193 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import { describe, expect, it } from 'vitest';
+import { overviewRoutes } from '@/modules/statistics-insights/interface-adapters/controllers/http/overview.routes.js';
+import type { StatsGateway } from '@/modules/statistics-insights/entities/stats/stats.gateway.js';
+import type { ReviewFileGateway, ReviewFileInfo } from '@/modules/review-execution/entities/review/reviewFile.gateway.js';
+import type { ProjectStats } from '@/modules/statistics-insights/entities/stats/projectStats.js';
+import type { OverviewViewModel } from '@/modules/statistics-insights/interface-adapters/presenters/overview.presenter.js';
+import { RepositoryConfigFactory } from '@/tests/factories/repositoryConfig.factory.js';
+
+function makeStats(reviews: ProjectStats['reviews']): ProjectStats {
+  const scoredReviews = reviews.filter((review) => review.score !== null);
+  const averageScore = scoredReviews.length === 0
+    ? null
+    : scoredReviews.reduce((sum, review) => sum + (review.score ?? 0), 0) / scoredReviews.length;
+  return {
+    totalReviews: reviews.length,
+    totalDuration: 0,
+    averageScore,
+    averageDuration: 0,
+    totalBlocking: 0,
+    totalWarnings: 0,
+    totalAdditions: 0,
+    totalDeletions: 0,
+    averageAdditions: null,
+    averageDeletions: null,
+    reviews,
+    lastUpdated: '2026-05-25T12:00:00.000Z',
+  };
+}
+
+function makeReview(overrides: Partial<ProjectStats['reviews'][number]>): ProjectStats['reviews'][number] {
+  return {
+    id: 'review-1',
+    timestamp: '2026-05-25T10:00:00.000Z',
+    mrNumber: 1,
+    duration: 60,
+    score: 7,
+    blocking: 0,
+    warnings: 0,
+    ...overrides,
+  };
+}
+
+function makeReviewFile(overrides: Partial<ReviewFileInfo>): ReviewFileInfo {
+  return {
+    filename: '2026-05-25-MR-142.md',
+    path: '/repos/frontend/.claude/reviews/2026-05-25-MR-142.md',
+    date: '2026-05-25',
+    mrNumber: '142',
+    type: 'MR',
+    size: 1024,
+    mtime: '2026-05-25T14:05:00.000Z',
+    ...overrides,
+  };
+}
+
+function stubStatsGateway(byPath: Record<string, ProjectStats | null>): StatsGateway {
+  return {
+    loadProjectStats: (path: string) => byPath[path] ?? null,
+  } as StatsGateway;
+}
+
+function stubReviewFileGateway(byPath: Record<string, ReviewFileInfo[]>): ReviewFileGateway {
+  return {
+    listReviews: async (path: string) => byPath[path] ?? [],
+    readReview: async () => null,
+    deleteReview: async () => false,
+    reviewExists: async () => false,
+    getReviewsDirectory: () => '',
+  };
+}
+
+async function buildApp(options: {
+  repositories: ReturnType<typeof RepositoryConfigFactory.create>[];
+  activeJobs?: Array<{
+    id: string;
+    mrNumber: number;
+    project: string;
+    mrUrl: string;
+    status: string;
+    startedAt: string | null;
+    jobType?: 'review' | 'followup';
+  }>;
+  statsByPath?: Record<string, ProjectStats | null>;
+  reviewsByPath?: Record<string, ReviewFileInfo[]>;
+}): Promise<FastifyInstance> {
+  const app = Fastify();
+  await app.register(overviewRoutes, {
+    getRepositories: () => options.repositories,
+    getActiveJobs: () => options.activeJobs ?? [],
+    statsGateway: stubStatsGateway(options.statsByPath ?? {}),
+    reviewFileGateway: stubReviewFileGateway(options.reviewsByPath ?? {}),
+  });
+  return app;
+}
+
+describe('overviewRoutes — GET /api/overview', () => {
+  it('returns an empty view-model when no repository is configured', async () => {
+    const app = await buildApp({ repositories: [] });
+
+    const response = await app.inject({ method: 'GET', url: '/api/overview' });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as OverviewViewModel;
+    expect(body.activeReviews.isEmpty).toBe(true);
+    expect(body.projectCards.isEmpty).toBe(true);
+    expect(body.recentReviewsFeed.isEmpty).toBe(true);
+
+    await app.close();
+  });
+
+  it('aggregates active jobs, project stats, and recent reviews', async () => {
+    const app = await buildApp({
+      repositories: [
+        RepositoryConfigFactory.create({ name: 'frontend', localPath: '/repos/frontend', platform: 'gitlab', enabled: true }),
+        RepositoryConfigFactory.create({ name: 'api', localPath: '/repos/api', platform: 'github', enabled: true }),
+      ],
+      activeJobs: [
+        {
+          id: 'job-1',
+          mrNumber: 142,
+          project: '/repos/frontend',
+          mrUrl: 'https://example.com/mr/142',
+          status: 'running',
+          startedAt: '2026-05-25T14:00:00.000Z',
+        },
+      ],
+      statsByPath: {
+        '/repos/frontend': makeStats([
+          makeReview({ id: 'r-1', mrNumber: 100, timestamp: '2026-05-24T10:00:00.000Z', score: 7 }),
+          makeReview({ id: 'r-2', mrNumber: 101, timestamp: '2026-05-25T10:00:00.000Z', score: 8 }),
+        ]),
+        '/repos/api': makeStats([]),
+      },
+      reviewsByPath: {
+        '/repos/frontend': [makeReviewFile({ filename: '2026-05-25-MR-137.md', mrNumber: '137' })],
+        '/repos/api': [makeReviewFile({
+          filename: '2026-05-25-PR-28.md',
+          path: '/repos/api/.claude/reviews/2026-05-25-PR-28.md',
+          mrNumber: '28',
+          type: 'PR',
+          mtime: '2026-05-25T14:10:00.000Z',
+        })],
+      },
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/api/overview' });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as OverviewViewModel;
+
+    expect(body.activeReviews.items).toHaveLength(1);
+    expect(body.activeReviews.items[0]?.projectName).toBe('frontend');
+    expect(body.activeReviews.items[0]?.mrPrefix).toBe('MR');
+
+    expect(body.projectCards.items).toHaveLength(2);
+    expect(body.projectCards.items[0]?.projectName).toBe('frontend');
+    expect(body.projectCards.items[0]?.sparklinePoints).toEqual([7, 8]);
+    expect(body.projectCards.items[1]?.projectName).toBe('api');
+    expect(body.projectCards.items[1]?.isEmptyHistory).toBe(true);
+
+    expect(body.recentReviewsFeed.items).toHaveLength(2);
+    expect(body.recentReviewsFeed.items[0]?.filename).toBe('2026-05-25-PR-28.md');
+    expect(body.recentReviewsFeed.items[0]?.mrPrefix).toBe('PR');
+
+    await app.close();
+  });
+
+  it('skips disabled repositories when aggregating stats and reviews', async () => {
+    const app = await buildApp({
+      repositories: [
+        RepositoryConfigFactory.create({ name: 'enabled', localPath: '/repos/enabled', enabled: true }),
+        RepositoryConfigFactory.create({ name: 'disabled', localPath: '/repos/disabled', enabled: false }),
+      ],
+      statsByPath: {
+        '/repos/disabled': makeStats([
+          makeReview({ id: 'r-x', mrNumber: 99, timestamp: '2026-05-25T10:00:00.000Z', score: 5 }),
+        ]),
+      },
+      reviewsByPath: {
+        '/repos/disabled': [makeReviewFile({ filename: '2026-05-25-MR-99.md', mrNumber: '99' })],
+      },
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/api/overview' });
+
+    const body = response.json() as OverviewViewModel;
+    expect(body.recentReviewsFeed.items).toHaveLength(0);
+    expect(body.projectCards.items.find((card) => card.projectName === 'disabled')?.isEmptyHistory).toBe(true);
+
+    await app.close();
+  });
+});

--- a/src/tests/units/modules/statistics-insights/interface-adapters/presenters/overview.presenter.test.ts
+++ b/src/tests/units/modules/statistics-insights/interface-adapters/presenters/overview.presenter.test.ts
@@ -1,0 +1,328 @@
+import { describe, expect, it } from 'vitest';
+import { OverviewPresenter } from '@/modules/statistics-insights/interface-adapters/presenters/overview.presenter.js';
+import { RepositoryConfigFactory } from '@/tests/factories/repositoryConfig.factory.js';
+import { ProjectStatsApiResponseFactory } from '@/tests/factories/projectStatsApiResponse.factory.js';
+import { RecentReviewFileFactory } from '@/tests/factories/recentReviewFile.factory.js';
+import { ReviewStatsFactory } from '@/tests/factories/projectStats.factory.js';
+
+const NOW = new Date('2026-05-25T12:00:00.000Z');
+
+describe('OverviewPresenter', () => {
+  describe('empty inputs', () => {
+    it('marks every section as empty with French messages', () => {
+      const presenter = new OverviewPresenter({ now: () => NOW });
+
+      const viewModel = presenter.present({
+        repositories: [],
+        activeJobs: [],
+        projectStats: [],
+        recentReviews: [],
+      });
+
+      expect(viewModel.activeReviews.items).toEqual([]);
+      expect(viewModel.activeReviews.isEmpty).toBe(true);
+      expect(viewModel.activeReviews.emptyMessage).toBe('Aucune review en cours');
+      expect(viewModel.projectCards.items).toEqual([]);
+      expect(viewModel.projectCards.isEmpty).toBe(true);
+      expect(viewModel.projectCards.emptyMessage).toBe('Aucun projet configuré');
+      expect(viewModel.recentReviewsFeed.items).toEqual([]);
+      expect(viewModel.recentReviewsFeed.isEmpty).toBe(true);
+      expect(viewModel.recentReviewsFeed.emptyMessage).toBe('Aucune review récente');
+    });
+  });
+
+  describe('active reviews', () => {
+    it('formats one running review with elapsed time and resolves project name from localPath', () => {
+      const presenter = new OverviewPresenter({ now: () => NOW });
+      const startedFiveMinutesAgo = new Date(NOW.getTime() - 5 * 60_000).toISOString();
+
+      const viewModel = presenter.present({
+        repositories: [RepositoryConfigFactory.create({ name: 'frontend', localPath: '/repos/frontend', platform: 'gitlab' })],
+        activeJobs: [
+          {
+            id: 'gitlab:frontend:142',
+            mrNumber: 142,
+            project: '/repos/frontend',
+            mrUrl: 'https://gitlab.com/org/frontend/-/merge_requests/142',
+            status: 'running',
+            startedAt: startedFiveMinutesAgo,
+            jobType: 'review',
+          },
+        ],
+        projectStats: [],
+        recentReviews: [],
+      });
+
+      expect(viewModel.activeReviews.items).toHaveLength(1);
+      const entry = viewModel.activeReviews.items[0];
+      expect(entry?.jobId).toBe('gitlab:frontend:142');
+      expect(entry?.projectName).toBe('frontend');
+      expect(entry?.mrNumber).toBe(142);
+      expect(entry?.mrPrefix).toBe('MR');
+      expect(entry?.mrUrl).toBe('https://gitlab.com/org/frontend/-/merge_requests/142');
+      expect(entry?.elapsedLabel).toBe('5m');
+    });
+
+    it('orders active reviews by startedAt DESC (most recent first)', () => {
+      const presenter = new OverviewPresenter({ now: () => NOW });
+      const startedTenMinutesAgo = new Date(NOW.getTime() - 10 * 60_000).toISOString();
+      const startedTwoMinutesAgo = new Date(NOW.getTime() - 2 * 60_000).toISOString();
+
+      const viewModel = presenter.present({
+        repositories: [
+          RepositoryConfigFactory.create({ name: 'older', localPath: '/repos/older' }),
+          RepositoryConfigFactory.create({ name: 'newer', localPath: '/repos/newer' }),
+        ],
+        activeJobs: [
+          {
+            id: 'older-job',
+            mrNumber: 1,
+            project: '/repos/older',
+            mrUrl: 'https://example.com/1',
+            status: 'running',
+            startedAt: startedTenMinutesAgo,
+          },
+          {
+            id: 'newer-job',
+            mrNumber: 2,
+            project: '/repos/newer',
+            mrUrl: 'https://example.com/2',
+            status: 'running',
+            startedAt: startedTwoMinutesAgo,
+          },
+        ],
+        projectStats: [],
+        recentReviews: [],
+      });
+
+      expect(viewModel.activeReviews.items.map((item) => item.jobId)).toEqual(['newer-job', 'older-job']);
+    });
+
+    it('uses PR prefix when the job runs on a GitHub project', () => {
+      const presenter = new OverviewPresenter({ now: () => NOW });
+
+      const viewModel = presenter.present({
+        repositories: [RepositoryConfigFactory.create({ name: 'api', localPath: '/repos/api', platform: 'github' })],
+        activeJobs: [
+          {
+            id: 'github:api:28',
+            mrNumber: 28,
+            project: '/repos/api',
+            mrUrl: 'https://github.com/org/api/pull/28',
+            status: 'running',
+            startedAt: new Date(NOW.getTime() - 60_000).toISOString(),
+          },
+        ],
+        projectStats: [],
+        recentReviews: [],
+      });
+
+      expect(viewModel.activeReviews.items[0]?.mrPrefix).toBe('PR');
+    });
+
+    it('falls back to "—" elapsedLabel when startedAt is missing', () => {
+      const presenter = new OverviewPresenter({ now: () => NOW });
+
+      const viewModel = presenter.present({
+        repositories: [RepositoryConfigFactory.create({ name: 'frontend', localPath: '/repos/frontend' })],
+        activeJobs: [
+          {
+            id: 'queued-job',
+            mrNumber: 5,
+            project: '/repos/frontend',
+            mrUrl: 'https://example.com/5',
+            status: 'queued',
+          },
+        ],
+        projectStats: [],
+        recentReviews: [],
+      });
+
+      expect(viewModel.activeReviews.items[0]?.elapsedLabel).toBe('—');
+    });
+  });
+
+  describe('project cards', () => {
+    it('builds a card per repository with totals from projectStats and the last 10 scores as sparkline points', () => {
+      const presenter = new OverviewPresenter({ now: () => NOW });
+      const reviews = Array.from({ length: 12 }, (_, index) =>
+        ReviewStatsFactory.create({
+          id: `r-${index}`,
+          timestamp: new Date(NOW.getTime() - (12 - index) * 60_000).toISOString(),
+          mrNumber: index,
+          score: index + 1,
+        }),
+      );
+
+      const viewModel = presenter.present({
+        repositories: [RepositoryConfigFactory.create({ name: 'frontend', localPath: '/repos/frontend' })],
+        activeJobs: [],
+        projectStats: [
+          ProjectStatsApiResponseFactory.create({
+            project: 'frontend',
+            path: '/repos/frontend',
+            totalReviews: 12,
+            averageScore: 7.2,
+            reviews,
+          }),
+        ],
+        recentReviews: [],
+      });
+
+      expect(viewModel.projectCards.items).toHaveLength(1);
+      const card = viewModel.projectCards.items[0];
+      expect(card?.projectName).toBe('frontend');
+      expect(card?.projectPath).toBe('/repos/frontend');
+      expect(card?.totalReviews).toBe(12);
+      expect(card?.averageScoreLabel).toBe('7.2');
+      expect(card?.sparklinePoints).toHaveLength(10);
+      expect(card?.sparklinePoints[0]).toBe(3);
+      expect(card?.sparklinePoints[9]).toBe(12);
+      expect(card?.isEmptyHistory).toBe(false);
+    });
+
+    it('renders a card with 0 reviews, score "-", and empty sparkline when a project has no history', () => {
+      const presenter = new OverviewPresenter({ now: () => NOW });
+
+      const viewModel = presenter.present({
+        repositories: [RepositoryConfigFactory.create({ name: 'new-project', localPath: '/repos/new' })],
+        activeJobs: [],
+        projectStats: [
+          ProjectStatsApiResponseFactory.create({
+            project: 'new-project',
+            path: '/repos/new',
+            totalReviews: 0,
+            averageScore: null,
+            reviews: [],
+          }),
+        ],
+        recentReviews: [],
+      });
+
+      const card = viewModel.projectCards.items[0];
+      expect(card?.totalReviews).toBe(0);
+      expect(card?.averageScoreLabel).toBe('-');
+      expect(card?.sparklinePoints).toEqual([]);
+      expect(card?.isEmptyHistory).toBe(true);
+    });
+
+    it('still renders the card when the repository has no stats entry yet', () => {
+      const presenter = new OverviewPresenter({ now: () => NOW });
+
+      const viewModel = presenter.present({
+        repositories: [RepositoryConfigFactory.create({ name: 'orphan', localPath: '/repos/orphan' })],
+        activeJobs: [],
+        projectStats: [],
+        recentReviews: [],
+      });
+
+      expect(viewModel.projectCards.items).toHaveLength(1);
+      expect(viewModel.projectCards.items[0]?.totalReviews).toBe(0);
+      expect(viewModel.projectCards.items[0]?.averageScoreLabel).toBe('-');
+    });
+
+    it('ignores scores that are null when building sparkline points', () => {
+      const presenter = new OverviewPresenter({ now: () => NOW });
+
+      const viewModel = presenter.present({
+        repositories: [RepositoryConfigFactory.create({ name: 'frontend', localPath: '/repos/frontend' })],
+        activeJobs: [],
+        projectStats: [
+          ProjectStatsApiResponseFactory.create({
+            project: 'frontend',
+            path: '/repos/frontend',
+            totalReviews: 3,
+            averageScore: 7,
+            reviews: [
+              ReviewStatsFactory.create({ id: 'a', timestamp: '2026-05-25T11:58:00.000Z', score: 6 }),
+              ReviewStatsFactory.create({ id: 'b', timestamp: '2026-05-25T11:59:00.000Z', score: null }),
+              ReviewStatsFactory.create({ id: 'c', timestamp: '2026-05-25T12:00:00.000Z', score: 8 }),
+            ],
+          }),
+        ],
+        recentReviews: [],
+      });
+
+      expect(viewModel.projectCards.items[0]?.sparklinePoints).toEqual([6, 8]);
+    });
+  });
+
+  describe('recent reviews feed', () => {
+    it('orders entries by mtime DESC and caps the feed at 10 items', () => {
+      const presenter = new OverviewPresenter({ now: () => NOW });
+      const items = Array.from({ length: 12 }, (_, index) =>
+        RecentReviewFileFactory.create({
+          filename: `2026-05-25-MR-${index}.md`,
+          path: `/repos/frontend/.claude/reviews/2026-05-25-MR-${index}.md`,
+          mrNumber: String(index),
+          mtime: new Date(NOW.getTime() - (12 - index) * 60_000).toISOString(),
+        }),
+      );
+
+      const viewModel = presenter.present({
+        repositories: [RepositoryConfigFactory.create({ name: 'frontend', localPath: '/repos/frontend' })],
+        activeJobs: [],
+        projectStats: [],
+        recentReviews: items,
+      });
+
+      expect(viewModel.recentReviewsFeed.items).toHaveLength(10);
+      expect(viewModel.recentReviewsFeed.items[0]?.filename).toBe('2026-05-25-MR-11.md');
+      expect(viewModel.recentReviewsFeed.items[9]?.filename).toBe('2026-05-25-MR-2.md');
+    });
+
+    it('resolves project name from the file path when it matches a configured repository localPath', () => {
+      const presenter = new OverviewPresenter({ now: () => NOW });
+
+      const viewModel = presenter.present({
+        repositories: [
+          RepositoryConfigFactory.create({ name: 'frontend', localPath: '/repos/frontend' }),
+          RepositoryConfigFactory.create({ name: 'api', localPath: '/repos/api' }),
+        ],
+        activeJobs: [],
+        projectStats: [],
+        recentReviews: [
+          RecentReviewFileFactory.create({
+            filename: '2026-05-25-MR-1.md',
+            path: '/repos/frontend/.claude/reviews/2026-05-25-MR-1.md',
+            mrNumber: '1',
+            mtime: '2026-05-25T11:59:00.000Z',
+          }),
+          RecentReviewFileFactory.create({
+            filename: '2026-05-25-PR-2.md',
+            path: '/repos/api/.claude/reviews/2026-05-25-PR-2.md',
+            mrNumber: '2',
+            type: 'PR',
+            mtime: '2026-05-25T11:58:00.000Z',
+          }),
+        ],
+      });
+
+      expect(viewModel.recentReviewsFeed.items[0]?.projectName).toBe('frontend');
+      expect(viewModel.recentReviewsFeed.items[0]?.mrPrefix).toBe('MR');
+      expect(viewModel.recentReviewsFeed.items[1]?.projectName).toBe('api');
+      expect(viewModel.recentReviewsFeed.items[1]?.mrPrefix).toBe('PR');
+    });
+
+    it('falls back to "—" project name when no repository localPath matches the review file path', () => {
+      const presenter = new OverviewPresenter({ now: () => NOW });
+
+      const viewModel = presenter.present({
+        repositories: [],
+        activeJobs: [],
+        projectStats: [],
+        recentReviews: [
+          RecentReviewFileFactory.create({
+            path: '/unknown/.claude/reviews/2026-05-25-MR-1.md',
+            mrNumber: '1',
+            mtime: '2026-05-25T11:59:00.000Z',
+          }),
+        ],
+        // empty repositories with one review means we still want to render
+        // a row but cannot derive a project label
+      });
+
+      expect(viewModel.recentReviewsFeed.items[0]?.projectName).toBe('—');
+    });
+  });
+});

--- a/src/tests/units/modules/statistics-insights/interface-adapters/presenters/overview.presenter.test.ts
+++ b/src/tests/units/modules/statistics-insights/interface-adapters/presenters/overview.presenter.test.ts
@@ -120,7 +120,7 @@ describe('OverviewPresenter', () => {
       expect(viewModel.activeReviews.items[0]?.mrPrefix).toBe('PR');
     });
 
-    it('falls back to "—" elapsedLabel when startedAt is missing', () => {
+    it('falls back to "—" elapsedLabel when startedAt is null', () => {
       const presenter = new OverviewPresenter({ now: () => NOW });
 
       const viewModel = presenter.present({
@@ -132,6 +132,7 @@ describe('OverviewPresenter', () => {
             project: '/repos/frontend',
             mrUrl: 'https://example.com/5',
             status: 'queued',
+            startedAt: null,
           },
         ],
         projectStats: [],


### PR DESCRIPTION
## Summary

Closes the UI gap identified in SPEC-91's 2026-05-24 re-draft. The backend layer was shipped in an earlier increment but the dashboard still rendered the single-project `<select>` dropdown. This PR delivers the missing UI.

- **Tab bar** replaces the project dropdown — Overview tab (default) + one tab per configured repository, persisted in `localStorage`
- **Overview tab** with 3 sections: cross-project active reviews (live via WS), project cards with SVG sparklines (last 10 scores), recent reviews feed (top 10 cross-project)
- **Click-card navigation** to per-project tab; per-project tabs retain all existing behaviour (cancel, sync, followup, approve)
- **No new entity, no new use case, no new gateway** — anti-overengineering challenge respected. Overview is presentation aggregation only, isolated in `OverviewPresenter` (server-side, unit-tested) and humble JS modules

### Files

| Layer | Created |
|---|---|
| HTTP route | `repositories.routes.ts` (`GET /api/repositories`) |
| Presenter | `overview.presenter.ts` (3-section view-model with French empty messages) |
| Humble JS | `overview.js`, `tabBar.js` (pure render + tiny tested helpers) |
| Tests | 5 new test files (46 tests) + 3 factories + 1 acceptance test (8 scenarios) |

| Layer | Modified |
|---|---|
| `index.html` | +261/-42 — thin orchestration only (mount, fetch, listeners) |
| `styles.css` | +336 — Agentic OS DNA (corner-brackets, `// LABEL`, glow-pulse, amber/green) |
| `routes.ts` | +5/-9 — register plugin |
| `constants.js` | +1 — `STORAGE_KEY_ACTIVE_TAB` |

## Test plan

- [x] `yarn typecheck` — 0 errors
- [x] `yarn lint` — 673 files, 0 issues
- [x] `yarn test:ci` — 272 test files, **1968 tests pass, 0 fail** (46 new for SPEC-91, 0 regression on the existing 1922)
- [x] `yarn verify` GREEN end-to-end
- [x] 12/12 spec scenarios covered (9 automated via acceptance + presenter + modules, 3 via wiring code review per plan disposition: Scenarios 3 real-time WS update, 5 click→navigate, 7 per-project tab unchanged)
- [ ] Manual QA: open dashboard → Overview displays 3 sections → trigger a review → row appears live in Active Reviews → click project card → switches to project tab with existing behaviour intact → reload → tab restored from localStorage

## Spec & report

- Spec: [`docs/specs/91-dashboard-multi-project-overview.md`](docs/specs/91-dashboard-multi-project-overview.md) — status `implemented`
- Plan: [`docs/plans/91-dashboard-multi-project-overview.plan.md`](docs/plans/91-dashboard-multi-project-overview.plan.md)
- Report: [`docs/reports/91-dashboard-multi-project-overview.report.md`](docs/reports/91-dashboard-multi-project-overview.report.md)