### PR TITLE
fix(worktree): preserve sub-path between localPath and gitRoot when launching Claude

### DIFF
--- a/src/frameworks/claude/claudeInvoker.ts
+++ b/src/frameworks/claude/claudeInvoker.ts
@@ -47,6 +47,8 @@ import type { WorktreeGateway } from '@/modules/worktree-management/entities/wor
 import type { MrSource } from '@/modules/worktree-management/entities/worktree/worktree.schema.js';
 import { WorktreeFileSystemGateway } from '@/modules/worktree-management/interface-adapters/gateways/worktree.fileSystem.gateway.js';
 import { GitCommandCliGateway } from '@/modules/worktree-management/interface-adapters/gateways/gitCommand.cli.gateway.js';
+import type { GitCommandExecutor } from '@/modules/worktree-management/entities/gitCommand/gitCommand.gateway.js';
+import { resolveClaudeCwd } from '@/modules/worktree-management/services/claudeCwd.js';
 
 /**
  * Bundle of gateways needed by runClaudeReviewJob. Built in the composition
@@ -82,6 +84,7 @@ export interface ClaudeInvokerDependencies {
   getEnabledLocalPaths?: () => string[];
   invocation: ClaudeInvocationDeps;
   worktreeGateway: WorktreeGateway;
+  gitExecutor: GitCommandExecutor;
 }
 
 /**
@@ -159,6 +162,7 @@ export function createDefaultClaudeInvocationDeps(): ClaudeInvocationDeps {
 export function createDefaultClaudeInvokerDependencies(): ClaudeInvokerDependencies {
   const tokenUsageGateway = new FilesystemTokenUsageGateway();
   const budgetGateway = new FilesystemBudgetGateway();
+  const gitExecutor = new GitCommandCliGateway();
   return {
     diffStatsFetchFactory: platform =>
       platform === 'github'
@@ -172,7 +176,8 @@ export function createDefaultClaudeInvokerDependencies(): ClaudeInvokerDependenc
     budgetStatusPresenter: new BudgetStatusPresenter(),
     broadcastBudgetStatus: () => {},
     invocation: createDefaultClaudeInvocationDeps(),
-    worktreeGateway: new WorktreeFileSystemGateway({ executor: new GitCommandCliGateway() }),
+    worktreeGateway: new WorktreeFileSystemGateway({ executor: gitExecutor }),
+    gitExecutor,
   };
 }
 
@@ -578,6 +583,17 @@ async function invokeViaBackgroundSession(
   }
 
   const worktreePath = ensureResult.path;
+  const claudeCwd = await resolveClaudeCwd({
+    localPath: job.localPath,
+    worktreePath,
+    executor: deps.gitExecutor,
+  });
+  if (claudeCwd !== worktreePath) {
+    logger.info(
+      { jobId: job.id, worktreePath, claudeCwd },
+      'Claude cwd points to a sub-path of the worktree (monorepo source checkout)',
+    );
+  }
   // attempt counter is reserved for the queue layer to re-enqueue with backoff
   // when status === 'retry' is returned. Until that wiring exists, every
   // invocation is treated as attempt 0 and a single retry signal surfaces back
@@ -601,7 +617,7 @@ async function invokeViaBackgroundSession(
         jobType,
         prompt,
         flags,
-        localPath: worktreePath,
+        localPath: claudeCwd,
         mergeRequestId,
         mergeRequestNumber: job.mrNumber,
         attempt,
@@ -696,7 +712,7 @@ async function invokeViaBackgroundSession(
       }
     } else {
       logger.warn(
-        { jobId: job.id, sessionContext: worktreePath },
+        { jobId: job.id, sessionContext: claudeCwd },
         'Token usage unavailable for --bg review (missing or unparseable JSONL transcript)',
       );
     }

--- a/src/modules/worktree-management/entities/gitCommand/gitCommand.gateway.ts
+++ b/src/modules/worktree-management/entities/gitCommand/gitCommand.gateway.ts
@@ -3,7 +3,8 @@ export type GitCommandKind =
   | 'worktree-add'
   | 'worktree-remove'
   | 'worktree-prune'
-  | 'reset-hard';
+  | 'reset-hard'
+  | 'rev-parse-toplevel';
 
 export interface GitCommand {
   kind: GitCommandKind;

--- a/src/modules/worktree-management/services/claudeCwd.ts
+++ b/src/modules/worktree-management/services/claudeCwd.ts
@@ -1,0 +1,71 @@
+import { isAbsolute, relative } from 'node:path';
+import type {
+  GitCommandExecutor,
+} from '@/modules/worktree-management/entities/gitCommand/gitCommand.gateway.js';
+import type { WorktreePath } from '@/modules/worktree-management/entities/worktree/worktree.schema.js';
+
+export interface ComputeClaudeCwdInput {
+  localPath: string;
+  gitRoot: string;
+  worktreePath: WorktreePath;
+}
+
+function stripTrailingSlash(value: string): string {
+  if (value.length > 1 && value.endsWith('/')) {
+    return value.slice(0, -1);
+  }
+  return value;
+}
+
+export function computeClaudeCwd(input: ComputeClaudeCwdInput): string {
+  const localPath = stripTrailingSlash(input.localPath);
+  const gitRoot = stripTrailingSlash(input.gitRoot);
+  const worktreePath = stripTrailingSlash(input.worktreePath);
+
+  const subPath = relative(gitRoot, localPath);
+
+  if (subPath === '') {
+    return worktreePath;
+  }
+
+  if (subPath.startsWith('..') || isAbsolute(subPath)) {
+    throw new Error(
+      `localPath ${input.localPath} is not inside gitRoot ${input.gitRoot}`,
+    );
+  }
+
+  return `${worktreePath}/${subPath}`;
+}
+
+export interface ResolveClaudeCwdInput {
+  localPath: string;
+  worktreePath: WorktreePath;
+  executor: GitCommandExecutor;
+}
+
+export async function resolveClaudeCwd(input: ResolveClaudeCwdInput): Promise<string> {
+  const result = await input.executor.execute({
+    kind: 'rev-parse-toplevel',
+    args: ['rev-parse', '--show-toplevel'],
+    cwd: input.localPath,
+  });
+
+  if (result.exitCode !== 0) {
+    return input.worktreePath;
+  }
+
+  const gitRoot = result.stdout.trim();
+  if (gitRoot.length === 0) {
+    return input.worktreePath;
+  }
+
+  try {
+    return computeClaudeCwd({
+      localPath: input.localPath,
+      gitRoot,
+      worktreePath: input.worktreePath,
+    });
+  } catch {
+    return input.worktreePath;
+  }
+}

--- a/src/tests/units/modules/worktree-management/services/claudeCwd.test.ts
+++ b/src/tests/units/modules/worktree-management/services/claudeCwd.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeClaudeCwd,
+  resolveClaudeCwd,
+} from '@/modules/worktree-management/services/claudeCwd.js';
+import type {
+  GitCommand,
+  GitCommandExecutor,
+  GitCommandResult,
+} from '@/modules/worktree-management/entities/gitCommand/gitCommand.gateway.js';
+import { createWorktreePath } from '@/modules/worktree-management/entities/worktree/worktree.js';
+
+function stubExecutor(commands: { stdout: string; exitCode?: number }[]): {
+  executor: GitCommandExecutor;
+  calls: GitCommand[];
+} {
+  const calls: GitCommand[] = [];
+  let index = 0;
+  const executor: GitCommandExecutor = {
+    async execute(command: GitCommand): Promise<GitCommandResult> {
+      calls.push(command);
+      const next = commands[index];
+      index += 1;
+      return {
+        stdout: next?.stdout ?? '',
+        stderr: '',
+        exitCode: next?.exitCode ?? 0,
+      };
+    },
+  };
+  return { executor, calls };
+}
+
+describe('computeClaudeCwd', () => {
+  it('returns the worktree path unchanged when localPath equals gitRoot', () => {
+    const worktreePath = createWorktreePath('/wt/gitlab-acme-42');
+    const result = computeClaudeCwd({
+      localPath: '/home/user/repos/acme',
+      gitRoot: '/home/user/repos/acme',
+      worktreePath,
+    });
+    expect(result).toBe('/wt/gitlab-acme-42');
+  });
+
+  it('appends the relative sub-path when localPath sits inside a monorepo', () => {
+    const worktreePath = createWorktreePath('/wt/gitlab-acme-42');
+    const result = computeClaudeCwd({
+      localPath: '/home/user/repos/acme/frontend',
+      gitRoot: '/home/user/repos/acme',
+      worktreePath,
+    });
+    expect(result).toBe('/wt/gitlab-acme-42/frontend');
+  });
+
+  it('appends a nested sub-path for deeper checkouts', () => {
+    const worktreePath = createWorktreePath('/wt/gitlab-acme-42');
+    const result = computeClaudeCwd({
+      localPath: '/home/user/repos/acme/apps/dashboard',
+      gitRoot: '/home/user/repos/acme',
+      worktreePath,
+    });
+    expect(result).toBe('/wt/gitlab-acme-42/apps/dashboard');
+  });
+
+  it('normalises trailing slashes on localPath and gitRoot', () => {
+    const worktreePath = createWorktreePath('/wt/gitlab-acme-42');
+    const result = computeClaudeCwd({
+      localPath: '/home/user/repos/acme/frontend/',
+      gitRoot: '/home/user/repos/acme/',
+      worktreePath,
+    });
+    expect(result).toBe('/wt/gitlab-acme-42/frontend');
+  });
+
+  it('throws when localPath is not contained in gitRoot', () => {
+    const worktreePath = createWorktreePath('/wt/gitlab-acme-42');
+    expect(() =>
+      computeClaudeCwd({
+        localPath: '/elsewhere/project',
+        gitRoot: '/home/user/repos/acme',
+        worktreePath,
+      }),
+    ).toThrow(/not inside/i);
+  });
+});
+
+describe('resolveClaudeCwd', () => {
+  it('queries git rev-parse --show-toplevel and applies the relative sub-path', async () => {
+    const { executor, calls } = stubExecutor([
+      { stdout: '/home/user/repos/acme\n' },
+    ]);
+    const worktreePath = createWorktreePath('/wt/gitlab-acme-42');
+
+    const result = await resolveClaudeCwd({
+      localPath: '/home/user/repos/acme/frontend',
+      worktreePath,
+      executor,
+    });
+
+    expect(result).toBe('/wt/gitlab-acme-42/frontend');
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      kind: 'rev-parse-toplevel',
+      args: ['rev-parse', '--show-toplevel'],
+      cwd: '/home/user/repos/acme/frontend',
+    });
+  });
+
+  it('returns the worktree path unchanged when the source checkout is already the git root', async () => {
+    const { executor } = stubExecutor([
+      { stdout: '/home/user/repos/acme\n' },
+    ]);
+    const worktreePath = createWorktreePath('/wt/gitlab-acme-42');
+
+    const result = await resolveClaudeCwd({
+      localPath: '/home/user/repos/acme',
+      worktreePath,
+      executor,
+    });
+
+    expect(result).toBe('/wt/gitlab-acme-42');
+  });
+
+  it('falls back to the worktree path when rev-parse fails', async () => {
+    const { executor } = stubExecutor([
+      { stdout: '', exitCode: 128 },
+    ]);
+    const worktreePath = createWorktreePath('/wt/gitlab-acme-42');
+
+    const result = await resolveClaudeCwd({
+      localPath: '/home/user/repos/acme/frontend',
+      worktreePath,
+      executor,
+    });
+
+    expect(result).toBe('/wt/gitlab-acme-42');
+  });
+});


### PR DESCRIPTION
## Summary
- Restores Claude CLI cwd to the project sub-path (`localPath`) instead of the worktree's git root
- Fixes `Unknown command: /review-front` failures on monorepo source checkouts (e.g. `main-app-v3/frontend`) introduced by SPEC-170
- New `worktree-management/services/claudeCwd.ts` queries `git rev-parse --show-toplevel`, computes the relative sub-path, and joins it onto the worktree path
- Zero impact on repos where `localPath === gitRoot` (sub-path = "")

## Why
Before SPEC-170 (commit `0474587`), Claude was spawned in `job.localPath` directly. Since the worktree migration, it spawns in the worktree path — always the git root, because git worktrees can only branch from the root. When `localPath` sits in a sub-directory (monorepo), Claude no longer sees the project-local `.claude/skills/` directory and rejects the review skill.

## Test plan
- [x] 8 new unit tests in `claudeCwd.test.ts` (GREEN)
- [x] `yarn verify` — 2265/2265 tests pass, typecheck OK, lint OK
- [ ] Live verification on `main-app-v3` review after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)