### PR TITLE
feat(dashboard): rich, interactive desktop notifications

### DIFF
--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -664,10 +664,18 @@
 
       const desktopPayload = getDesktopNotificationPayload(notification, t);
       if (!desktopPayload) return;
-      new Notification(desktopPayload.title, {
+      const desktopNotif = new Notification(desktopPayload.title, {
         body: desktopPayload.body,
         tag: desktopPayload.tag,
+        icon: desktopPayload.iconDataUri,
       });
+      desktopNotif.onclick = () => {
+        window.focus();
+        if (desktopPayload.url) {
+          window.open(desktopPayload.url, '_blank', 'noopener');
+        }
+        desktopNotif.close();
+      };
     }
 
     function dispatchReviewNotifications(activeReviews, recentReviews) {

--- a/src/dashboard/modules/desktopNotifications.js
+++ b/src/dashboard/modules/desktopNotifications.js
@@ -24,14 +24,74 @@ const KIND_FORMATS = {
   reviewPendingConfirmation: { emoji: '⏳', labelKey: 'notify.label.reviewPendingConfirmation' },
 };
 
+// Size category thresholds (sum of additions + deletions).
+// Tweak here if you find them off — kept central on purpose.
+const SIZE_THRESHOLD_SMALL_MAX = 50;
+const SIZE_THRESHOLD_MEDIUM_MAX = 300;
+const SIZE_EMOJI = { small: '🪶', medium: '🚀', big: '🐘' };
+
+/**
+ * @param {unknown} value
+ * @returns {number | null}
+ */
+function toFiniteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * @param {Record<string, unknown> | undefined} sizeMetrics
+ * @returns {'small' | 'medium' | 'big'}
+ */
+function categorizeSize(sizeMetrics) {
+  if (!sizeMetrics) return 'small';
+  const additions = toFiniteNumber(sizeMetrics.additions);
+  const deletions = toFiniteNumber(sizeMetrics.deletions);
+  if (additions !== null && deletions !== null) {
+    const total = additions + deletions;
+    if (total < SIZE_THRESHOLD_SMALL_MAX) return 'small';
+    if (total < SIZE_THRESHOLD_MEDIUM_MAX) return 'medium';
+    return 'big';
+  }
+  const filesChanged = toFiniteNumber(sizeMetrics.filesChanged);
+  if (filesChanged !== null) {
+    if (filesChanged <= 3) return 'small';
+    if (filesChanged <= 10) return 'medium';
+    return 'big';
+  }
+  return 'small';
+}
+
 /**
  * @param {Record<string, unknown>} review
  * @returns {string | null}
  */
-function resolveAuthor(review) {
-  const assignedBy = review.assignedBy;
-  if (!assignedBy || typeof assignedBy !== 'object') return null;
-  const typed = /** @type {{ displayName?: unknown, username?: unknown }} */ (assignedBy);
+function buildSizeLine(review) {
+  const metrics = review.sizeMetrics;
+  if (!metrics || typeof metrics !== 'object') return null;
+  const typed = /** @type {Record<string, unknown>} */ (metrics);
+  const additions = toFiniteNumber(typed.additions);
+  const deletions = toFiniteNumber(typed.deletions);
+  const filesChanged = toFiniteNumber(typed.filesChanged);
+  const hasAnyStat = additions !== null || deletions !== null || filesChanged !== null;
+  if (!hasAnyStat) return null;
+  const emoji = SIZE_EMOJI[categorizeSize(typed)];
+  const parts = [];
+  if (additions !== null && deletions !== null) {
+    parts.push(`+${additions}/-${deletions}`);
+  }
+  if (filesChanged !== null) {
+    parts.push(`${filesChanged} files`);
+  }
+  return `${emoji} ${parts.join(' · ')}`;
+}
+
+/**
+ * @param {unknown} actor
+ * @returns {string | null}
+ */
+function resolveActorName(actor) {
+  if (!actor || typeof actor !== 'object') return null;
+  const typed = /** @type {{ displayName?: unknown, username?: unknown }} */ (actor);
   if (typeof typed.displayName === 'string' && typed.displayName.length > 0) {
     return typed.displayName;
   }
@@ -39,6 +99,14 @@ function resolveAuthor(review) {
     return typed.username;
   }
   return null;
+}
+
+/**
+ * @param {Record<string, unknown>} review
+ * @returns {string | null}
+ */
+function resolveAuthor(review) {
+  return resolveActorName(review.author) ?? resolveActorName(review.assignedBy);
 }
 
 /**
@@ -86,8 +154,12 @@ function buildBody(review) {
   const lines = [];
   const title = typeof review.title === 'string' ? review.title.trim() : '';
   if (title.length > 0) lines.push(title);
+  const sizeLine = buildSizeLine(review);
   const project = resolveProjectShortName(review);
-  if (project) lines.push(project);
+  const secondLineParts = [];
+  if (sizeLine) secondLineParts.push(sizeLine);
+  if (project) secondLineParts.push(project);
+  if (secondLineParts.length > 0) lines.push(secondLineParts.join(' · '));
   return lines.join('\n');
 }
 

--- a/src/dashboard/modules/desktopNotifications.js
+++ b/src/dashboard/modules/desktopNotifications.js
@@ -122,11 +122,39 @@ function resolveProjectShortName(review) {
 
 /**
  * @param {Record<string, unknown>} review
+ * @returns {'gitlab' | 'github'}
+ */
+function resolvePlatform(review) {
+  const id = typeof review.id === 'string' ? review.id : '';
+  return id.startsWith('github') ? 'github' : 'gitlab';
+}
+
+/**
+ * @param {Record<string, unknown>} review
  * @returns {'!' | '#'}
  */
 function resolveMrPrefix(review) {
-  const id = typeof review.id === 'string' ? review.id : '';
-  return id.startsWith('github') ? '#' : '!';
+  return resolvePlatform(review) === 'github' ? '#' : '!';
+}
+
+const PLATFORM_ICONS = {
+  gitlab: buildPlatformIconDataUri('GL', 'FC6D26'),
+  github: buildPlatformIconDataUri('GH', '181717'),
+};
+
+/**
+ * @param {string} label
+ * @param {string} hexColor
+ * @returns {string}
+ */
+function buildPlatformIconDataUri(label, hexColor) {
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">` +
+    `<rect width="64" height="64" rx="12" fill="#${hexColor}"/>` +
+    `<text x="32" y="42" font-size="28" text-anchor="middle" fill="white" ` +
+    `font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-weight="700">${label}</text>` +
+    `</svg>`;
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
 }
 
 /**
@@ -166,7 +194,7 @@ function buildBody(review) {
 /**
  * @param {{ kind: string, review: Record<string, unknown> }} notification
  * @param {(key: string, params?: Record<string, string | number>) => string} translate
- * @returns {{ title: string, body: string, tag: string } | null}
+ * @returns {{ title: string, body: string, tag: string, url: string | null, iconDataUri: string } | null}
  */
 export function getDesktopNotificationPayload(notification, translate) {
   const format = KIND_FORMATS[notification.kind];
@@ -175,10 +203,15 @@ export function getDesktopNotificationPayload(notification, translate) {
   const mrNumber = typeof notification.review.mrNumber === 'number'
     ? String(notification.review.mrNumber)
     : '?';
+  const url = typeof notification.review.mrUrl === 'string' && notification.review.mrUrl.length > 0
+    ? notification.review.mrUrl
+    : null;
 
   return {
     title: buildTitle(format, translate, notification.review),
     body: buildBody(notification.review),
     tag: `reviewflow-${notification.kind}-${mrNumber}`,
+    url,
+    iconDataUri: PLATFORM_ICONS[resolvePlatform(notification.review)],
   };
 }

--- a/src/dashboard/modules/desktopNotifications.js
+++ b/src/dashboard/modules/desktopNotifications.js
@@ -153,7 +153,7 @@ function buildPlatformIconDataUri(label, hexColor) {
     `<rect width="64" height="64" rx="12" fill="#${hexColor}"/>` +
     `<text x="32" y="42" font-size="28" text-anchor="middle" fill="white" ` +
     `font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-weight="700">${label}</text>` +
-    `</svg>`;
+    '</svg>';
   return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
 }
 

--- a/src/dashboard/modules/desktopNotifications.js
+++ b/src/dashboard/modules/desktopNotifications.js
@@ -9,30 +9,104 @@ export function shouldNotifyDesktop(options) {
 }
 
 /**
+ * @typedef {Object} KindFormat
+ * @property {string} emoji
+ * @property {string} labelKey
+ */
+
+/** @type {Record<string, KindFormat>} */
+const KIND_FORMATS = {
+  reviewStarted: { emoji: '🔍', labelKey: 'notify.label.reviewStarted' },
+  followupStarted: { emoji: '🔁', labelKey: 'notify.label.followupStarted' },
+  reviewCompleted: { emoji: '✅', labelKey: 'notify.label.reviewCompleted' },
+  followupCompleted: { emoji: '✅', labelKey: 'notify.label.followupCompleted' },
+  reviewFailed: { emoji: '❌', labelKey: 'notify.label.reviewFailed' },
+  reviewPendingConfirmation: { emoji: '⏳', labelKey: 'notify.label.reviewPendingConfirmation' },
+};
+
+/**
+ * @param {Record<string, unknown>} review
+ * @returns {string | null}
+ */
+function resolveAuthor(review) {
+  const assignedBy = review.assignedBy;
+  if (!assignedBy || typeof assignedBy !== 'object') return null;
+  const typed = /** @type {{ displayName?: unknown, username?: unknown }} */ (assignedBy);
+  if (typeof typed.displayName === 'string' && typed.displayName.length > 0) {
+    return typed.displayName;
+  }
+  if (typeof typed.username === 'string' && typed.username.length > 0) {
+    return typed.username;
+  }
+  return null;
+}
+
+/**
+ * @param {Record<string, unknown>} review
+ * @returns {string | null}
+ */
+function resolveProjectShortName(review) {
+  if (typeof review.project !== 'string' || review.project.length === 0) return null;
+  const segments = review.project.split('/');
+  const last = segments[segments.length - 1];
+  return last && last.length > 0 ? last : null;
+}
+
+/**
+ * @param {Record<string, unknown>} review
+ * @returns {'!' | '#'}
+ */
+function resolveMrPrefix(review) {
+  const id = typeof review.id === 'string' ? review.id : '';
+  return id.startsWith('github') ? '#' : '!';
+}
+
+/**
+ * @param {KindFormat} format
+ * @param {(key: string) => string} translate
+ * @param {Record<string, unknown>} review
+ * @returns {string}
+ */
+function buildTitle(format, translate, review) {
+  const mrNumber = typeof review.mrNumber === 'number' ? String(review.mrNumber) : '?';
+  const mrToken = `${resolveMrPrefix(review)}${mrNumber}`;
+  const label = translate(format.labelKey);
+  const author = resolveAuthor(review);
+  const segments = author
+    ? [`${format.emoji} ${label}`, author, mrToken]
+    : [`${format.emoji} ${label}`, mrToken];
+  return segments.join(' · ');
+}
+
+/**
+ * @param {Record<string, unknown>} review
+ * @returns {string}
+ */
+function buildBody(review) {
+  const lines = [];
+  const title = typeof review.title === 'string' ? review.title.trim() : '';
+  if (title.length > 0) lines.push(title);
+  const project = resolveProjectShortName(review);
+  if (project) lines.push(project);
+  return lines.join('\n');
+}
+
+/**
  * @param {{ kind: string, review: Record<string, unknown> }} notification
  * @param {(key: string, params?: Record<string, string | number>) => string} translate
  * @returns {{ title: string, body: string, tag: string } | null}
  */
 export function getDesktopNotificationPayload(notification, translate) {
+  const format = KIND_FORMATS[notification.kind];
+  if (!format) return null;
+
   const mrNumber = typeof notification.review.mrNumber === 'number'
     ? String(notification.review.mrNumber)
     : '?';
 
-  const messageKeyByKind = {
-    reviewStarted: 'notify.reviewStarted',
-    followupStarted: 'notify.followupStarted',
-    reviewCompleted: 'notify.reviewCompleted',
-    followupCompleted: 'notify.followupCompleted',
-    reviewFailed: 'notify.reviewFailed',
-    reviewPendingConfirmation: 'notify.reviewPendingConfirmation',
-  };
-
-  const messageKey = messageKeyByKind[notification.kind];
-  if (!messageKey) return null;
-
   return {
-    title: translate('notify.desktopTitle'),
-    body: translate(messageKey, { mrNumber }),
+    title: buildTitle(format, translate, notification.review),
+    body: buildBody(notification.review),
     tag: `reviewflow-${notification.kind}-${mrNumber}`,
   };
 }

--- a/src/dashboard/modules/i18n.js
+++ b/src/dashboard/modules/i18n.js
@@ -60,7 +60,7 @@ const translations = {
     'quality.trendFlat': 'Stable',
     'quality.trendUnknown': 'No trend yet',
 
-    // Notifications
+    // Notifications — toast labels (in-page)
     'notify.reviewStarted': 'Review started for !{{mrNumber}}',
     'notify.followupStarted': 'Follow-up started for !{{mrNumber}}',
     'notify.reviewCompleted': 'Review completed for !{{mrNumber}}',
@@ -69,6 +69,13 @@ const translations = {
     'notify.followupRequested': 'Follow-up requested for !{{mrNumber}}',
     'notify.reviewPendingConfirmation': 'Review awaiting your confirmation for !{{mrNumber}}',
     'notify.desktopTitle': 'Reviewflow alert',
+    // Notifications — desktop labels (short, used in rich payload)
+    'notify.label.reviewStarted': 'Review',
+    'notify.label.followupStarted': 'Follow-up',
+    'notify.label.reviewCompleted': 'Review done',
+    'notify.label.followupCompleted': 'Follow-up done',
+    'notify.label.reviewFailed': 'Review failed',
+    'notify.label.reviewPendingConfirmation': 'Awaiting confirmation',
 
     // Loading
     'loading.data': 'Syncing dashboard data...',
@@ -475,7 +482,7 @@ const translations = {
     'quality.trendFlat': 'Stable',
     'quality.trendUnknown': 'Pas de tendance',
 
-    // Notifications
+    // Notifications — toast labels (in-page)
     'notify.reviewStarted': 'Review démarrée pour !{{mrNumber}}',
     'notify.followupStarted': 'Follow-up démarré pour !{{mrNumber}}',
     'notify.reviewCompleted': 'Review terminée pour !{{mrNumber}}',
@@ -484,6 +491,13 @@ const translations = {
     'notify.followupRequested': 'Follow-up demandé pour !{{mrNumber}}',
     'notify.reviewPendingConfirmation': 'Review en attente de votre confirmation pour !{{mrNumber}}',
     'notify.desktopTitle': 'Alerte Reviewflow',
+    // Notifications — desktop labels (short, used in rich payload)
+    'notify.label.reviewStarted': 'Review',
+    'notify.label.followupStarted': 'Follow-up',
+    'notify.label.reviewCompleted': 'Review terminée',
+    'notify.label.followupCompleted': 'Follow-up terminé',
+    'notify.label.reviewFailed': 'Review échouée',
+    'notify.label.reviewPendingConfirmation': 'En attente',
 
     // Loading
     'loading.data': 'Synchronisation des données du dashboard...',

--- a/src/frameworks/queue/pQueueAdapter.ts
+++ b/src/frameworks/queue/pQueueAdapter.ts
@@ -28,6 +28,17 @@ export interface ReviewJob {
     username: string;
     displayName?: string;
   };
+  // The actual author of the MR/PR (distinct from assignedBy, which is the reviewer/assignee).
+  author?: {
+    username: string;
+    displayName?: string;
+  };
+  // Diff size metrics. Any field may be null when the platform does not provide it.
+  sizeMetrics?: {
+    additions: number | null;
+    deletions: number | null;
+    filesChanged: number | null;
+  };
   // SPEC-170 FR-8: clone URL of the source fork for cross-fork PRs (GitHub).
   // null/undefined means the MR/PR source is the same repository as the base.
   sourceForkCloneUrl?: string;
@@ -345,6 +356,8 @@ export function getJobsStatus(): {
     title?: string;
     description?: string;
     assignedBy?: { username: string; displayName?: string };
+    author?: { username: string; displayName?: string };
+    sizeMetrics?: { additions: number | null; deletions: number | null; filesChanged: number | null };
     jobType?: 'review' | 'followup';
   }>;
   recent: Array<{
@@ -359,6 +372,8 @@ export function getJobsStatus(): {
     progress?: ReviewProgress;
     title?: string;
     assignedBy?: { username: string; displayName?: string };
+    author?: { username: string; displayName?: string };
+    sizeMetrics?: { additions: number | null; deletions: number | null; filesChanged: number | null };
     jobType?: 'review' | 'followup';
   }>;
 } {
@@ -374,6 +389,8 @@ export function getJobsStatus(): {
       title: js.job.title,
       description: js.job.description,
       assignedBy: js.job.assignedBy,
+      author: js.job.author,
+      sizeMetrics: js.job.sizeMetrics,
       jobType: js.job.jobType || 'review',
     })),
     recent: completedJobs.map(js => ({
@@ -388,6 +405,8 @@ export function getJobsStatus(): {
       progress: js.progress,
       title: js.job.title,
       assignedBy: js.job.assignedBy,
+      author: js.job.author,
+      sizeMetrics: js.job.sizeMetrics,
       jobType: js.job.jobType || 'review',
     })),
   };

--- a/src/modules/platform-integration/entities/github/githubPullRequestEvent.guard.ts
+++ b/src/modules/platform-integration/entities/github/githubPullRequestEvent.guard.ts
@@ -11,6 +11,7 @@ const gitHubPullRequestEventSchema = z.object({
     state: z.enum(['open', 'closed']),
     draft: z.boolean(),
     html_url: z.string(),
+    user: z.object({ login: z.string() }).optional(),
     head: z.object({
       ref: z.string(),
       repo: z.object({
@@ -26,6 +27,9 @@ const gitHubPullRequestEventSchema = z.object({
     }),
     requested_reviewers: z.array(z.object({ login: z.string() })),
     assignees: z.array(z.object({ login: z.string() })).optional(),
+    additions: z.number().optional(),
+    deletions: z.number().optional(),
+    changed_files: z.number().optional(),
   }),
   repository: z.object({
     full_name: z.string(),

--- a/src/modules/platform-integration/interface-adapters/controllers/webhook/github.controller.ts
+++ b/src/modules/platform-integration/interface-adapters/controllers/webhook/github.controller.ts
@@ -705,6 +705,19 @@ export async function handleGitHubWebhook(
     username: prAssignee?.login || event.sender?.login || 'unknown',
     displayName: prAssignee?.login || event.sender?.login,
   };
+  const prAuthorLogin = event.pull_request?.user?.login;
+  const author = prAuthorLogin
+    ? { username: prAuthorLogin, displayName: prAuthorLogin }
+    : undefined;
+  const sizeMetrics = (event.pull_request?.additions !== undefined
+    || event.pull_request?.deletions !== undefined
+    || event.pull_request?.changed_files !== undefined)
+    ? {
+        additions: event.pull_request?.additions ?? null,
+        deletions: event.pull_request?.deletions ?? null,
+        filesChanged: event.pull_request?.changed_files ?? null,
+      }
+    : undefined;
 
   trackAssignment.execute({
     projectPath: repoConfig.localPath,
@@ -742,6 +755,8 @@ export async function handleGitHubWebhook(
     title: prTitle,
     description: event.pull_request?.body,
     assignedBy,
+    author,
+    sizeMetrics,
     sourceForkCloneUrl: computeSourceForkCloneUrl(event.pull_request),
   };
 

--- a/src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts
+++ b/src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts
@@ -719,6 +719,11 @@ export async function handleGitLabWebhook(
     username: mrAssignee?.username || event.user?.username || 'unknown',
     displayName: mrAssignee?.name || event.user?.name,
   };
+  // Best-effort author from the GitLab webhook (event.user is the actor that opened/updated the MR).
+  // The GitLab webhook does not expose diff size stats, so sizeMetrics stays undefined here.
+  const author = event.user?.username
+    ? { username: event.user.username, displayName: event.user.name }
+    : undefined;
 
   trackAssignment.execute({
     projectPath: repoConfig.localPath,
@@ -757,6 +762,7 @@ export async function handleGitLabWebhook(
     title: mrTitle,
     description: event.object_attributes?.description,
     assignedBy,
+    author,
   };
 
   const budgetDecision = await deps.enforceBudget.execute({

--- a/src/tests/units/dashboard/modules/desktopNotifications.test.ts
+++ b/src/tests/units/dashboard/modules/desktopNotifications.test.ts
@@ -186,6 +186,132 @@ describe('getDesktopNotificationPayload', () => {
     expect(result?.title.startsWith('⏳ Awaiting confirmation')).toBe(true);
   });
 
+  it('uses author.displayName in title when present (priority over assignedBy)', () => {
+    const result = getDesktopNotificationPayload(
+      {
+        kind: 'reviewStarted',
+        review: {
+          mrNumber: 100,
+          title: 'feat: x',
+          project: 'org/repo',
+          assignedBy: { displayName: 'Reviewer' },
+          author: { displayName: 'Author', username: 'author' },
+          id: 'gitlab-x',
+        },
+      },
+      translate,
+    );
+
+    expect(result?.title).toBe('🔍 Review · Author · !100');
+  });
+
+  it('falls back to author.username when displayName missing', () => {
+    const result = getDesktopNotificationPayload(
+      {
+        kind: 'reviewStarted',
+        review: {
+          mrNumber: 101,
+          title: 'feat: x',
+          project: 'org/repo',
+          author: { username: 'alice' },
+          id: 'gitlab-x',
+        },
+      },
+      translate,
+    );
+
+    expect(result?.title).toBe('🔍 Review · alice · !101');
+  });
+
+  it('falls back to assignedBy when author missing', () => {
+    const result = getDesktopNotificationPayload(
+      {
+        kind: 'reviewStarted',
+        review: {
+          mrNumber: 102,
+          project: 'org/repo',
+          assignedBy: { displayName: 'Bob' },
+          id: 'gitlab-x',
+        },
+      },
+      translate,
+    );
+
+    expect(result?.title).toBe('🔍 Review · Bob · !102');
+  });
+
+  it('renders 🪶 emoji and stats line for small size (additions+deletions < 50)', () => {
+    const result = getDesktopNotificationPayload(
+      {
+        kind: 'reviewStarted',
+        review: {
+          mrNumber: 200,
+          title: 'docs: update',
+          project: 'org/repo',
+          sizeMetrics: { additions: 20, deletions: 10, filesChanged: 2 },
+          id: 'gitlab-x',
+        },
+      },
+      translate,
+    );
+
+    expect(result?.body).toBe('docs: update\n🪶 +20/-10 · 2 files · repo');
+  });
+
+  it('renders 🚀 emoji for medium size (50-300 lines)', () => {
+    const result = getDesktopNotificationPayload(
+      {
+        kind: 'reviewStarted',
+        review: {
+          mrNumber: 201,
+          title: 'feat: middle',
+          project: 'org/repo',
+          sizeMetrics: { additions: 120, deletions: 45, filesChanged: 8 },
+          id: 'gitlab-x',
+        },
+      },
+      translate,
+    );
+
+    expect(result?.body).toBe('feat: middle\n🚀 +120/-45 · 8 files · repo');
+  });
+
+  it('renders 🐘 emoji for big size (>300 lines)', () => {
+    const result = getDesktopNotificationPayload(
+      {
+        kind: 'reviewStarted',
+        review: {
+          mrNumber: 202,
+          title: 'refactor: huge',
+          project: 'org/repo',
+          sizeMetrics: { additions: 700, deletions: 300, filesChanged: 25 },
+          id: 'gitlab-x',
+        },
+      },
+      translate,
+    );
+
+    expect(result?.body).toBe('refactor: huge\n🐘 +700/-300 · 25 files · repo');
+  });
+
+  it('renders size emoji even when additions/deletions are null but filesChanged is known', () => {
+    const result = getDesktopNotificationPayload(
+      {
+        kind: 'reviewStarted',
+        review: {
+          mrNumber: 203,
+          title: 'fix: small',
+          project: 'org/repo',
+          sizeMetrics: { additions: null, deletions: null, filesChanged: 3 },
+          id: 'gitlab-x',
+        },
+      },
+      translate,
+    );
+
+    expect(result?.body).toBe('fix: small\n🪶 3 files · repo');
+  });
+
   it('returns null for unknown notification kind', () => {
     const result = getDesktopNotificationPayload(
       {

--- a/src/tests/units/dashboard/modules/desktopNotifications.test.ts
+++ b/src/tests/units/dashboard/modules/desktopNotifications.test.ts
@@ -35,29 +35,158 @@ describe('shouldNotifyDesktop', () => {
 });
 
 describe('getDesktopNotificationPayload', () => {
-  const translate = (key: string, params?: Record<string, string | number>) => {
-    if (key === 'notify.desktopTitle') return 'Reviewflow alert';
-    if (key === 'notify.reviewStarted') return `Review started for !${params?.mrNumber}`;
-    return key;
+  const translate = (key: string) => {
+    const dictionary: Record<string, string> = {
+      'notify.label.reviewStarted': 'Review',
+      'notify.label.followupStarted': 'Follow-up',
+      'notify.label.reviewCompleted': 'Review done',
+      'notify.label.followupCompleted': 'Follow-up done',
+      'notify.label.reviewFailed': 'Review failed',
+      'notify.label.reviewPendingConfirmation': 'Awaiting confirmation',
+    };
+    return dictionary[key] ?? key;
   };
 
-  it('should map known notification kind to desktop payload', () => {
+  it('builds a rich payload with emoji, author, project and title for reviewStarted', () => {
     const result = getDesktopNotificationPayload(
       {
         kind: 'reviewStarted',
-        review: { mrNumber: 42 },
+        review: {
+          mrNumber: 1234,
+          title: 'feat(dashboard): add chart',
+          project: 'main-app-v3/frontend',
+          assignedBy: { displayName: 'Damien', username: 'dgouron' },
+          id: 'gitlab-main-app-v3-1234',
+          jobType: 'review',
+        },
       },
       translate,
     );
 
     expect(result).toEqual({
-      title: 'Reviewflow alert',
-      body: 'Review started for !42',
-      tag: 'reviewflow-reviewStarted-42',
+      title: '🔍 Review · Damien · !1234',
+      body: 'feat(dashboard): add chart\nfrontend',
+      tag: 'reviewflow-reviewStarted-1234',
     });
   });
 
-  it('should return null for unknown notification kind', () => {
+  it('uses # prefix and 🔁 emoji for github followupStarted', () => {
+    const result = getDesktopNotificationPayload(
+      {
+        kind: 'followupStarted',
+        review: {
+          mrNumber: 42,
+          title: 'fix(auth): token refresh',
+          project: 'org/repo',
+          assignedBy: { displayName: 'Alice' },
+          id: 'github-org-repo-42',
+          jobType: 'followup',
+        },
+      },
+      translate,
+    );
+
+    expect(result).toEqual({
+      title: '🔁 Follow-up · Alice · #42',
+      body: 'fix(auth): token refresh\nrepo',
+      tag: 'reviewflow-followupStarted-42',
+    });
+  });
+
+  it('falls back to username when displayName is missing', () => {
+    const result = getDesktopNotificationPayload(
+      {
+        kind: 'reviewStarted',
+        review: {
+          mrNumber: 7,
+          title: 'chore: bump deps',
+          project: 'org/repo',
+          assignedBy: { username: 'bob' },
+          id: 'gitlab-x',
+        },
+      },
+      translate,
+    );
+
+    expect(result?.title).toBe('🔍 Review · bob · !7');
+  });
+
+  it('omits author segment when assignedBy is missing', () => {
+    const result = getDesktopNotificationPayload(
+      {
+        kind: 'reviewStarted',
+        review: {
+          mrNumber: 9,
+          title: 'docs: update README',
+          project: 'org/repo',
+          id: 'gitlab-x',
+        },
+      },
+      translate,
+    );
+
+    expect(result?.title).toBe('🔍 Review · !9');
+  });
+
+  it('omits title line when title is missing', () => {
+    const result = getDesktopNotificationPayload(
+      {
+        kind: 'reviewStarted',
+        review: {
+          mrNumber: 11,
+          project: 'org/repo',
+          assignedBy: { displayName: 'Alice' },
+          id: 'gitlab-x',
+        },
+      },
+      translate,
+    );
+
+    expect(result?.body).toBe('repo');
+  });
+
+  it('uses ✅ for reviewCompleted', () => {
+    const result = getDesktopNotificationPayload(
+      {
+        kind: 'reviewCompleted',
+        review: {
+          mrNumber: 5,
+          title: 'feat: add login',
+          project: 'org/repo',
+          id: 'gitlab-x',
+        },
+      },
+      translate,
+    );
+
+    expect(result?.title.startsWith('✅ Review done')).toBe(true);
+  });
+
+  it('uses ❌ for reviewFailed', () => {
+    const result = getDesktopNotificationPayload(
+      {
+        kind: 'reviewFailed',
+        review: { mrNumber: 6, id: 'gitlab-x' },
+      },
+      translate,
+    );
+
+    expect(result?.title.startsWith('❌ Review failed')).toBe(true);
+  });
+
+  it('uses ⏳ for reviewPendingConfirmation', () => {
+    const result = getDesktopNotificationPayload(
+      {
+        kind: 'reviewPendingConfirmation',
+        review: { mrNumber: 8, id: 'gitlab-x' },
+      },
+      translate,
+    );
+
+    expect(result?.title.startsWith('⏳ Awaiting confirmation')).toBe(true);
+  });
+
+  it('returns null for unknown notification kind', () => {
     const result = getDesktopNotificationPayload(
       {
         kind: 'unknown',

--- a/src/tests/units/dashboard/modules/desktopNotifications.test.ts
+++ b/src/tests/units/dashboard/modules/desktopNotifications.test.ts
@@ -63,7 +63,7 @@ describe('getDesktopNotificationPayload', () => {
       translate,
     );
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       title: '🔍 Review · Damien · !1234',
       body: 'feat(dashboard): add chart\nfrontend',
       tag: 'reviewflow-reviewStarted-1234',
@@ -86,7 +86,7 @@ describe('getDesktopNotificationPayload', () => {
       translate,
     );
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       title: '🔁 Follow-up · Alice · #42',
       body: 'fix(auth): token refresh\nrepo',
       tag: 'reviewflow-followupStarted-42',
@@ -310,6 +310,60 @@ describe('getDesktopNotificationPayload', () => {
     );
 
     expect(result?.body).toBe('fix: small\n🪶 3 files · repo');
+  });
+
+  it('includes mrUrl in payload when present', () => {
+    const result = getDesktopNotificationPayload(
+      {
+        kind: 'reviewStarted',
+        review: {
+          mrNumber: 300,
+          mrUrl: 'https://gitlab.example.com/group/repo/-/merge_requests/300',
+          id: 'gitlab-x',
+        },
+      },
+      translate,
+    );
+
+    expect(result?.url).toBe('https://gitlab.example.com/group/repo/-/merge_requests/300');
+  });
+
+  it('omits url when mrUrl is missing', () => {
+    const result = getDesktopNotificationPayload(
+      {
+        kind: 'reviewStarted',
+        review: { mrNumber: 301, id: 'gitlab-x' },
+      },
+      translate,
+    );
+
+    expect(result?.url).toBeNull();
+  });
+
+  it('returns a GitLab-colored icon data URI for gitlab platform', () => {
+    const result = getDesktopNotificationPayload(
+      {
+        kind: 'reviewStarted',
+        review: { mrNumber: 400, id: 'gitlab-x' },
+      },
+      translate,
+    );
+
+    expect(result?.iconDataUri).toMatch(/^data:image\/svg\+xml/);
+    expect(result?.iconDataUri).toContain('FC6D26');
+  });
+
+  it('returns a GitHub-colored icon data URI for github platform', () => {
+    const result = getDesktopNotificationPayload(
+      {
+        kind: 'reviewStarted',
+        review: { mrNumber: 401, id: 'github-org-repo-401' },
+      },
+      translate,
+    );
+
+    expect(result?.iconDataUri).toMatch(/^data:image\/svg\+xml/);
+    expect(result?.iconDataUri).toContain('181717');
   });
 
   it('returns null for unknown notification kind', () => {


### PR DESCRIPTION
## Summary

Three-phase enrichment of the desktop notifications so reviewers can decide at a glance whether to engage with a new MR/PR.

- **Phase 1 — content** (`24feb0d`): title now carries an emoji + label + author + MR/PR number (e.g. `🔍 Review · damien · !1234`); body shows the MR title and short project name. Per-kind emoji mapping (`🔍` review, `🔁` follow-up, `✅` done, `❌` failed, `⏳` pending). Falls back to `assignedBy` when no other author is known.
- **Phase 2 — backend propagation** (`f38910e`): `ReviewJob` now carries `author` and `sizeMetrics`. GitHub webhook extracts `pull_request.user.login` + `additions` / `deletions` / `changed_files`. GitLab webhook extracts `event.user` as best-effort author (the GitLab MR webhook does not expose diff stats). `getJobsStatus` exposes both fields. The notification renders a size emoji (`🪶` < 50 LOC, `🚀` 50–300, `🐘` > 300) with `+A/-D · N files` on a second body line.
- **Phase 3 — interactivity** (`2ad88b9`): payload now carries `mrUrl` and an inline-SVG `iconDataUri` (orange `GL` for GitLab, dark `GH` for GitHub). Clicking the notif focuses the window and opens the MR/PR in a new tab.

## Visual result

```
┌──────┐ 🔍 Review · damien · #1234
│  GH  │ feat(dashboard): add chart
│      │ 🚀 +120/-45 · 8 files · frontend
└──────┘
```

## Tweak points (centralized)

- `KIND_FORMATS` (per-event emoji + label key) — `src/dashboard/modules/desktopNotifications.js`
- `SIZE_THRESHOLD_SMALL_MAX` / `SIZE_THRESHOLD_MEDIUM_MAX` (size buckets)
- `SIZE_EMOJI` (`🪶` / `🚀` / `🐘`)
- `PLATFORM_ICONS` (hex colors `FC6D26` / `181717`)

## Known limitations

- GitLab webhook MR has no diff stats, so the size emoji currently only shows on GitHub PRs. Adding `glab api .../merge_requests/N` in the gitlab controller (~10 lines) would close the gap.
- Followup jobs (push events) still ship without the new `title` / `author` / `sizeMetrics` — cohérent with the existing behaviour but worth a follow-up scope if you want the follow-up notif equally rich.

## Test plan

- [x] `yarn test:ci` — 2275/2275 pass (19 new tests on `desktopNotifications`, type-safe `ReviewJob` extension covered indirectly through unchanged usecases).
- [ ] Restart `reviewflow-app` after merge + `yarn build`, then trigger a real PR/MR and confirm the notif renders + click opens the MR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)