### PR TITLE
docs: update README and VitePress docs for worktree mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ GitLab/GitHub webhook ──► Review server receives event
                           Queue deduplicates & schedules
                                     │
                                     ▼
-                          Claude Code runs review skill
+                          Pre-built worktree ensured
+                          (~/.reviewflow/worktrees/...)
+                                    │
+                                    ▼
+                          Claude Code dispatched in --bg mode
                                     │
                           ┌─────────┼─────────┐
                           ▼         ▼         ▼
@@ -45,6 +49,7 @@ GitLab/GitHub webhook ──► Review server receives event
                                     │
                                     ▼
                           Dev pushes fixes ──► Auto follow-up
+                                              (same worktree, fast-forwarded)
 ```
 
 ---
@@ -148,6 +153,43 @@ Review behavior is defined by [Claude Code skills](https://docs.anthropic.com/en
 
 ---
 
+## Under the Hood
+
+For contributors and curious operators — what actually happens between the webhook and the posted review.
+
+### Background sessions, not foreground spawn
+
+Earlier versions of Reviewflow invoked `claude -p` and streamed JSON in the foreground. The server now dispatches each review as a **detached background session** with `claude --bg`. The Fastify process returns the session ID immediately and observes completion asynchronously.
+
+Completion is detected via **three independent signals in first-wins semantics**:
+
+1. **MCP `set_phase('completed')`** — Claude's skill calls the MCP server when the review finishes
+2. **`claude agents --json` polling** — every 30s, looks for `completed` / `failed` / `stopped`
+3. **15-minute hard timeout** — backstop if the other two miss
+
+Whichever fires first wins; the other two are cancelled. The review report is then read from `<worktree>/.claude/reviews/report-<mrNumber>.md` and the session is cleaned with `claude stop` + `claude rm`.
+
+### Isolated git worktrees
+
+Each MR runs in its own pre-built git worktree at `~/.reviewflow/worktrees/<platform>-<slug>-<mrNumber>`. This:
+
+- **Isolates concurrent reviews** so they cannot step on each other's index
+- **Keeps your main checkout untouched** — `git checkout` inside Claude no longer pollutes your working branch
+- **Speeds up followups** — the worktree is fetched + reset to the new HEAD, never recreated from scratch
+- **Self-cleans** — `removeWorktree` runs on merge/close, plus a daily sweep reclaims worktrees of MRs closed >24h ago or with `mtime` >7 days
+
+Full state machine: [Worktree Lifecycle](https://dgouron.github.io/review-flow/architecture/worktree-lifecycle).
+
+### Supervisor health
+
+The Claude agents supervisor (long-running daemon that hosts background sessions) is probed every 60 seconds. If it dies, a detached spawn brings it back under a PID-validated file lock at `~/.reviewflow/supervisor.lock`. The `/health` endpoint surfaces the live state and reports `status: degraded` when the supervisor is down — Reviewflow keeps booting, but reviews will fail fast.
+
+### Token budget cap
+
+Every session's token usage is parsed from the Claude transcript and persisted. A configurable monthly budget caps further dispatch and broadcasts a budget panel update over WebSocket whenever a session completes. The hourly billing audit calls `claude /usage` and pauses dispatch if it detects unexpected API-pool usage (the OAuth subscription is the only billing path that should be active).
+
+---
+
 ## Quick Start
 
 ### 1. Install
@@ -219,6 +261,7 @@ For detailed setup, see the **[Quick Start Guide](https://dgouron.github.io/revi
 | Review Skills Guide | [guide/review-skills](https://dgouron.github.io/review-flow/guide/review-skills) |
 | MCP Tools Reference | [reference/mcp-tools](https://dgouron.github.io/review-flow/reference/mcp-tools) |
 | Architecture | [architecture](https://dgouron.github.io/review-flow/architecture/) |
+| Worktree Lifecycle | [architecture/worktree-lifecycle](https://dgouron.github.io/review-flow/architecture/worktree-lifecycle) |
 | Deployment | [deployment](https://dgouron.github.io/review-flow/deployment/) |
 | Troubleshooting | [guide/troubleshooting](https://dgouron.github.io/review-flow/guide/troubleshooting) |
 

--- a/docs/.vitepress/config/sidebar.ts
+++ b/docs/.vitepress/config/sidebar.ts
@@ -35,6 +35,7 @@ const architectureSidebar: DefaultTheme.SidebarItem[] = [
 		items: [
 			{ text: "Overview", link: "/architecture/" },
 			{ text: "Current Architecture", link: "/architecture/current" },
+			{ text: "Worktree Lifecycle", link: "/architecture/worktree-lifecycle" },
 			{ text: "Target Architecture", link: "/architecture/target" },
 		],
 	},

--- a/docs/HARNESS-ONBOARDING.md
+++ b/docs/HARNESS-ONBOARDING.md
@@ -117,4 +117,12 @@ cat docs/feature-tracker.md | head -5
 
 ---
 
-_Last updated: 2026-05-15_
+## Runtime mental model
+
+Reviews no longer spawn `claude -p` in your checkout. Each MR runs in a **dedicated pre-built git worktree** at `~/.reviewflow/worktrees/<platform>-<slug>-<mrNumber>`, dispatched with `claude --bg` (detached background session). Completion is detected via three first-wins signals: MCP `set_phase`, `claude agents --json` polling, 15-min timeout. Worktrees are reused on followup, removed on merge/close, and a daily sweep reclaims stale ones (>24h closed or >7d mtime).
+
+Full state machine: [Worktree Lifecycle](./architecture/worktree-lifecycle.md). When in doubt about operator behaviour, that page documents the ground truth.
+
+---
+
+_Last updated: 2026-05-26_

--- a/docs/architecture/current.md
+++ b/docs/architecture/current.md
@@ -68,11 +68,12 @@ src/
 │   ├── worktree-management/                       # Pre-built worktree lifecycle (ensure/remove/sweep)
 │   ├── supervisor-management/                     # Claude agents supervisor health + respawn
 │   ├── review-execution/                          # Review job orchestration, model routing
-│   ├── platform-integration/                     # GitLab + GitHub webhook controllers
+│   ├── platform-integration/                      # GitLab + GitHub webhook controllers
 │   ├── tracking/                                  # MR lifecycle tracking
 │   ├── token-accounting/                          # Token usage + budget cap
 │   ├── statistics-insights/                       # Stats recalculation + developer insights
 │   ├── cli-configuration/                         # init, validate, discover commands
+│   ├── data-lifecycle/                            # Periodic cleanup of stale tracking data
 │   └── shared-kernel/                             # Cross-module shared types (diff stats, ...)
 │
 ├── frameworks/
@@ -157,7 +158,7 @@ claude --bg \
   3. Hard 15-minute timeout
 - **Report retrieval**: read from `<worktree>/.claude/reviews/report-<mrNumber>.md`
 - **Cleanup**: `claude stop <sessionId>` then `claude rm <sessionId>`
-- **Rate-limit handling**: stderr pattern `/rate|429|throttle/i` triggers exponential backoff retry
+- **Rate-limit handling**: stderr or stdout matching `RATE_LIMIT_DETECTION_REGEX` (exported from `claudeSession.cli.gateway.ts`) triggers exponential backoff retry
 - **Notifications**: `notify-send` at start and end (Linux)
 
 Source: `src/modules/claude-invocation/usecases/runClaudeReviewJob.usecase.ts` orchestrates `dispatchClaudeSession` → `awaitSessionCompletion` → `retrieveReviewReport` → `cleanupClaudeSession`.

--- a/docs/architecture/current.md
+++ b/docs/architecture/current.md
@@ -35,16 +35,20 @@ title: Technical Architecture
          │                           │                   │  (max 2)    │
          │                           │                   └──────┬──────┘
          │                           │                          │
-         │                           │                   6. spawn claude
+         │                           │                   6. ensureWorktree
+         │                           │                      (~/.reviewflow/worktrees/...)
+         │                           │                          │
+         │                           │                   7. claude --bg
          │                           │                          │
          │                           │                   ┌──────┴──────┐
-         │                           │                   │ Claude CLI  │
-         │                           │                   │ /skill MR#  │
+         │                           │                   │  Background │
+         │                           │                   │  Session    │
+         │                           │                   │  /skill MR# │
          │                           │                   └──────┬──────┘
          │                           │                          │
          │◄──────────────────────────┼──────────────────────────┤
-         │                           │                   7. Post comments
-         │ 8. Inline comments        │                      via glab api
+         │                           │                   8. Post comments
+         │ 9. Inline comments        │                      via glab/gh api
          │    on MR                  │                          │
          │                           │                          │
 ```
@@ -53,49 +57,42 @@ title: Technical Architecture
 
 ```
 src/
-├── server.ts                                      # Fastify entry point
+├── main/
+│   ├── server.ts                                  # Fastify entry point
+│   ├── routes.ts                                  # Composition root (DI wiring)
+│   └── dependencies.ts                            # Shared dependency construction
 ├── mcpServer.ts                                   # MCP server entry point
 │
-├── config/                                        # Config loading and validation
-├── security/                                      # Webhook signature verification
-├── entities/                                      # Domain entities and types
-│   ├── insight/                                   # Developer & team insights
-│   ├── stats/                                     # Review statistics
+├── modules/                                       # Bounded contexts (Clean Architecture per module)
+│   ├── claude-invocation/                         # `claude --bg` dispatch + completion + cleanup
+│   ├── worktree-management/                       # Pre-built worktree lifecycle (ensure/remove/sweep)
+│   ├── supervisor-management/                     # Claude agents supervisor health + respawn
+│   ├── review-execution/                          # Review job orchestration, model routing
+│   ├── platform-integration/                     # GitLab + GitHub webhook controllers
 │   ├── tracking/                                  # MR lifecycle tracking
-│   └── ...                                        # Other domain entities
-├── usecases/                                      # Business logic
-│   ├── insights/                                  # Insight computation & AI generation
-│   ├── stats/                                     # Stats recalculation & backfill
-│   └── ...                                        # Other use cases
-│
-├── interface-adapters/
-│   ├── controllers/
-│   │   ├── webhook/
-│   │   │   ├── gitlab.controller.ts               # GitLab webhook handler
-│   │   │   ├── github.controller.ts               # GitHub webhook handler
-│   │   │   └── eventFilter.ts                     # Filtering logic
-│   │   ├── http/                                  # REST API routes
-│   │   │   ├── insights.routes.ts                 # Developer & team insights
-│   │   │   ├── stats.routes.ts                    # Stats recalculation
-│   │   │   ├── version.routes.ts                  # Self-update mechanism
-│   │   │   └── ...                                # Other routes
-│   │   └── mcp/                                   # MCP tool handlers
-│   ├── presenters/                                # Domain → ViewModel transformation
-│   │   └── insights.presenter.ts                  # Insights presentation
-│   └── gateways/                                  # Gateway implementations
+│   ├── token-accounting/                          # Token usage + budget cap
+│   ├── statistics-insights/                       # Stats recalculation + developer insights
+│   ├── cli-configuration/                         # init, validate, discover commands
+│   └── shared-kernel/                             # Cross-module shared types (diff stats, ...)
 │
 ├── frameworks/
-│   ├── claude/                                    # Claude CLI integration
-│   │   └── claudeInsightsInvoker.ts               # AI insights generation via Claude
+│   ├── claude/                                    # Claude CLI orchestration shim
+│   ├── queue/                                     # p-queue adapter with MR-scoped concurrency
+│   ├── scheduler/                                 # Cleanup + worktree sweep + supervisor schedulers
+│   ├── logging/                                   # Pino + log buffer
+│   ├── config/                                    # Config loader
 │   └── settings/                                  # Runtime settings (model, language)
 │
 ├── mcp/                                           # MCP server infrastructure
 │   ├── server.ts                                  # MCP server setup
 │   └── mcpServerStdio.ts                          # Stdio transport
 │
-├── queue/                                         # Review queue management
-└── shared/                                        # Shared services and utilities
+├── security/                                      # Webhook signature verification
+├── shared/                                        # Foundation utilities + cross-cutting services
+└── tests/                                         # Vitest tests mirroring src structure
 ```
+
+Each module follows Clean Architecture internally: `entities/` → `usecases/` → `interface-adapters/`. Dependency direction is always inward.
 
 ## Components
 
@@ -137,16 +134,43 @@ Filters events based on these criteria:
 - **Deduplication**: Map with TTL (default: 5 min)
 - **Tracking**: Active jobs and history of last 20
 
-### 6. Claude Invoker (claude/invoker.ts)
+### 6. Claude Invocation (`modules/claude-invocation/`)
+
+Reviewflow no longer streams Claude's output via `-p`. Each review runs as a **detached background session** dispatched with `claude --bg`. Completion is detected via three independent signals in first-wins semantics.
 
 ```bash
-claude --print --permission-mode dontAsk --model sonnet -p "/<skill> <MR_NUMBER>"
+claude --bg \
+  --model <sonnet|opus|haiku> \
+  --permission-mode auto \
+  --append-system-prompt "<job context + MCP directives>" \
+  --mcp-config <inline-json> \
+  --strict-mcp-config \
+  --allowedTools "Read,Glob,Grep,Bash,Edit,Task,Skill,Write,LSP,mcp__review-progress__*" \
+  --disallowedTools "EnterPlanMode,AskUserQuestion" \
+  -- "/<skill> <MR_NUMBER>"
 ```
 
-- **Spawn**: `child_process.spawn` (not exec, to handle large outputs)
-- **CWD**: Configured local repo path
-- **Timeout**: 30 minutes max
-- **Notifications**: `notify-send` at start and end
+- **CWD**: The pre-built worktree at `~/.reviewflow/worktrees/<platform>-<slug>-<mrNumber>` — see [Worktree Lifecycle](./worktree-lifecycle.md)
+- **Completion signals** (first wins):
+  1. MCP `set_phase('completed')` published via the in-memory completion bridge
+  2. `claude agents --json` poll every 30s reports `completed` / `failed` / `stopped`
+  3. Hard 15-minute timeout
+- **Report retrieval**: read from `<worktree>/.claude/reviews/report-<mrNumber>.md`
+- **Cleanup**: `claude stop <sessionId>` then `claude rm <sessionId>`
+- **Rate-limit handling**: stderr pattern `/rate|429|throttle/i` triggers exponential backoff retry
+- **Notifications**: `notify-send` at start and end (Linux)
+
+Source: `src/modules/claude-invocation/usecases/runClaudeReviewJob.usecase.ts` orchestrates `dispatchClaudeSession` → `awaitSessionCompletion` → `retrieveReviewReport` → `cleanupClaudeSession`.
+
+### 7. Worktree Management (`modules/worktree-management/`)
+
+Each MR runs in its own git worktree to isolate concurrent reviews and give followups a stable cwd. `ensureWorktree` is idempotent (creates on first review, fetch + reset on followup). `removeWorktree` runs on merge/close. A daily sweep reclaims worktrees of MRs closed >24h ago, untracked worktrees, and any directory with `mtime` >7d.
+
+See [Worktree Lifecycle](./worktree-lifecycle.md) for the full state machine, file paths, and operator commands.
+
+### 8. Supervisor Management (`modules/supervisor-management/`)
+
+The Claude agents supervisor (long-running `claude` daemon hosting background sessions) is probed every 60 seconds. If it is `down`, a detached spawn brings it back up under a PID-validated file lock at `~/.reviewflow/supervisor.lock`. The `/health` endpoint surfaces `supervisor: { state, reason, lastCheckedAt }` and reports `status: 'degraded'` when the supervisor is unreachable. Reviewflow shutdown does NOT kill the spawned supervisor (`detached: true` + `unref()`).
 
 ## Security
 

--- a/docs/architecture/worktree-lifecycle.md
+++ b/docs/architecture/worktree-lifecycle.md
@@ -1,0 +1,142 @@
+---
+title: Worktree Lifecycle
+---
+
+# Worktree Lifecycle
+
+Reviewflow runs each Claude review in a **pre-built git worktree** dedicated to the merge request. This page explains why, where worktrees live on disk, and how they are created, reused, and reclaimed.
+
+## Why worktrees
+
+Earlier versions of Reviewflow invoked `claude -p` in the user's main checkout. That coupled review state to the developer's working copy and caused three classes of bugs:
+
+- Concurrent reviews stepped on each other's index
+- `git checkout` inside Claude polluted the parent branch
+- Followup reviews could not reproduce the exact state of the MR head
+
+Switching to one worktree per MR isolates each review in its own checkout, lets concurrent reviews on different MRs run truly in parallel, and gives followup reviews a stable cwd that always reflects the latest push.
+
+## On-disk layout
+
+```
+~/.reviewflow/worktrees/
+├── gitlab-myorg-myrepo-142/        # platform-slug-mrNumber
+│   ├── .claude/
+│   │   └── settings.json           # { "worktree": { "bgIsolation": "none" } }
+│   ├── .git                        # git worktree pointer
+│   └── ...                         # full project checkout at the MR head
+├── github-myorg-otherrepo-87/
+└── gitlab-myorg-myrepo-156/
+```
+
+| Element | Source |
+|---|---|
+| Base dir | `~/.reviewflow/worktrees/` — see `WORKTREE_BASE_DIR` in `src/shared/services/daemonPaths.ts` |
+| Directory name | `<platform>-<slug>-<mrNumber>` — `deriveWorktreeDirectoryName` in `src/modules/worktree-management/entities/worktree/worktree.ts` |
+| Slug | `projectPath` with `/` replaced by `-` |
+| `.claude/settings.json` | `{ worktree: { bgIsolation: 'none' } }` — tells the Claude CLI not to create a nested worktree inside the review worktree |
+
+The parse function `parseWorktreeDirectoryName` accepts directories matching `^(gitlab|github)-(.+)-(\d+)$`. Anything else is ignored by the sweep.
+
+## End-to-end flow
+
+```
+Webhook ──► Queue ──► ensureWorktree ──► dispatchClaudeSession (--bg)
+                              │                       │
+                              │                       ▼
+                              │             awaitSessionCompletion
+                              │                       │
+                              │         ┌─────────────┼─────────────┐
+                              │         ▼             ▼             ▼
+                              │   MCP set_phase   agents --json  timeout 15min
+                              │         │             │             │
+                              │         └─────────────┼─────────────┘
+                              │                       ▼
+                              │              retrieveReviewReport
+                              │                       │
+                              ▼                       ▼
+                       (worktree reused                Post to MR/PR
+                        on followup)                   cleanupClaudeSession
+
+On merge / close ──► removeWorktree
+Daily 02:00     ──► sweepStaleWorktrees
+```
+
+## `ensureWorktree` — create or fast-forward
+
+Source: `src/modules/worktree-management/usecases/ensureWorktree.usecase.ts`
+
+The use case is **idempotent**. First call creates the worktree; subsequent calls (followup reviews) fetch and reset to the MR head.
+
+| Branch | Sequence |
+|---|---|
+| Fresh review (path does not exist) | `git worktree prune` → `git fetch <remote> <refspec>` from source checkout → `git worktree add <path> <ref>` → write `.claude/settings.json` → return `{ status: 'created' }` |
+| Followup (path exists) | `git worktree prune` → `git fetch <remote> <refspec>` inside the worktree → `git reset --hard <ref>` → return `{ status: 'reused' }` |
+| Source branch deleted upstream | Fetch fails → return `{ status: 'failed', reason: 'branch-not-found' }`. `claudeInvoker` propagates the failure rather than running the review against the wrong tree. |
+| `.claude/settings.json` write failure | Logged as `settingsWarning`. Dispatch continues. Worst case: Claude opens a nested sub-worktree (pre-SPEC-170 behaviour). |
+
+### Fetch refspec — origin vs fork
+
+Source: `deriveFetchRef` in `worktree.ts`.
+
+| MR source | Refspec | Worktree ref |
+|---|---|---|
+| `origin` (same repo) | `<sourceBranch>` | `origin/<sourceBranch>` |
+| `fork` (cross-repo PR) | `<sourceBranch>:refs/remotes/pr-<mrNumber>/head` | `refs/remotes/pr-<mrNumber>/head` |
+
+Cross-fork support exists in the use case; GitHub controller wiring is tracked under FR-8 of SPEC-170.
+
+## `removeWorktree` — on merge / close
+
+Source: `src/modules/worktree-management/usecases/removeWorktree.usecase.ts`
+
+Triggered by the webhook controllers when a merge request transitions to `merged` or `closed`:
+
+- `gitlab.controller.ts` — close + merge
+- `github.controller.ts` — close (merged PRs are funneled through the same `closeResult` branch)
+
+The operation is **idempotent**. A missing worktree returns `{ status: 'not-found' }` and logs a warning — never an error.
+
+## `sweepStaleWorktrees` — daily safety net
+
+Source: `src/modules/worktree-management/usecases/sweepStaleWorktrees.usecase.ts`
+
+A worktree is reclaimed when **any** of these is true:
+
+| Predicate | Threshold |
+|---|---|
+| Tracked MR not found in any enabled repository | immediate |
+| Tracked MR is `merged` or `closed` for more than 24h | `ONE_DAY_MS` |
+| Worktree directory `mtime` older than 7 days | `STALE_THRESHOLD_MS = 7 * ONE_DAY_MS` |
+
+The sweep walks every directory under `~/.reviewflow/worktrees/` that matches the naming pattern, cross-references the tracking gateway across all enabled repositories, and removes the matches. Failures are counted but do not abort the sweep.
+
+## Concurrency
+
+The queue (`pQueueAdapter`) serializes operations sharing the same MR key `<platform>:<projectPath>:<mrNumber>`. Fresh review and followup on the same MR run sequentially against the same worktree. Reviews on different MRs run in parallel up to `queue.maxConcurrent` (default 2).
+
+## Operator commands
+
+```bash
+# Inspect worktrees on disk
+ls -la ~/.reviewflow/worktrees/
+
+# Disk usage per worktree
+du -sh ~/.reviewflow/worktrees/*
+
+# Manual cleanup (rare — sweep handles this)
+git worktree prune
+rm -rf ~/.reviewflow/worktrees/<platform>-<slug>-<mrNumber>
+```
+
+The dashboard "Worktree" panel surfaces the same information plus per-worktree size probe — see SPEC-173.
+
+## Related specs and reports
+
+| Concern | Spec | Report |
+|---|---|---|
+| `claude -p` → `claude --bg` migration | [SPEC-169](../specs/169-migrate-claude-invocation-to-bg-mode.md) | [Report](../reports/169-migrate-claude-invocation-to-bg-mode.report.md) |
+| Pre-built worktree lifecycle | [SPEC-170](../specs/170-prebuilt-worktree-lifecycle.md) | [Report](../reports/170-prebuilt-worktree-lifecycle.report.md) |
+| Daily sweep scheduler + GitHub fork | [SPEC-170 FR6/FR8](../specs/170-prebuilt-worktree-lifecycle.md) | [Report](../reports/170-prebuilt-worktree-lifecycle-fr6-fr8.report.md) |
+| Dashboard worktree panel | [SPEC-173](../specs/173-dashboard-worktree-panel.md) | [Report](../reports/173-dashboard-worktree-panel.report.md) |
+| Worktree failure visibility | [SPEC-175](../specs/175-worktree-failure-visibility.md) | — |

--- a/docs/architecture/worktree-lifecycle.md
+++ b/docs/architecture/worktree-lifecycle.md
@@ -59,7 +59,7 @@ Webhook ──► Queue ──► ensureWorktree ──► dispatchClaudeSession
                         on followup)                   cleanupClaudeSession
 
 On merge / close ──► removeWorktree
-Daily 02:00     ──► sweepStaleWorktrees
+Every 24h (since startup) ──► sweepStaleWorktrees
 ```
 
 ## `ensureWorktree` — create or fast-forward
@@ -110,6 +110,8 @@ A worktree is reclaimed when **any** of these is true:
 | Worktree directory `mtime` older than 7 days | `STALE_THRESHOLD_MS = 7 * ONE_DAY_MS` |
 
 The sweep walks every directory under `~/.reviewflow/worktrees/` that matches the naming pattern, cross-references the tracking gateway across all enabled repositories, and removes the matches. Failures are counted but do not abort the sweep.
+
+The scheduler (`src/frameworks/scheduler/worktreeSweepScheduler.ts`) fires an immediate first sweep at server startup, then re-runs every 24 hours from that point — there is no wall-clock cron. The next-sweep ETA is exposed via `getNextSweepEta()` and surfaced on the dashboard worktree panel (SPEC-173).
 
 ## Concurrency
 

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -16,8 +16,11 @@ This guide covers:
 
 - Linux server with systemd (Ubuntu, Debian, etc.)
 - Node.js 20+ installed
+- `claude` CLI ≥ v2.1.139 (the `--bg` background dispatch mode is required)
+- `claude auth status` returns OAuth — **never** set `ANTHROPIC_API_KEY` in the systemd environment, Reviewflow auto-pauses dispatch if it detects the API pool is in use
 - `cloudflared` installed ([download](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/))
 - A domain on Cloudflare (for permanent URL)
+- Disk headroom on `$HOME` for `~/.reviewflow/worktrees/` — one full project checkout per active MR (typical: a few hundred MB per worktree, reclaimed automatically by the daily sweep)
 
 ## Quick Test (Temporary Tunnel)
 
@@ -111,12 +114,31 @@ sudo systemctl enable --now cloudflared-review-flow
 sudo systemctl status review-flow
 sudo systemctl status cloudflared-review-flow
 
-# Test endpoint
-curl https://review.your-domain.com/health
+# Test endpoint — expect status: "ok" and supervisor.state: "up"
+curl https://review.your-domain.com/health | jq .
+
+# If supervisor.state is "down", the 60s scheduler will respawn it on
+# the next tick. Persistent "down" usually means `claude` is not in
+# PATH or OAuth is not configured for the systemd user.
 
 # View logs
 journalctl -u review-flow -f
 ```
+
+The `/health` payload includes a `supervisor` block reporting the live state of the Claude agents daemon:
+
+```json
+{
+  "status": "ok",
+  "supervisor": {
+    "state": "up",
+    "reason": null,
+    "lastCheckedAt": "2026-05-26T10:42:00.000Z"
+  }
+}
+```
+
+When `supervisor.state === "down"`, overall `status` becomes `"degraded"` — Reviewflow still accepts webhooks but reviews will fail dispatch until the supervisor is back up. See the [Supervisor troubleshooting section](../guide/troubleshooting.md#supervisor).
 
 ## Templates
 
@@ -140,6 +162,25 @@ yarn build
 # Restart
 sudo systemctl start review-flow
 ```
+
+::: tip Worktrees survive restarts
+The worktree state lives at `~/.reviewflow/worktrees/` (independent of the source checkout). A restart does not invalidate active worktrees; in-flight reviews resume on the next webhook with `ensureWorktree` fast-forwarding the existing worktree.
+:::
+
+## Operating worktrees
+
+Each active MR has a dedicated worktree at `~/.reviewflow/worktrees/<platform>-<slug>-<mrNumber>`. They are created on first review, fast-forwarded on followup, removed on merge/close, and a daily sweep at 02:00 reclaims anything stale.
+
+```bash
+# Disk usage overview
+du -sh ~/.reviewflow/worktrees/*
+
+# Manual cleanup (rare — sweep handles this)
+rm -rf ~/.reviewflow/worktrees/<platform>-<slug>-<mrNumber>
+cd /path/to/source/checkout && git worktree prune
+```
+
+Full state machine: [Worktree Lifecycle](../architecture/worktree-lifecycle.md).
 
 ## Troubleshooting
 

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -169,7 +169,7 @@ The worktree state lives at `~/.reviewflow/worktrees/` (independent of the sourc
 
 ## Operating worktrees
 
-Each active MR has a dedicated worktree at `~/.reviewflow/worktrees/<platform>-<slug>-<mrNumber>`. They are created on first review, fast-forwarded on followup, removed on merge/close, and a daily sweep at 02:00 reclaims anything stale.
+Each active MR has a dedicated worktree at `~/.reviewflow/worktrees/<platform>-<slug>-<mrNumber>`. They are created on first review, fast-forwarded on followup, removed on merge/close, and a sweep every 24h (anchored to server startup, also fires immediately on boot) reclaims anything stale.
 
 ```bash
 # Disk usage overview

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -126,11 +126,16 @@ reviewflow status
 3. Open `http://localhost:3847/dashboard/`
 4. Watch the review appear!
 
+::: info Where reviews actually run
+On first review of each MR, Reviewflow creates a dedicated git worktree at `~/.reviewflow/worktrees/<platform>-<slug>-<mrNumber>` and dispatches `claude --bg` against it. Your main checkout is never touched. Followups fast-forward the existing worktree; merge/close removes it; a daily sweep reclaims anything stale. See [Worktree Lifecycle](../architecture/worktree-lifecycle.md).
+:::
+
 ## Next steps
 
 - [Project Configuration](./project-config.md) - Configure review skills per project
 - [Deployment Guide](../deployment/index.md) - Run in production with systemd
 - [Architecture](../architecture/current.md) - Understand the codebase
+- [Worktree Lifecycle](../architecture/worktree-lifecycle.md) - How review isolation works
 
 ## Troubleshooting
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -75,12 +75,83 @@ sudo systemctl restart cloudflared-review-flow
 - Verify the skill exists in the target project
 - Check Claude Code permissions (`settings.local.json`)
 
+### Session dispatch fails immediately
+
+Reviewflow dispatches with `claude --bg`. Check:
+
+- `claude` binary version: must support `--bg` (≥ v2.1.139)
+- `claude auth status` returns OAuth (no `ANTHROPIC_API_KEY` should be set — Reviewflow auto-pauses if it detects the API pool is in use)
+- Server logs for `dispatchClaudeSession` errors
+
+### Review hangs and never completes
+
+Three completion signals are wired (MCP `set_phase`, `claude agents --json` poll, 15-min timeout). If all three miss, the session is killed on timeout and the report is missing. Inspect:
+
+```bash
+claude agents --json                # is the session still listed?
+claude logs <sessionId>             # what is it doing?
+```
+
+If the session is healthy but unresponsive, `claude stop <sessionId>` clears it.
+
+## Worktree
+
+### "branch-not-found" error in review job logs
+
+The source branch was deleted upstream between webhook reception and worktree fetch. The review is aborted — re-push the branch or close the MR.
+
+### "worktree-add-failed" error
+
+Common causes:
+
+- A stale worktree pointer survived (`git worktree prune` from the source checkout fixes this — `ensureWorktree` already runs prune, but a corrupted `.git/worktrees/` may need manual cleanup)
+- Disk full on `~/.reviewflow/worktrees/` — check `du -sh ~/.reviewflow/worktrees/*`
+
+### Worktree directory missing on merge
+
+`removeWorktree` is idempotent — a missing path is logged as a warning and the merge completes normally. No action needed.
+
+### Manual cleanup
+
+```bash
+# Inspect
+ls -la ~/.reviewflow/worktrees/
+du -sh ~/.reviewflow/worktrees/*
+
+# Force-remove a specific worktree
+rm -rf ~/.reviewflow/worktrees/<platform>-<slug>-<mrNumber>
+# then prune from the source checkout
+cd /path/to/source/checkout && git worktree prune
+```
+
+The daily sweep at 02:00 normally reclaims stale worktrees automatically (closed >24h or `mtime` >7d).
+
+## Supervisor
+
+### `/health` returns `status: degraded`
+
+The Claude agents supervisor is unreachable. The 60-second scheduler will attempt to respawn it on the next tick. Check:
+
+```bash
+curl http://localhost:3847/health | jq .supervisor
+# { state: "down", reason: "...", lastCheckedAt: "..." }
+```
+
+Possible reasons:
+
+- `claude` binary not in `PATH`
+- `claude auth status` not authenticated
+- Lock file held by a dead PID at `~/.reviewflow/supervisor.lock` — the scheduler takes over automatically on the next tick
+
+### Supervisor keeps respawning
+
+Look for `spawn-unstable` in `/health` reason — the supervisor dies immediately after spawn. Usually means OAuth credentials are missing or `claude` is broken. Run `claude agents` manually to see the error.
+
 ## MCP Server
 
 ### No MCP logs created
 
 - The MCP server only starts when Claude actually calls a tool
-- Ensure `--print` mode and MCP server config are both set
 - Check `~/.review-flow/logs/mcp-server.log`
 
 ### "Workflow not found" error
@@ -101,3 +172,6 @@ sudo systemctl restart cloudflared-review-flow
 | MCP server | `~/.review-flow/logs/mcp-server.log` |
 | Review stats | `.claude/reviews/stats.json` (in project) |
 | MR tracking | `.claude/reviews/tracking.json` (in project) |
+| Claude session transcripts | `~/.claude/projects/<cwd-slug>/<sessionId>.jsonl` |
+| Worktrees | `~/.reviewflow/worktrees/<platform>-<slug>-<mrNumber>/` |
+| Supervisor lock | `~/.reviewflow/supervisor.lock` |

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -124,7 +124,7 @@ rm -rf ~/.reviewflow/worktrees/<platform>-<slug>-<mrNumber>
 cd /path/to/source/checkout && git worktree prune
 ```
 
-The daily sweep at 02:00 normally reclaims stale worktrees automatically (closed >24h or `mtime` >7d).
+The sweep (every 24h since server startup) normally reclaims stale worktrees automatically (closed >24h or `mtime` >7d).
 
 ## Supervisor
 


### PR DESCRIPTION
## Summary

- Documents the `claude -p` → `claude --bg` + pre-built git worktree migration shipped in SPEC-169, SPEC-170, SPEC-172
- Adds a new `docs/architecture/worktree-lifecycle.md` page covering on-disk layout, `ensureWorktree` / `removeWorktree` / `sweepStaleWorktrees`, fetch refspec (origin vs fork), concurrency, and operator commands
- Refreshes README (How It Works diagram + new "Under the Hood" section), `architecture/current.md` (file structure + Claude Invocation + Worktree + Supervisor sections), quick-start, deployment, troubleshooting, and HARNESS-ONBOARDING to match the actual runtime

## Files

| File | Change |
|---|---|
| `docs/architecture/worktree-lifecycle.md` | **new** — full state machine + paths + operator commands |
| `README.md` | flow diagram + "Under the Hood" (background sessions, worktrees, supervisor, budget) |
| `docs/architecture/current.md` | file structure rewritten around bounded contexts; section 6 (`claude -p`) replaced with `claude --bg` + triple completion signal; new Worktree + Supervisor sections |
| `docs/guide/quick-start.md` | info box on worktree creation |
| `docs/deployment/index.md` | claude CLI prereqs, `/health` payload with supervisor block, disk headroom note, worktree operations |
| `docs/guide/troubleshooting.md` | new Worktree + Supervisor sections, dispatch + completion troubleshooting, log locations |
| `docs/HARNESS-ONBOARDING.md` | runtime mental model section, date refresh |
| `docs/.vitepress/config/sidebar.ts` | adds "Worktree Lifecycle" entry under Architecture |

## Out of scope (signaled, not fixed)

- `docs/guide/review-skills.md:191,205` still shows `claude -p "/my-review 123"` as a manual local skill testing command — still valid as a developer pattern, but unrelated to the Reviewflow runtime
- `docs/architecture/mcp/specification.md:80` still shows `claude --print` as an MCP example — same as above

## Test plan

- [ ] `yarn docs:dev` and confirm the "Worktree Lifecycle" sidebar entry appears under Architecture
- [ ] Visually verify the worktree-lifecycle page renders (diagrams, tables, internal links)
- [ ] Spot-check that the cross-links in README → quick-start → architecture/current → worktree-lifecycle resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)