### PR TITLE
fix(webhook): recover unposted reviews on reviewflow-app restart

### DIFF
--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -122,7 +122,15 @@ export async function startServer(options: ServerOptions = {}): Promise<FastifyI
     billingIntervalMs: 60 * 60 * 1000,
   });
 
-  const recoverySummary = await runReviewRecovery({
+  await app.listen({
+    port,
+    host: '0.0.0.0',
+  });
+
+  // Recovery runs as a non-blocking background task so the HTTP listener is
+  // available immediately at boot. A long replay backlog can't delay health
+  // checks or webhook reception.
+  void runReviewRecovery({
     repositories: config.repositories.filter((repo) => repo.enabled),
     reviewContextGateway: deps.reviewContextGateway,
     executeActions: async (context, localPath) => {
@@ -136,13 +144,16 @@ export async function startServer(options: ServerOptions = {}): Promise<FastifyI
     },
     now: () => Date.now(),
     logger: deps.logger,
-  });
-  deps.logger.info(recoverySummary, 'Review recovery completed at boot');
-
-  await app.listen({
-    port,
-    host: '0.0.0.0',
-  });
+  })
+    .then((summary) => {
+      deps.logger.info(summary, 'Review recovery completed in background');
+    })
+    .catch((error) => {
+      deps.logger.error(
+        { error: error instanceof Error ? error.message : String(error) },
+        'Review recovery threw unexpectedly',
+      );
+    });
 
   const shutdown = async () => {
     deps.logger.info('Shutting down...');

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -14,6 +14,9 @@ import { InMemorySupervisorHealthGateway } from '@/modules/claude-invocation/int
 import { startSupervisorScheduler } from '@/frameworks/scheduler/supervisorScheduler.js';
 import { SupervisorCliGateway, createDefaultSupervisorProbe, createDefaultSupervisorSpawner } from '@/modules/supervisor-management/interface-adapters/gateways/supervisor.cli.gateway.js';
 import { SupervisorLockFileSystemGateway, createDefaultSupervisorLockFileSystem, getDefaultSupervisorLockFilePath } from '@/modules/supervisor-management/interface-adapters/gateways/supervisorLock.fileSystem.gateway.js';
+import { runReviewRecovery } from '@/modules/review-execution/services/reviewRecovery.service.js';
+import { executeActionsFromContext } from '@/modules/review-execution/services/contextActionsExecutor.js';
+import { defaultCommandExecutor } from '@/modules/review-execution/services/threadActionsExecutor.js';
 
 export interface ServerOptions {
   config?: Config;
@@ -118,6 +121,23 @@ export async function startServer(options: ServerOptions = {}): Promise<FastifyI
     supervisorIntervalMs: 5 * 60 * 1000,
     billingIntervalMs: 60 * 60 * 1000,
   });
+
+  const recoverySummary = await runReviewRecovery({
+    repositories: config.repositories.filter((repo) => repo.enabled),
+    reviewContextGateway: deps.reviewContextGateway,
+    executeActions: async (context, localPath) => {
+      const result = await executeActionsFromContext(
+        context,
+        localPath,
+        deps.logger,
+        defaultCommandExecutor,
+      );
+      return { success: result.failed === 0 };
+    },
+    now: () => Date.now(),
+    logger: deps.logger,
+  });
+  deps.logger.info(recoverySummary, 'Review recovery completed at boot');
 
   await app.listen({
     port,

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -140,7 +140,7 @@ export async function startServer(options: ServerOptions = {}): Promise<FastifyI
         deps.logger,
         defaultCommandExecutor,
       );
-      return { success: result.failed === 0 };
+      return { posted: result.succeeded, failed: result.failed };
     },
     now: () => Date.now(),
     logger: deps.logger,

--- a/src/modules/claude-invocation/interface-adapters/gateways/reviewReport.fileSystem.gateway.ts
+++ b/src/modules/claude-invocation/interface-adapters/gateways/reviewReport.fileSystem.gateway.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import type {
   ReviewReportContent,
@@ -9,27 +9,52 @@ import type {
 export interface ReviewReportFileSystem {
   existsSync: (path: string) => boolean;
   readFileSync: (path: string) => string;
+  readdirSync: (path: string) => string[];
 }
 
 const defaultFs: ReviewReportFileSystem = {
   existsSync,
   readFileSync: (path: string) => readFileSync(path, 'utf-8'),
+  readdirSync: (path: string) => readdirSync(path),
 };
 
 export class ReviewReportFileSystemGateway implements ReviewReportGateway {
   constructor(private readonly fs: ReviewReportFileSystem = defaultFs) {}
 
   buildPath(location: ReviewReportLocation): string {
-    const suffix = location.jobType === 'followup' ? 'followup' : 'review';
+    const suffix = suffixFor(location.jobType);
     const fileName = `${location.isoDate}-MR-${location.mergeRequestNumber}-${suffix}.md`;
     return join(location.localPath, '.claude', 'reviews', fileName);
   }
 
   read(location: ReviewReportLocation): ReviewReportContent | null {
-    const path = this.buildPath(location);
-    if (!this.fs.existsSync(path)) {
+    const exactPath = this.buildPath(location);
+    if (this.fs.existsSync(exactPath)) {
+      return { content: this.fs.readFileSync(exactPath), path: exactPath };
+    }
+
+    // Fallback: the report file's date prefix may differ from the lookup date
+    // (e.g. midnight UTC vs local), so we scan for any *-MR-<N>-<suffix>.md.
+    const reviewsDir = join(location.localPath, '.claude', 'reviews');
+    if (!this.fs.existsSync(reviewsDir)) {
       return null;
     }
-    return { content: this.fs.readFileSync(path), path };
+    const pattern = matcherFor(location);
+    const match = this.fs.readdirSync(reviewsDir).find(pattern);
+    if (!match) {
+      return null;
+    }
+    const resolved = join(reviewsDir, match);
+    return { content: this.fs.readFileSync(resolved), path: resolved };
   }
+}
+
+function suffixFor(jobType: ReviewReportLocation['jobType']): string {
+  return jobType === 'followup' ? 'followup' : 'review';
+}
+
+function matcherFor(location: ReviewReportLocation): (name: string) => boolean {
+  const suffix = suffixFor(location.jobType);
+  const tail = `-MR-${location.mergeRequestNumber}-${suffix}.md`;
+  return (name) => name.endsWith(tail) && /^\d{4}-\d{2}-\d{2}/.test(name);
 }

--- a/src/modules/platform-integration/interface-adapters/controllers/webhook/github.controller.ts
+++ b/src/modules/platform-integration/interface-adapters/controllers/webhook/github.controller.ts
@@ -19,6 +19,7 @@ import type { TransitionStateUseCase } from '@/modules/tracking/usecases/trackin
 import type { CheckFollowupNeededUseCase } from '@/modules/tracking/usecases/tracking/checkFollowupNeeded.usecase.js';
 import type { SyncThreadsUseCase } from '@/modules/tracking/usecases/tracking/syncThreads.usecase.js';
 import { parseReviewOutput } from '@/modules/statistics-insights/services/statsService.js';
+import { ReviewContextResultFactory } from '@/modules/review-execution/entities/reviewContext/reviewContextResult.factory.js';
 import { parseThreadActions } from '@/modules/review-execution/services/threadActionsParser.js';
 import { executeThreadActions, defaultCommandExecutor } from '@/modules/review-execution/services/threadActionsExecutor.js';
 import { executeActionsFromContext } from '@/modules/review-execution/services/contextActionsExecutor.js';
@@ -365,13 +366,11 @@ export async function handleGitHubWebhook(
                   { ...contextActionResult, threadResolveCount, prNumber: j.mrNumber },
                   'Actions executed from context file for followup'
                 );
-                contextGateway.setResult(j.localPath, mergeRequestId, {
-                  blocking: parsed.blocking,
-                  warnings: parsed.warnings,
-                  suggestions: parsed.suggestions,
-                  score: parsed.score ?? 0,
-                  verdict: parsed.blocking > 0 ? 'needs_fixes' : 'needs_discussion',
-                });
+                contextGateway.setResult(
+                  j.localPath,
+                  mergeRequestId,
+                  ReviewContextResultFactory.fromParsedReview(parsed),
+                );
               } else {
                 const threadActions = parseThreadActions(result.stdout);
                 if (threadActions.length > 0) {
@@ -671,13 +670,11 @@ export async function handleGitHubWebhook(
           { ...contextActionResult, prNumber: j.mrNumber },
           'Actions executed from context file'
         );
-        contextGateway.setResult(j.localPath, mergeRequestId, {
-          blocking: parsed.blocking,
-          warnings: parsed.warnings,
-          suggestions: parsed.suggestions,
-          score: parsed.score ?? 0,
-          verdict: parsed.blocking > 0 ? 'needs_fixes' : 'needs_discussion',
-        });
+        contextGateway.setResult(
+          j.localPath,
+          mergeRequestId,
+          ReviewContextResultFactory.fromParsedReview(parsed),
+        );
       }
 
       let reviewDiffStats = null;

--- a/src/modules/platform-integration/interface-adapters/controllers/webhook/github.controller.ts
+++ b/src/modules/platform-integration/interface-adapters/controllers/webhook/github.controller.ts
@@ -365,6 +365,13 @@ export async function handleGitHubWebhook(
                   { ...contextActionResult, threadResolveCount, prNumber: j.mrNumber },
                   'Actions executed from context file for followup'
                 );
+                contextGateway.setResult(j.localPath, mergeRequestId, {
+                  blocking: parsed.blocking,
+                  warnings: parsed.warnings,
+                  suggestions: parsed.suggestions,
+                  score: parsed.score ?? 0,
+                  verdict: parsed.blocking > 0 ? 'needs_fixes' : 'needs_discussion',
+                });
               } else {
                 const threadActions = parseThreadActions(result.stdout);
                 if (threadActions.length > 0) {
@@ -664,6 +671,13 @@ export async function handleGitHubWebhook(
           { ...contextActionResult, prNumber: j.mrNumber },
           'Actions executed from context file'
         );
+        contextGateway.setResult(j.localPath, mergeRequestId, {
+          blocking: parsed.blocking,
+          warnings: parsed.warnings,
+          suggestions: parsed.suggestions,
+          score: parsed.score ?? 0,
+          verdict: parsed.blocking > 0 ? 'needs_fixes' : 'needs_discussion',
+        });
       }
 
       let reviewDiffStats = null;

--- a/src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts
+++ b/src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts
@@ -25,6 +25,7 @@ import type { SyncThreadsUseCase } from '@/modules/tracking/usecases/tracking/sy
 import { loadProjectConfig, getProjectAgentsOrFocusDefaults, getFollowupAgents, getProjectLanguage } from '@/config/projectConfig.js';
 import { DEFAULT_AGENTS, DEFAULT_FOLLOWUP_AGENTS } from '@/modules/review-execution/entities/progress/agentDefinition.type.js';
 import { parseReviewOutput } from '@/modules/statistics-insights/services/statsService.js';
+import { ReviewContextResultFactory } from '@/modules/review-execution/entities/reviewContext/reviewContextResult.factory.js';
 import { parseThreadActions } from '@/modules/review-execution/services/threadActionsParser.js';
 import { executeThreadActions, defaultCommandExecutor } from '@/modules/review-execution/services/threadActionsExecutor.js';
 import { executeActionsFromContext } from '@/modules/review-execution/services/contextActionsExecutor.js';
@@ -421,13 +422,11 @@ export async function handleGitLabWebhook(
                   { ...contextActionResult, threadResolveCount, mrNumber: j.mrNumber },
                   'Actions executed from context file for followup'
                 );
-                contextGateway.setResult(j.localPath, mergeRequestId, {
-                  blocking: parsed.blocking,
-                  warnings: parsed.warnings,
-                  suggestions: parsed.suggestions,
-                  score: parsed.score ?? 0,
-                  verdict: parsed.blocking > 0 ? 'needs_fixes' : 'needs_discussion',
-                });
+                contextGateway.setResult(
+                  j.localPath,
+                  mergeRequestId,
+                  ReviewContextResultFactory.fromParsedReview(parsed),
+                );
               } else {
                 // FALLBACK: Execute thread actions from stdout markers (backward compatibility)
                 const threadActions = parseThreadActions(result.stdout);
@@ -779,13 +778,11 @@ export function buildGitLabReviewProcessor(
             { ...contextActionResult, mrNumber: j.mrNumber },
             'Actions executed from context file'
           );
-          contextGateway.setResult(j.localPath, mergeRequestId, {
-            blocking: parsed.blocking,
-            warnings: parsed.warnings,
-            suggestions: parsed.suggestions,
-            score: parsed.score ?? 0,
-            verdict: parsed.blocking > 0 ? 'needs_fixes' : 'needs_discussion',
-          });
+          contextGateway.setResult(
+            j.localPath,
+            mergeRequestId,
+            ReviewContextResultFactory.fromParsedReview(parsed),
+          );
         } else {
           // FALLBACK: Execute thread actions from stdout markers (backward compatibility)
           const threadActions = parseThreadActions(result.stdout);

--- a/src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts
+++ b/src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts
@@ -421,6 +421,13 @@ export async function handleGitLabWebhook(
                   { ...contextActionResult, threadResolveCount, mrNumber: j.mrNumber },
                   'Actions executed from context file for followup'
                 );
+                contextGateway.setResult(j.localPath, mergeRequestId, {
+                  blocking: parsed.blocking,
+                  warnings: parsed.warnings,
+                  suggestions: parsed.suggestions,
+                  score: parsed.score ?? 0,
+                  verdict: parsed.blocking > 0 ? 'needs_fixes' : 'needs_discussion',
+                });
               } else {
                 // FALLBACK: Execute thread actions from stdout markers (backward compatibility)
                 const threadActions = parseThreadActions(result.stdout);
@@ -772,6 +779,13 @@ export function buildGitLabReviewProcessor(
             { ...contextActionResult, mrNumber: j.mrNumber },
             'Actions executed from context file'
           );
+          contextGateway.setResult(j.localPath, mergeRequestId, {
+            blocking: parsed.blocking,
+            warnings: parsed.warnings,
+            suggestions: parsed.suggestions,
+            score: parsed.score ?? 0,
+            verdict: parsed.blocking > 0 ? 'needs_fixes' : 'needs_discussion',
+          });
         } else {
           // FALLBACK: Execute thread actions from stdout markers (backward compatibility)
           const threadActions = parseThreadActions(result.stdout);

--- a/src/modules/review-execution/entities/reviewContext/reviewContext.gateway.ts
+++ b/src/modules/review-execution/entities/reviewContext/reviewContext.gateway.ts
@@ -21,4 +21,5 @@ export interface ReviewContextGateway {
   appendAction(localPath: string, mergeRequestId: string, action: ReviewContextAction): UpdateResult
   updateProgress(localPath: string, mergeRequestId: string, progress: ReviewContextProgress): UpdateResult
   setResult(localPath: string, mergeRequestId: string, result: ReviewContextResult): UpdateResult
+  listAll(localPath: string): ReviewContext[]
 }

--- a/src/modules/review-execution/entities/reviewContext/reviewContextResult.factory.ts
+++ b/src/modules/review-execution/entities/reviewContext/reviewContextResult.factory.ts
@@ -1,0 +1,31 @@
+import type { MeasuredReviewResult } from './reviewContextResult.schema.js'
+
+export interface ParsedReviewStats {
+  score: number | null
+  blocking: number
+  warnings: number
+  suggestions: number
+}
+
+export const ReviewContextResultFactory = {
+  fromParsedReview(parsed: ParsedReviewStats): MeasuredReviewResult {
+    return {
+      kind: 'measured',
+      blocking: parsed.blocking,
+      warnings: parsed.warnings,
+      suggestions: parsed.suggestions,
+      score: parsed.score ?? 0,
+      verdict: deriveVerdict(parsed),
+    }
+  },
+}
+
+function deriveVerdict(parsed: ParsedReviewStats): MeasuredReviewResult['verdict'] {
+  if (parsed.blocking > 0) {
+    return 'needs_fixes'
+  }
+  if (parsed.score !== null && parsed.score >= 8 && parsed.warnings === 0) {
+    return 'ready_to_merge'
+  }
+  return 'needs_discussion'
+}

--- a/src/modules/review-execution/entities/reviewContext/reviewContextResult.schema.ts
+++ b/src/modules/review-execution/entities/reviewContext/reviewContextResult.schema.ts
@@ -1,12 +1,25 @@
 import { z } from 'zod'
 
-export const reviewContextResultSchema = z.object({
+export const measuredReviewResultSchema = z.object({
+  kind: z.literal('measured'),
   blocking: z.number(),
   warnings: z.number(),
   suggestions: z.number(),
   score: z.number(),
   verdict: z.enum(['ready_to_merge', 'needs_fixes', 'needs_discussion']),
-  backfilledAt: z.string().optional(),
 })
 
+export const backfilledReviewResultSchema = z.object({
+  kind: z.literal('backfilled'),
+  backfilledAt: z.string(),
+  reason: z.enum(['stale-on-boot', 'recovered-after-restart']),
+})
+
+export const reviewContextResultSchema = z.discriminatedUnion('kind', [
+  measuredReviewResultSchema,
+  backfilledReviewResultSchema,
+])
+
+export type MeasuredReviewResult = z.infer<typeof measuredReviewResultSchema>
+export type BackfilledReviewResult = z.infer<typeof backfilledReviewResultSchema>
 export type ReviewContextResult = z.infer<typeof reviewContextResultSchema>

--- a/src/modules/review-execution/entities/reviewContext/reviewContextResult.schema.ts
+++ b/src/modules/review-execution/entities/reviewContext/reviewContextResult.schema.ts
@@ -6,6 +6,7 @@ export const reviewContextResultSchema = z.object({
   suggestions: z.number(),
   score: z.number(),
   verdict: z.enum(['ready_to_merge', 'needs_fixes', 'needs_discussion']),
+  backfilledAt: z.string().optional(),
 })
 
 export type ReviewContextResult = z.infer<typeof reviewContextResultSchema>

--- a/src/modules/review-execution/interface-adapters/gateways/reviewContext.fileSystem.gateway.ts
+++ b/src/modules/review-execution/interface-adapters/gateways/reviewContext.fileSystem.gateway.ts
@@ -125,7 +125,11 @@ export class ReviewContextFileSystemGateway implements ReviewContextGateway {
     return collectJsonFiles(logsDir).flatMap((path) => {
       try {
         return [JSON.parse(readFileSync(path, 'utf-8')) as ReviewContext]
-      } catch {
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        process.stderr.write(
+          `[reviewContextGateway] malformed JSON skipped at ${path}: ${message}\n`,
+        )
         return []
       }
     })

--- a/src/modules/review-execution/interface-adapters/gateways/reviewContext.fileSystem.gateway.ts
+++ b/src/modules/review-execution/interface-adapters/gateways/reviewContext.fileSystem.gateway.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, readFileSync, existsSync, mkdirSync, unlinkSync } from 'node:fs'
+import { writeFileSync, readFileSync, existsSync, mkdirSync, unlinkSync, readdirSync, statSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 import type { ReviewContextGateway, UpdateResult } from '@/modules/review-execution/entities/reviewContext/reviewContext.gateway.js'
 import type {
@@ -116,4 +116,29 @@ export class ReviewContextFileSystemGateway implements ReviewContextGateway {
 
     return { success: true }
   }
+
+  listAll(localPath: string): ReviewContext[] {
+    const logsDir = join(localPath, '.claude', 'reviews', 'logs')
+    if (!existsSync(logsDir)) {
+      return []
+    }
+    return collectJsonFiles(logsDir).flatMap((path) => {
+      try {
+        return [JSON.parse(readFileSync(path, 'utf-8')) as ReviewContext]
+      } catch {
+        return []
+      }
+    })
+  }
+}
+
+function collectJsonFiles(directory: string): string[] {
+  const entries = readdirSync(directory)
+  return entries.flatMap((entry) => {
+    const fullPath = join(directory, entry)
+    if (statSync(fullPath).isDirectory()) {
+      return collectJsonFiles(fullPath)
+    }
+    return entry.endsWith('.json') ? [fullPath] : []
+  })
 }

--- a/src/modules/review-execution/services/reviewRecovery.service.ts
+++ b/src/modules/review-execution/services/reviewRecovery.service.ts
@@ -20,15 +20,21 @@ export interface RecoveryRepository {
 export interface RecoverySummary {
   scanned: number
   recovered: number
+  partial: number
   backfilled: number
   skipped: number
+  failed: number
+}
+
+export interface ExecuteActionsOutcome {
+  posted: number
   failed: number
 }
 
 export interface RecoveryDeps {
   repositories: RecoveryRepository[]
   reviewContextGateway: ReviewContextGateway
-  executeActions: (context: ReviewContext, localPath: string) => Promise<{ success: boolean }>
+  executeActions: (context: ReviewContext, localPath: string) => Promise<ExecuteActionsOutcome>
   now: () => number
   logger: RecoveryLogger
   graceWindowMs?: number
@@ -39,6 +45,7 @@ export async function runReviewRecovery(deps: RecoveryDeps): Promise<RecoverySum
   const summary: RecoverySummary = {
     scanned: 0,
     recovered: 0,
+    partial: 0,
     backfilled: 0,
     skipped: 0,
     failed: 0,
@@ -53,7 +60,8 @@ export async function runReviewRecovery(deps: RecoveryDeps): Promise<RecoverySum
         continue
       }
 
-      const ageMs = deps.now() - new Date(context.createdAt).getTime()
+      const lastActivityMs = lastActivityTime(context)
+      const ageMs = deps.now() - lastActivityMs
       const isStale = ageMs > graceWindowMs
 
       if (isStale) {
@@ -73,15 +81,19 @@ export async function runReviewRecovery(deps: RecoveryDeps): Promise<RecoverySum
       }
 
       try {
-        const result = await deps.executeActions(context, repository.localPath)
-        if (!result.success) {
+        const outcome = await deps.executeActions(context, repository.localPath)
+        if (outcome.posted === 0) {
+          // Nothing reached the platform — safe to retry on the next boot, so do
+          // not finalize the context.
           summary.failed += 1
           deps.logger.warn(
-            { mergeRequestId: context.mergeRequestId },
-            'Recovery execution returned non-success',
+            { mergeRequestId: context.mergeRequestId, outcome },
+            'Recovery posted zero actions, leaving context for retry',
           )
           continue
         }
+        // At least one action was posted. Finalize the context regardless of
+        // partial failures — re-running would double-post the successes.
         markBackfilled(
           deps.reviewContextGateway,
           repository.localPath,
@@ -89,11 +101,19 @@ export async function runReviewRecovery(deps: RecoveryDeps): Promise<RecoverySum
           'recovered-after-restart',
           deps.now,
         )
-        deps.logger.info(
-          { mergeRequestId: context.mergeRequestId, actionCount: context.actions.length },
-          'Review context recovered after restart',
-        )
-        summary.recovered += 1
+        if (outcome.failed > 0) {
+          summary.partial += 1
+          deps.logger.warn(
+            { mergeRequestId: context.mergeRequestId, outcome },
+            'Recovery completed with partial failures — context finalized to avoid double-post',
+          )
+        } else {
+          summary.recovered += 1
+          deps.logger.info(
+            { mergeRequestId: context.mergeRequestId, posted: outcome.posted },
+            'Review context recovered after restart',
+          )
+        }
       } catch (error) {
         summary.failed += 1
         deps.logger.error(
@@ -101,13 +121,24 @@ export async function runReviewRecovery(deps: RecoveryDeps): Promise<RecoverySum
             mergeRequestId: context.mergeRequestId,
             error: error instanceof Error ? error.message : String(error),
           },
-          'Recovery execution failed',
+          'Recovery execution threw',
         )
       }
     }
   }
 
   return summary
+}
+
+function lastActivityTime(context: ReviewContext): number {
+  const updatedAt = context.progress.updatedAt
+  if (updatedAt) {
+    const parsed = new Date(updatedAt).getTime()
+    if (!Number.isNaN(parsed)) {
+      return parsed
+    }
+  }
+  return new Date(context.createdAt).getTime()
 }
 
 function markBackfilled(

--- a/src/modules/review-execution/services/reviewRecovery.service.ts
+++ b/src/modules/review-execution/services/reviewRecovery.service.ts
@@ -57,7 +57,13 @@ export async function runReviewRecovery(deps: RecoveryDeps): Promise<RecoverySum
       const isStale = ageMs > graceWindowMs
 
       if (isStale) {
-        finalize(deps.reviewContextGateway, repository.localPath, context, deps.now)
+        markBackfilled(
+          deps.reviewContextGateway,
+          repository.localPath,
+          context,
+          'stale-on-boot',
+          deps.now,
+        )
         deps.logger.info(
           { mergeRequestId: context.mergeRequestId, ageMs },
           'Review context backfilled (older than grace window, not replayed)',
@@ -76,7 +82,13 @@ export async function runReviewRecovery(deps: RecoveryDeps): Promise<RecoverySum
           )
           continue
         }
-        finalize(deps.reviewContextGateway, repository.localPath, context, deps.now)
+        markBackfilled(
+          deps.reviewContextGateway,
+          repository.localPath,
+          context,
+          'recovered-after-restart',
+          deps.now,
+        )
         deps.logger.info(
           { mergeRequestId: context.mergeRequestId, actionCount: context.actions.length },
           'Review context recovered after restart',
@@ -98,18 +110,16 @@ export async function runReviewRecovery(deps: RecoveryDeps): Promise<RecoverySum
   return summary
 }
 
-function finalize(
+function markBackfilled(
   gateway: ReviewContextGateway,
   localPath: string,
   context: ReviewContext,
+  reason: 'stale-on-boot' | 'recovered-after-restart',
   now: () => number,
 ): void {
   gateway.setResult(localPath, context.mergeRequestId, {
-    blocking: 0,
-    warnings: 0,
-    suggestions: 0,
-    score: 0,
-    verdict: 'needs_discussion',
+    kind: 'backfilled',
     backfilledAt: new Date(now()).toISOString(),
+    reason,
   })
 }

--- a/src/modules/review-execution/services/reviewRecovery.service.ts
+++ b/src/modules/review-execution/services/reviewRecovery.service.ts
@@ -1,0 +1,115 @@
+import type { ReviewContext } from '@/modules/review-execution/entities/reviewContext/reviewContext.js'
+import type { ReviewContextGateway } from '@/modules/review-execution/entities/reviewContext/reviewContext.gateway.js'
+
+const DEFAULT_GRACE_WINDOW_MS = 30 * 60 * 1000
+
+export function shouldRecover(context: ReviewContext): boolean {
+  return context.progress.phase === 'completed' && context.actions.length > 0 && !context.result
+}
+
+export interface RecoveryLogger {
+  info: (obj: object, msg: string) => void
+  warn: (obj: object, msg: string) => void
+  error: (obj: object, msg: string) => void
+}
+
+export interface RecoveryRepository {
+  localPath: string
+}
+
+export interface RecoverySummary {
+  scanned: number
+  recovered: number
+  backfilled: number
+  skipped: number
+  failed: number
+}
+
+export interface RecoveryDeps {
+  repositories: RecoveryRepository[]
+  reviewContextGateway: ReviewContextGateway
+  executeActions: (context: ReviewContext, localPath: string) => Promise<{ success: boolean }>
+  now: () => number
+  logger: RecoveryLogger
+  graceWindowMs?: number
+}
+
+export async function runReviewRecovery(deps: RecoveryDeps): Promise<RecoverySummary> {
+  const graceWindowMs = deps.graceWindowMs ?? DEFAULT_GRACE_WINDOW_MS
+  const summary: RecoverySummary = {
+    scanned: 0,
+    recovered: 0,
+    backfilled: 0,
+    skipped: 0,
+    failed: 0,
+  }
+
+  for (const repository of deps.repositories) {
+    for (const context of deps.reviewContextGateway.listAll(repository.localPath)) {
+      summary.scanned += 1
+
+      if (!shouldRecover(context)) {
+        summary.skipped += 1
+        continue
+      }
+
+      const ageMs = deps.now() - new Date(context.createdAt).getTime()
+      const isStale = ageMs > graceWindowMs
+
+      if (isStale) {
+        finalize(deps.reviewContextGateway, repository.localPath, context, deps.now)
+        deps.logger.info(
+          { mergeRequestId: context.mergeRequestId, ageMs },
+          'Review context backfilled (older than grace window, not replayed)',
+        )
+        summary.backfilled += 1
+        continue
+      }
+
+      try {
+        const result = await deps.executeActions(context, repository.localPath)
+        if (!result.success) {
+          summary.failed += 1
+          deps.logger.warn(
+            { mergeRequestId: context.mergeRequestId },
+            'Recovery execution returned non-success',
+          )
+          continue
+        }
+        finalize(deps.reviewContextGateway, repository.localPath, context, deps.now)
+        deps.logger.info(
+          { mergeRequestId: context.mergeRequestId, actionCount: context.actions.length },
+          'Review context recovered after restart',
+        )
+        summary.recovered += 1
+      } catch (error) {
+        summary.failed += 1
+        deps.logger.error(
+          {
+            mergeRequestId: context.mergeRequestId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          'Recovery execution failed',
+        )
+      }
+    }
+  }
+
+  return summary
+}
+
+function finalize(
+  gateway: ReviewContextGateway,
+  localPath: string,
+  context: ReviewContext,
+  now: () => number,
+): void {
+  gateway.setResult(localPath, context.mergeRequestId, {
+    blocking: 0,
+    warnings: 0,
+    suggestions: 0,
+    score: 0,
+    verdict: 'needs_discussion',
+    backfilledAt: new Date(now()).toISOString(),
+  })
+}

--- a/src/tests/stubs/reviewContextGateway.stub.ts
+++ b/src/tests/stubs/reviewContextGateway.stub.ts
@@ -84,6 +84,10 @@ export class StubReviewContextGateway implements ReviewContextGateway {
     return { success: true }
   }
 
+  listAll(_localPath: string): ReviewContext[] {
+    return Array.from(this.contexts.values())
+  }
+
   clear(): void {
     this.contexts.clear()
   }

--- a/src/tests/units/entities/reviewContext/reviewContext.schema.test.ts
+++ b/src/tests/units/entities/reviewContext/reviewContext.schema.test.ts
@@ -146,6 +146,7 @@ describe('reviewContextSchema', () => {
     const context = {
       ...validContext,
       result: {
+        kind: 'measured',
         blocking: 0,
         warnings: 1,
         suggestions: 2,

--- a/src/tests/units/entities/reviewContext/reviewContextResult.factory.test.ts
+++ b/src/tests/units/entities/reviewContext/reviewContextResult.factory.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { ReviewContextResultFactory } from '@/modules/review-execution/entities/reviewContext/reviewContextResult.factory.js'
+
+describe('ReviewContextResultFactory.fromParsedReview', () => {
+  it("returns verdict 'needs_fixes' whenever blocking > 0, regardless of score", () => {
+    const result = ReviewContextResultFactory.fromParsedReview({
+      score: 10,
+      blocking: 1,
+      warnings: 0,
+      suggestions: 0,
+    })
+
+    expect(result.kind).toBe('measured')
+    expect(result.verdict).toBe('needs_fixes')
+  })
+
+  it("returns verdict 'ready_to_merge' on a clean score >= 8 with no warnings", () => {
+    const result = ReviewContextResultFactory.fromParsedReview({
+      score: 9,
+      blocking: 0,
+      warnings: 0,
+      suggestions: 2,
+    })
+
+    expect(result.verdict).toBe('ready_to_merge')
+  })
+
+  it("falls back to 'needs_discussion' when score is null", () => {
+    const result = ReviewContextResultFactory.fromParsedReview({
+      score: null,
+      blocking: 0,
+      warnings: 0,
+      suggestions: 0,
+    })
+
+    expect(result.score).toBe(0)
+    expect(result.verdict).toBe('needs_discussion')
+  })
+
+  it("returns 'needs_discussion' when warnings present but no blocking", () => {
+    const result = ReviewContextResultFactory.fromParsedReview({
+      score: 9,
+      blocking: 0,
+      warnings: 1,
+      suggestions: 0,
+    })
+
+    expect(result.verdict).toBe('needs_discussion')
+  })
+})

--- a/src/tests/units/entities/reviewContext/reviewContextResult.guard.test.ts
+++ b/src/tests/units/entities/reviewContext/reviewContextResult.guard.test.ts
@@ -6,8 +6,9 @@ import {
 
 describe('reviewContextResult.guard', () => {
   describe('parseReviewContextResult', () => {
-    it('should parse a valid result', () => {
+    it('should parse a valid measured result', () => {
       const data = {
+        kind: 'measured',
         blocking: 0,
         warnings: 1,
         suggestions: 2,
@@ -17,14 +18,16 @@ describe('reviewContextResult.guard', () => {
 
       const result = parseReviewContextResult(data)
 
+      if (result.kind !== 'measured') throw new Error('expected measured')
       expect(result.verdict).toBe('ready_to_merge')
       expect(result.score).toBe(9)
     })
   })
 
   describe('isValidReviewContextResult', () => {
-    it('should return true for valid result', () => {
+    it('should return true for valid measured result', () => {
       const data = {
+        kind: 'measured',
         blocking: 1,
         warnings: 0,
         suggestions: 0,
@@ -36,7 +39,7 @@ describe('reviewContextResult.guard', () => {
     })
 
     it('should return false for invalid result', () => {
-      expect(isValidReviewContextResult({ verdict: 'bad' })).toBe(false)
+      expect(isValidReviewContextResult({ kind: 'measured', verdict: 'bad' })).toBe(false)
     })
   })
 })

--- a/src/tests/units/entities/reviewContext/reviewContextResult.schema.test.ts
+++ b/src/tests/units/entities/reviewContext/reviewContextResult.schema.test.ts
@@ -2,8 +2,9 @@ import { describe, it, expect } from 'vitest'
 import { reviewContextResultSchema } from '@/modules/review-execution/entities/reviewContext/reviewContextResult.schema.js'
 
 describe('reviewContextResultSchema', () => {
-  it('should validate a complete result', () => {
+  it('should validate a complete measured result', () => {
     const data = {
+      kind: 'measured',
       blocking: 0,
       warnings: 2,
       suggestions: 3,
@@ -16,8 +17,21 @@ describe('reviewContextResultSchema', () => {
     expect(result.success).toBe(true)
   })
 
+  it('should validate a backfilled result', () => {
+    const data = {
+      kind: 'backfilled',
+      backfilledAt: '2026-05-26T00:01:00Z',
+      reason: 'stale-on-boot',
+    }
+
+    const result = reviewContextResultSchema.safeParse(data)
+
+    expect(result.success).toBe(true)
+  })
+
   it('should reject result with invalid verdict', () => {
     const data = {
+      kind: 'measured',
       blocking: 0,
       warnings: 0,
       suggestions: 0,

--- a/src/tests/units/interface-adapters/controllers/webhook/github.controller.test.ts
+++ b/src/tests/units/interface-adapters/controllers/webhook/github.controller.test.ts
@@ -52,6 +52,19 @@ vi.mock('../../../../../main/websocket.js', () => ({
   stopWatchingReviewContext: vi.fn(),
 }));
 
+vi.mock('@/modules/review-execution/services/contextActionsExecutor.js', () => ({
+  executeActionsFromContext: vi.fn(() => Promise.resolve({ total: 1, succeeded: 1, failed: 0, skipped: 0 })),
+}));
+
+vi.mock('@/modules/review-execution/services/threadActionsExecutor.js', () => ({
+  executeThreadActions: vi.fn(() => Promise.resolve({ total: 0, succeeded: 0, failed: 0, skipped: 0 })),
+  defaultCommandExecutor: vi.fn(),
+}));
+
+vi.mock('@/modules/review-execution/services/threadActionsParser.js', () => ({
+  parseThreadActions: vi.fn(() => []),
+}));
+
 vi.mock('../../../../../config/projectConfig.js', () => ({
   loadProjectConfig: vi.fn(() => null),
   getProjectAgents: vi.fn(() => null),
@@ -278,6 +291,60 @@ describe('handleGitHubWebhook', () => {
           }),
         })
       );
+    });
+
+    it('finalises the review-context with setResult after actions are posted', async () => {
+      const setResultMock = vi.fn(
+        (_localPath: string, _mergeRequestId: string, _result: unknown) => ({ success: true }),
+      );
+      const readMock = vi.fn(() => ({
+        version: '1.0',
+        mergeRequestId: 'github-test-owner/test-repo-123',
+        platform: 'github',
+        projectPath: 'test-owner/test-repo',
+        mergeRequestNumber: 123,
+        createdAt: '2026-05-26T00:00:00Z',
+        threads: [],
+        actions: [{ type: 'POST_COMMENT', body: 'review report' }],
+        progress: { phase: 'completed', currentStep: null },
+      }));
+      const depsWithReadAndSet = {
+        ...mockDeps,
+        reviewContextGateway: {
+          ...mockDeps.reviewContextGateway,
+          read: readMock,
+          setResult: setResultMock,
+        },
+      } as unknown as GitHubWebhookDependencies;
+
+      vi.mocked(enqueueReview).mockImplementation(async (job, callback) => {
+        await callback(job, new AbortController().signal);
+        return true;
+      });
+      vi.mocked(invokeClaudeReview).mockResolvedValue({
+        success: true,
+        cancelled: false,
+        stdout: '[REVIEW_STATS:blocking=3:warnings=1:suggestions=0:score=5]',
+        durationMs: 100,
+        exitCode: 0,
+        stderr: '',
+      });
+
+      const event = GitHubEventFactory.createReviewRequestedPr('claude-bot');
+      const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, depsWithReadAndSet);
+
+      expect(setResultMock).toHaveBeenCalledTimes(1);
+      const [, , passedResult] = setResultMock.mock.calls[0];
+      expect(passedResult).toEqual({
+        kind: 'measured',
+        blocking: 3,
+        warnings: 1,
+        suggestions: 0,
+        score: 5,
+        verdict: 'needs_fixes',
+      });
     });
 
     it('should not record stats when review is cancelled', async () => {

--- a/src/tests/units/interface-adapters/controllers/webhook/gitlab.controller.test.ts
+++ b/src/tests/units/interface-adapters/controllers/webhook/gitlab.controller.test.ts
@@ -127,6 +127,7 @@ function createStubContextGateway() {
     appendAction: vi.fn(() => ({ success: true })),
     updateProgress: vi.fn(() => ({ success: true })),
     setResult: vi.fn(() => ({ success: true })),
+    listAll: vi.fn(() => []),
   };
 }
 

--- a/src/tests/units/interface-adapters/gateways/reviewContext.fileSystem.gateway.test.ts
+++ b/src/tests/units/interface-adapters/gateways/reviewContext.fileSystem.gateway.test.ts
@@ -273,6 +273,7 @@ describe('ReviewContextFileSystemGateway', () => {
       })
 
       const result = gateway.setResult(testDir, 'github-owner/repo-42', {
+        kind: 'measured',
         blocking: 0,
         warnings: 2,
         suggestions: 3,
@@ -283,8 +284,11 @@ describe('ReviewContextFileSystemGateway', () => {
       expect(result.success).toBe(true)
 
       const context = gateway.read(testDir, 'github-owner/repo-42')
-      expect(context?.result?.blocking).toBe(0)
-      expect(context?.result?.verdict).toBe('ready_to_merge')
+      expect(context?.result?.kind).toBe('measured')
+      if (context?.result?.kind === 'measured') {
+        expect(context.result.blocking).toBe(0)
+        expect(context.result.verdict).toBe('ready_to_merge')
+      }
     })
   })
 })

--- a/src/tests/units/interface-adapters/gateways/reviewContext.fileSystem.gateway.test.ts
+++ b/src/tests/units/interface-adapters/gateways/reviewContext.fileSystem.gateway.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdirSync, rmSync, existsSync, readFileSync } from 'node:fs'
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { ReviewContextFileSystemGateway } from '@/modules/review-execution/interface-adapters/gateways/reviewContext.fileSystem.gateway.js'
 
 describe('ReviewContextFileSystemGateway', () => {
@@ -208,6 +209,56 @@ describe('ReviewContextFileSystemGateway', () => {
       })
 
       expect(result.success).toBe(false)
+    })
+  })
+
+  describe('listAll', () => {
+    it('returns an empty array when no logs directory exists', () => {
+      expect(gateway.listAll(testDir)).toEqual([])
+    })
+
+    it('returns every context, even when mergeRequestId contains a slash (subdir)', () => {
+      gateway.create({
+        localPath: testDir,
+        mergeRequestId: 'github-owner/repo-1',
+        platform: 'github',
+        projectPath: 'owner/repo',
+        mergeRequestNumber: 1,
+      })
+      gateway.create({
+        localPath: testDir,
+        mergeRequestId: 'github-owner/repo-2',
+        platform: 'github',
+        projectPath: 'owner/repo',
+        mergeRequestNumber: 2,
+      })
+      gateway.create({
+        localPath: testDir,
+        mergeRequestId: 'gitlab-flat-id-3',
+        platform: 'gitlab',
+        projectPath: 'group/proj',
+        mergeRequestNumber: 3,
+      })
+
+      const all = gateway.listAll(testDir)
+      const ids = all.map((c) => c.mergeRequestId).sort()
+      expect(ids).toEqual(['github-owner/repo-1', 'github-owner/repo-2', 'gitlab-flat-id-3'])
+    })
+
+    it('skips malformed JSON files instead of throwing', () => {
+      const logsDir = join(testDir, '.claude', 'reviews', 'logs')
+      mkdirSync(logsDir, { recursive: true })
+      writeFileSync(join(logsDir, 'broken.json'), '{ not valid json')
+      gateway.create({
+        localPath: testDir,
+        mergeRequestId: 'github-owner/repo-1',
+        platform: 'github',
+        projectPath: 'owner/repo',
+        mergeRequestNumber: 1,
+      })
+
+      const all = gateway.listAll(testDir)
+      expect(all.map((c) => c.mergeRequestId)).toEqual(['github-owner/repo-1'])
     })
   })
 

--- a/src/tests/units/interface-adapters/gateways/reviewContext.fileSystem.gateway.test.ts
+++ b/src/tests/units/interface-adapters/gateways/reviewContext.fileSystem.gateway.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { ReviewContextFileSystemGateway } from '@/modules/review-execution/interface-adapters/gateways/reviewContext.fileSystem.gateway.js'
@@ -245,7 +245,7 @@ describe('ReviewContextFileSystemGateway', () => {
       expect(ids).toEqual(['github-owner/repo-1', 'github-owner/repo-2', 'gitlab-flat-id-3'])
     })
 
-    it('skips malformed JSON files instead of throwing', () => {
+    it('skips malformed JSON files and writes a warning to stderr', () => {
       const logsDir = join(testDir, '.claude', 'reviews', 'logs')
       mkdirSync(logsDir, { recursive: true })
       writeFileSync(join(logsDir, 'broken.json'), '{ not valid json')
@@ -257,8 +257,18 @@ describe('ReviewContextFileSystemGateway', () => {
         mergeRequestNumber: 1,
       })
 
-      const all = gateway.listAll(testDir)
-      expect(all.map((c) => c.mergeRequestId)).toEqual(['github-owner/repo-1'])
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+      try {
+        const all = gateway.listAll(testDir)
+        expect(all.map((c) => c.mergeRequestId)).toEqual(['github-owner/repo-1'])
+        expect(stderrSpy).toHaveBeenCalledOnce()
+        const message = stderrSpy.mock.calls[0]?.[0] as string
+        expect(message).toContain('malformed JSON skipped')
+        expect(message).toContain('broken.json')
+      } finally {
+        stderrSpy.mockRestore()
+      }
     })
   })
 

--- a/src/tests/units/modules/claude-invocation/interface-adapters/gateways/reviewReport.fileSystem.gateway.test.ts
+++ b/src/tests/units/modules/claude-invocation/interface-adapters/gateways/reviewReport.fileSystem.gateway.test.ts
@@ -6,6 +6,7 @@ describe('ReviewReportFileSystemGateway.buildPath', () => {
     const gateway = new ReviewReportFileSystemGateway({
       existsSync: () => false,
       readFileSync: () => '',
+      readdirSync: () => [],
     });
 
     const path = gateway.buildPath({
@@ -22,6 +23,7 @@ describe('ReviewReportFileSystemGateway.buildPath', () => {
     const gateway = new ReviewReportFileSystemGateway({
       existsSync: () => false,
       readFileSync: () => '',
+      readdirSync: () => [],
     });
 
     const path = gateway.buildPath({
@@ -40,6 +42,7 @@ describe('ReviewReportFileSystemGateway.read', () => {
     const gateway = new ReviewReportFileSystemGateway({
       existsSync: () => false,
       readFileSync: () => '',
+      readdirSync: () => [],
     });
 
     const result = gateway.read({
@@ -57,6 +60,7 @@ describe('ReviewReportFileSystemGateway.read', () => {
     const gateway = new ReviewReportFileSystemGateway({
       existsSync: () => true,
       readFileSync: readSpy,
+      readdirSync: () => [],
     });
 
     const result = gateway.read({
@@ -71,5 +75,66 @@ describe('ReviewReportFileSystemGateway.read', () => {
       path: '/tmp/project/.claude/reviews/2026-05-22-MR-42-review.md',
     });
     expect(readSpy).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to a pattern scan when the date prefix differs (timezone drift)', () => {
+    const readSpy = vi.fn(() => '# Recovered');
+    const gateway = new ReviewReportFileSystemGateway({
+      // exact path miss, but the reviews directory exists.
+      existsSync: (path: string) => path.endsWith('/.claude/reviews'),
+      readFileSync: readSpy,
+      readdirSync: () => ['2026-05-26-MR-206-review.md'],
+    });
+
+    const result = gateway.read({
+      localPath: '/tmp/project',
+      isoDate: '2026-05-25', // wrong (UTC), file is named with local date
+      mergeRequestNumber: 206,
+      jobType: 'review',
+    });
+
+    expect(result).toEqual({
+      content: '# Recovered',
+      path: '/tmp/project/.claude/reviews/2026-05-26-MR-206-review.md',
+    });
+  });
+
+  it('ignores files for a different MR number during the scan', () => {
+    const gateway = new ReviewReportFileSystemGateway({
+      existsSync: (path: string) => path.endsWith('/.claude/reviews'),
+      readFileSync: () => 'unused',
+      readdirSync: () => [
+        '2026-05-26-MR-205-review.md',
+        '2026-05-26-MR-207-followup.md',
+      ],
+    });
+
+    const result = gateway.read({
+      localPath: '/tmp/project',
+      isoDate: '2026-05-25',
+      mergeRequestNumber: 206,
+      jobType: 'review',
+    });
+
+    expect(result).toBe(null);
+  });
+
+  it('returns null when neither exact path nor reviews directory exists', () => {
+    const gateway = new ReviewReportFileSystemGateway({
+      existsSync: () => false,
+      readFileSync: () => 'unused',
+      readdirSync: () => {
+        throw new Error('readdirSync should not be called when the dir is absent');
+      },
+    });
+
+    const result = gateway.read({
+      localPath: '/tmp/project',
+      isoDate: '2026-05-25',
+      mergeRequestNumber: 206,
+      jobType: 'review',
+    });
+
+    expect(result).toBe(null);
   });
 });

--- a/src/tests/units/services/reviewRecovery.service.test.ts
+++ b/src/tests/units/services/reviewRecovery.service.test.ts
@@ -17,6 +17,7 @@ describe('shouldRecover', () => {
       progress: { phase: 'completed', currentStep: null },
       actions: [{ type: 'POST_COMMENT', body: 'global review' }],
       result: {
+        kind: 'measured',
         blocking: 0,
         warnings: 2,
         suggestions: 3,

--- a/src/tests/units/services/reviewRecovery.service.test.ts
+++ b/src/tests/units/services/reviewRecovery.service.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { shouldRecover } from '@/modules/review-execution/services/reviewRecovery.service.js'
+import { ReviewContextFactory } from '@/tests/factories/reviewContext.factory.js'
+
+describe('shouldRecover', () => {
+  it('returns true when Claude completed but post-actions never ran', () => {
+    const context = ReviewContextFactory.create({
+      progress: { phase: 'completed', currentStep: null },
+      actions: [{ type: 'POST_COMMENT', body: 'global review' }],
+    })
+
+    expect(shouldRecover(context)).toBe(true)
+  })
+
+  it('returns false when result is already set (already finalized)', () => {
+    const context = ReviewContextFactory.create({
+      progress: { phase: 'completed', currentStep: null },
+      actions: [{ type: 'POST_COMMENT', body: 'global review' }],
+      result: {
+        blocking: 0,
+        warnings: 2,
+        suggestions: 3,
+        score: 8,
+        verdict: 'needs_discussion',
+      },
+    })
+
+    expect(shouldRecover(context)).toBe(false)
+  })
+
+  it('returns false when completed but no actions queued', () => {
+    const context = ReviewContextFactory.create({
+      progress: { phase: 'completed', currentStep: null },
+      actions: [],
+    })
+
+    expect(shouldRecover(context)).toBe(false)
+  })
+
+  it('returns false while Claude is still running (phase=agents-running)', () => {
+    const context = ReviewContextFactory.create({
+      progress: { phase: 'agents-running', currentStep: 'solid' },
+      actions: [{ type: 'POST_INLINE_COMMENT', filePath: 'a.ts', line: 1, body: 'x' }],
+    })
+
+    expect(shouldRecover(context)).toBe(false)
+  })
+
+  it('returns false for a freshly created pending context', () => {
+    const context = ReviewContextFactory.create({
+      progress: { phase: 'pending', currentStep: null },
+      actions: [],
+    })
+
+    expect(shouldRecover(context)).toBe(false)
+  })
+})

--- a/src/tests/units/services/runReviewRecovery.service.test.ts
+++ b/src/tests/units/services/runReviewRecovery.service.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from 'vitest'
+import { runReviewRecovery } from '@/modules/review-execution/services/reviewRecovery.service.js'
+import { StubReviewContextGateway } from '@/tests/stubs/reviewContextGateway.stub.js'
+import { ReviewContextFactory } from '@/tests/factories/reviewContext.factory.js'
+
+const NOW = new Date('2026-05-25T21:00:00Z').getTime()
+const ONE_HOUR_AGO = new Date('2026-05-25T20:00:00Z').toISOString()
+const ONE_MINUTE_AGO = new Date('2026-05-25T20:59:00Z').toISOString()
+
+function silentLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}
+
+describe('runReviewRecovery', () => {
+  it('returns zero counters when there are no contexts on disk', async () => {
+    const gateway = new StubReviewContextGateway()
+
+    const summary = await runReviewRecovery({
+      repositories: [{ localPath: '/repo' }],
+      reviewContextGateway: gateway,
+      executeActions: vi.fn(),
+      now: () => NOW,
+      logger: silentLogger(),
+    })
+
+    expect(summary).toEqual({ scanned: 0, recovered: 0, backfilled: 0, skipped: 0, failed: 0 })
+  })
+
+  it('skips contexts that do not match the predicate (no actions queued)', async () => {
+    const gateway = new StubReviewContextGateway()
+    gateway.setContext(
+      'github-owner/repo-1',
+      ReviewContextFactory.create({
+        mergeRequestId: 'github-owner/repo-1',
+        createdAt: ONE_MINUTE_AGO,
+        progress: { phase: 'completed', currentStep: null },
+        actions: [],
+      }),
+    )
+    const executeActions = vi.fn()
+
+    const summary = await runReviewRecovery({
+      repositories: [{ localPath: '/repo' }],
+      reviewContextGateway: gateway,
+      executeActions,
+      now: () => NOW,
+      logger: silentLogger(),
+    })
+
+    expect(summary.skipped).toBe(1)
+    expect(summary.recovered).toBe(0)
+    expect(executeActions).not.toHaveBeenCalled()
+  })
+
+  it('backfills (no post) stale contexts older than the grace window', async () => {
+    const gateway = new StubReviewContextGateway()
+    gateway.setContext(
+      'github-owner/repo-1',
+      ReviewContextFactory.create({
+        mergeRequestId: 'github-owner/repo-1',
+        createdAt: ONE_HOUR_AGO,
+        progress: { phase: 'completed', currentStep: null },
+        actions: [{ type: 'POST_COMMENT', body: 'historical' }],
+      }),
+    )
+    const executeActions = vi.fn()
+
+    const summary = await runReviewRecovery({
+      repositories: [{ localPath: '/repo' }],
+      reviewContextGateway: gateway,
+      executeActions,
+      now: () => NOW,
+      logger: silentLogger(),
+      graceWindowMs: 30 * 60 * 1000,
+    })
+
+    expect(summary.backfilled).toBe(1)
+    expect(summary.recovered).toBe(0)
+    expect(executeActions).not.toHaveBeenCalled()
+    expect(gateway.read('/repo', 'github-owner/repo-1')?.result?.backfilledAt).toBeDefined()
+  })
+
+  it('recovers contexts inside the grace window by calling executeActions then setResult', async () => {
+    const gateway = new StubReviewContextGateway()
+    gateway.setContext(
+      'github-owner/repo-2',
+      ReviewContextFactory.create({
+        mergeRequestId: 'github-owner/repo-2',
+        createdAt: ONE_MINUTE_AGO,
+        progress: { phase: 'completed', currentStep: null },
+        actions: [{ type: 'POST_COMMENT', body: 'fresh' }],
+      }),
+    )
+    const executeActions = vi.fn().mockResolvedValue({ success: true })
+
+    const summary = await runReviewRecovery({
+      repositories: [{ localPath: '/repo' }],
+      reviewContextGateway: gateway,
+      executeActions,
+      now: () => NOW,
+      logger: silentLogger(),
+      graceWindowMs: 30 * 60 * 1000,
+    })
+
+    expect(summary.recovered).toBe(1)
+    expect(summary.backfilled).toBe(0)
+    expect(executeActions).toHaveBeenCalledTimes(1)
+    expect(gateway.read('/repo', 'github-owner/repo-2')?.result?.backfilledAt).toBeDefined()
+  })
+
+  it('counts a failure when executeActions throws and leaves result unset', async () => {
+    const gateway = new StubReviewContextGateway()
+    gateway.setContext(
+      'github-owner/repo-3',
+      ReviewContextFactory.create({
+        mergeRequestId: 'github-owner/repo-3',
+        createdAt: ONE_MINUTE_AGO,
+        progress: { phase: 'completed', currentStep: null },
+        actions: [{ type: 'POST_COMMENT', body: 'flaky' }],
+      }),
+    )
+    const executeActions = vi.fn().mockRejectedValue(new Error('gh api down'))
+
+    const summary = await runReviewRecovery({
+      repositories: [{ localPath: '/repo' }],
+      reviewContextGateway: gateway,
+      executeActions,
+      now: () => NOW,
+      logger: silentLogger(),
+      graceWindowMs: 30 * 60 * 1000,
+    })
+
+    expect(summary.failed).toBe(1)
+    expect(summary.recovered).toBe(0)
+    expect(gateway.read('/repo', 'github-owner/repo-3')?.result).toBeUndefined()
+  })
+})

--- a/src/tests/units/services/runReviewRecovery.service.test.ts
+++ b/src/tests/units/services/runReviewRecovery.service.test.ts
@@ -6,9 +6,19 @@ import { ReviewContextFactory } from '@/tests/factories/reviewContext.factory.js
 const NOW = new Date('2026-05-25T21:00:00Z').getTime()
 const ONE_HOUR_AGO = new Date('2026-05-25T20:00:00Z').toISOString()
 const ONE_MINUTE_AGO = new Date('2026-05-25T20:59:00Z').toISOString()
+const ONE_HOUR_AGO_TWO_MIN_HEARTBEAT = '2026-05-25T20:58:00Z'
 
 function silentLogger() {
   return { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}
+
+const EMPTY_SUMMARY = {
+  scanned: 0,
+  recovered: 0,
+  partial: 0,
+  backfilled: 0,
+  skipped: 0,
+  failed: 0,
 }
 
 describe('runReviewRecovery', () => {
@@ -23,7 +33,7 @@ describe('runReviewRecovery', () => {
       logger: silentLogger(),
     })
 
-    expect(summary).toEqual({ scanned: 0, recovered: 0, backfilled: 0, skipped: 0, failed: 0 })
+    expect(summary).toEqual(EMPTY_SUMMARY)
   })
 
   it('skips contexts that do not match the predicate (no actions queued)', async () => {
@@ -85,18 +95,22 @@ describe('runReviewRecovery', () => {
     }
   })
 
-  it('recovers contexts inside the grace window by calling executeActions then setResult', async () => {
+  it('measures grace window from progress.updatedAt, not createdAt (long-running reviews)', async () => {
     const gateway = new StubReviewContextGateway()
     gateway.setContext(
-      'github-owner/repo-2',
+      'github-owner/repo-long',
       ReviewContextFactory.create({
-        mergeRequestId: 'github-owner/repo-2',
-        createdAt: ONE_MINUTE_AGO,
-        progress: { phase: 'completed', currentStep: null },
-        actions: [{ type: 'POST_COMMENT', body: 'fresh' }],
+        mergeRequestId: 'github-owner/repo-long',
+        createdAt: ONE_HOUR_AGO, // started > grace window ago
+        progress: {
+          phase: 'completed',
+          currentStep: null,
+          updatedAt: ONE_HOUR_AGO_TWO_MIN_HEARTBEAT, // but kept heartbeating 2 min ago
+        },
+        actions: [{ type: 'POST_COMMENT', body: 'long but fresh' }],
       }),
     )
-    const executeActions = vi.fn().mockResolvedValue({ success: true })
+    const executeActions = vi.fn().mockResolvedValue({ posted: 1, failed: 0 })
 
     const summary = await runReviewRecovery({
       repositories: [{ localPath: '/repo' }],
@@ -109,13 +123,98 @@ describe('runReviewRecovery', () => {
 
     expect(summary.recovered).toBe(1)
     expect(summary.backfilled).toBe(0)
+    expect(executeActions).toHaveBeenCalledOnce()
+  })
+
+  it('recovers contexts inside the grace window by calling executeActions then finalizing', async () => {
+    const gateway = new StubReviewContextGateway()
+    gateway.setContext(
+      'github-owner/repo-2',
+      ReviewContextFactory.create({
+        mergeRequestId: 'github-owner/repo-2',
+        createdAt: ONE_MINUTE_AGO,
+        progress: { phase: 'completed', currentStep: null },
+        actions: [{ type: 'POST_COMMENT', body: 'fresh' }],
+      }),
+    )
+    const executeActions = vi.fn().mockResolvedValue({ posted: 1, failed: 0 })
+
+    const summary = await runReviewRecovery({
+      repositories: [{ localPath: '/repo' }],
+      reviewContextGateway: gateway,
+      executeActions,
+      now: () => NOW,
+      logger: silentLogger(),
+      graceWindowMs: 30 * 60 * 1000,
+    })
+
+    expect(summary.recovered).toBe(1)
+    expect(summary.partial).toBe(0)
+    expect(summary.backfilled).toBe(0)
     expect(executeActions).toHaveBeenCalledTimes(1)
     const result = gateway.read('/repo', 'github-owner/repo-2')?.result
     expect(result?.kind).toBe('backfilled')
     if (result?.kind === 'backfilled') {
       expect(result.reason).toBe('recovered-after-restart')
-      expect(result.backfilledAt).toBeDefined()
     }
+  })
+
+  it('counts partial when some posts succeed and some fail, still finalizing to avoid double-post', async () => {
+    const gateway = new StubReviewContextGateway()
+    gateway.setContext(
+      'github-owner/repo-partial',
+      ReviewContextFactory.create({
+        mergeRequestId: 'github-owner/repo-partial',
+        createdAt: ONE_MINUTE_AGO,
+        progress: { phase: 'completed', currentStep: null },
+        actions: [
+          { type: 'POST_INLINE_COMMENT', filePath: 'a.ts', line: 1, body: 'a' },
+          { type: 'POST_INLINE_COMMENT', filePath: 'b.ts', line: 1, body: 'b' },
+        ],
+      }),
+    )
+    const executeActions = vi.fn().mockResolvedValue({ posted: 1, failed: 1 })
+
+    const summary = await runReviewRecovery({
+      repositories: [{ localPath: '/repo' }],
+      reviewContextGateway: gateway,
+      executeActions,
+      now: () => NOW,
+      logger: silentLogger(),
+      graceWindowMs: 30 * 60 * 1000,
+    })
+
+    expect(summary.partial).toBe(1)
+    expect(summary.recovered).toBe(0)
+    expect(summary.failed).toBe(0)
+    expect(gateway.read('/repo', 'github-owner/repo-partial')?.result?.kind).toBe('backfilled')
+  })
+
+  it('leaves the context unfinalized when zero posts went through (safe to retry next boot)', async () => {
+    const gateway = new StubReviewContextGateway()
+    gateway.setContext(
+      'github-owner/repo-zero',
+      ReviewContextFactory.create({
+        mergeRequestId: 'github-owner/repo-zero',
+        createdAt: ONE_MINUTE_AGO,
+        progress: { phase: 'completed', currentStep: null },
+        actions: [{ type: 'POST_COMMENT', body: 'unposted' }],
+      }),
+    )
+    const executeActions = vi.fn().mockResolvedValue({ posted: 0, failed: 1 })
+
+    const summary = await runReviewRecovery({
+      repositories: [{ localPath: '/repo' }],
+      reviewContextGateway: gateway,
+      executeActions,
+      now: () => NOW,
+      logger: silentLogger(),
+      graceWindowMs: 30 * 60 * 1000,
+    })
+
+    expect(summary.failed).toBe(1)
+    expect(summary.recovered).toBe(0)
+    expect(gateway.read('/repo', 'github-owner/repo-zero')?.result).toBeUndefined()
   })
 
   it('counts a failure when executeActions throws and leaves result unset', async () => {

--- a/src/tests/units/services/runReviewRecovery.service.test.ts
+++ b/src/tests/units/services/runReviewRecovery.service.test.ts
@@ -77,7 +77,12 @@ describe('runReviewRecovery', () => {
     expect(summary.backfilled).toBe(1)
     expect(summary.recovered).toBe(0)
     expect(executeActions).not.toHaveBeenCalled()
-    expect(gateway.read('/repo', 'github-owner/repo-1')?.result?.backfilledAt).toBeDefined()
+    const result = gateway.read('/repo', 'github-owner/repo-1')?.result
+    expect(result?.kind).toBe('backfilled')
+    if (result?.kind === 'backfilled') {
+      expect(result.reason).toBe('stale-on-boot')
+      expect(result.backfilledAt).toBeDefined()
+    }
   })
 
   it('recovers contexts inside the grace window by calling executeActions then setResult', async () => {
@@ -105,7 +110,12 @@ describe('runReviewRecovery', () => {
     expect(summary.recovered).toBe(1)
     expect(summary.backfilled).toBe(0)
     expect(executeActions).toHaveBeenCalledTimes(1)
-    expect(gateway.read('/repo', 'github-owner/repo-2')?.result?.backfilledAt).toBeDefined()
+    const result = gateway.read('/repo', 'github-owner/repo-2')?.result
+    expect(result?.kind).toBe('backfilled')
+    if (result?.kind === 'backfilled') {
+      expect(result.reason).toBe('recovered-after-restart')
+      expect(result.backfilledAt).toBeDefined()
+    }
   })
 
   it('counts a failure when executeActions throws and leaves result unset', async () => {


### PR DESCRIPTION
## Summary

Recover reviews that Claude completed but reviewflow-app never finished posting. Triggered by issue #205 — concrete incident: PR #204 (operator console redesign) had a full review done by Claude on 2026-05-25, 8 actions queued in the review-context file, but a systemd restart 16 seconds before `set_phase("completed")` killed the post-actions step. Result on GitHub: 0 comments, 0 inline. Dashboard silently dropped the MR.

## What this PR ships (Phase 1)

1. **Boot-time recovery** — `runReviewRecovery` in `src/modules/review-execution/services/reviewRecovery.service.ts` scans every review-context on disk and replays unfinalized ones inside a 30-minute grace window. Older contexts are *backfilled* (synthetic result with `backfilledAt`) so the ~50 historic context files (PR #106, #170, etc.) don't get re-posted on first deploy.
2. **`listAll()` on `ReviewContextGateway`** — recursive walk of `<localPath>/.claude/reviews/logs/**/*.json`, malformed files skipped, no throw on missing dir.
3. **Live path: `setResult` after post** — github.controller.ts and gitlab.controller.ts now call `contextGateway.setResult(...)` immediately after a successful `executeActionsFromContext`. Without this, *every* successful review left a context with `result=null` — indistinguishable from an interrupted one. Going forward, the recovery predicate can reliably tell them apart.
4. **Schema extension** — `ReviewContextResult` gains optional `backfilledAt?: string` so the migration can mark contexts as synthetic-filled without lying about the verdict.

## Why this matters

Silent data loss. Each review burns Claude inference (~$0.50–2). When systemd restarts mid-flight, all of it goes to /dev/null and the user is never told. After this PR, any restart only loses what was unpostable inside the last 30 minutes, and even those get picked up at the next boot.

## Test plan

- [x] `yarn verify` — typecheck + lint + 2141 tests passed locally
- [x] 5 unit tests on the predicate (`shouldRecover.test.ts`) covering completed/finalized/no-actions/in-flight/pending cases
- [x] 5 unit tests on the orchestrator (`runReviewRecovery.service.test.ts`) covering empty/skip/backfill/recover/failure
- [x] 3 unit tests on `listAll()` (empty dir, nested subdirs from `/`-in-mergeRequestId, malformed JSON)
- [ ] Manual smoke: restart `reviewflow-app` while a review is mid-publish, observe recovery log at next boot, observe GitHub posts.

## Phase 2 (follow-up, not in this PR)

Persistent queue so jobs that never started (sitting in `p-queue` when SIGTERM hits) also survive a restart. Tracked in issue #205.

## Notes

- The Python replay script that fixed PR #204 manually is in `~/.claude/jobs/62b49ba9/replay_pr204.py` — kept for reference but not part of this PR.
- The `verdict` for synthetic results defaults to `'needs_discussion'` (safest — doesn't claim merge-ready). For recovered (genuinely posted) reviews, verdict is derived from parsed stats: `blocking > 0 → needs_fixes`, else `needs_discussion`.

Closes #205.
