### PR TITLE
fix(claude-invocation): fall back to worktree root for review report lookup

### DIFF
--- a/src/frameworks/claude/claudeInvoker.ts
+++ b/src/frameworks/claude/claudeInvoker.ts
@@ -618,6 +618,7 @@ async function invokeViaBackgroundSession(
         prompt,
         flags,
         localPath: claudeCwd,
+        reportFallbackLocalPath: worktreePath,
         mergeRequestId,
         mergeRequestNumber: job.mrNumber,
         attempt,

--- a/src/modules/claude-invocation/usecases/retrieveReviewReport.usecase.ts
+++ b/src/modules/claude-invocation/usecases/retrieveReviewReport.usecase.ts
@@ -8,6 +8,7 @@ export interface RetrieveReviewReportInput {
   session: ClaudeSession;
   today: Date;
   mergeRequestNumber: number;
+  fallbackLocalPath?: string;
 }
 
 export interface RetrieveReviewReportDependencies {
@@ -26,16 +27,28 @@ export function retrieveReviewReport(
   input: RetrieveReviewReportInput,
   deps: RetrieveReviewReportDependencies,
 ): RetrieveReviewReportResult {
-  const location: ReviewReportLocation = {
+  const primary: ReviewReportLocation = {
     localPath: input.session.localPath,
     isoDate: formatIsoDate(input.today),
     mergeRequestNumber: input.mergeRequestNumber,
     jobType: input.session.jobType,
   };
 
-  const found = deps.reportGateway.read(location);
-  if (found) {
-    return { status: 'found', content: found.content, path: found.path };
+  const primaryHit = deps.reportGateway.read(primary);
+  if (primaryHit) {
+    return { status: 'found', content: primaryHit.content, path: primaryHit.path };
   }
-  return { status: 'missing', expectedPath: deps.reportGateway.buildPath(location) };
+
+  if (
+    input.fallbackLocalPath !== undefined &&
+    input.fallbackLocalPath !== input.session.localPath
+  ) {
+    const fallback: ReviewReportLocation = { ...primary, localPath: input.fallbackLocalPath };
+    const fallbackHit = deps.reportGateway.read(fallback);
+    if (fallbackHit) {
+      return { status: 'found', content: fallbackHit.content, path: fallbackHit.path };
+    }
+  }
+
+  return { status: 'missing', expectedPath: deps.reportGateway.buildPath(primary) };
 }

--- a/src/modules/claude-invocation/usecases/runClaudeReviewJob.usecase.ts
+++ b/src/modules/claude-invocation/usecases/runClaudeReviewJob.usecase.ts
@@ -21,6 +21,7 @@ export interface RunClaudeReviewJobInput {
   prompt: string;
   flags: ClaudeDispatchFlags;
   localPath: string;
+  reportFallbackLocalPath?: string;
   mergeRequestId: string;
   mergeRequestNumber: number;
   attempt: number;
@@ -154,6 +155,7 @@ export async function runClaudeReviewJob(
       session,
       today: deps.now(),
       mergeRequestNumber: input.mergeRequestNumber,
+      fallbackLocalPath: input.reportFallbackLocalPath,
     },
     { reportGateway: deps.reportGateway },
   );

--- a/src/tests/stubs/reviewReport.stub.ts
+++ b/src/tests/stubs/reviewReport.stub.ts
@@ -10,17 +10,26 @@ export class StubReviewReportGateway implements ReviewReportGateway {
     content: '# Stub report',
     path: '/tmp/project/.claude/reviews/2026-05-22-MR-42-review.md',
   };
+  private readStrategy: ((location: ReviewReportLocation) => ReviewReportContent | null) | null = null;
 
   lastReadJobType: ClaudeSessionJobType | null = null;
   readCallCount = 0;
 
   setReport(report: ReviewReportContent | null): void {
     this.report = report;
+    this.readStrategy = null;
+  }
+
+  setReadStrategy(strategy: (location: ReviewReportLocation) => ReviewReportContent | null): void {
+    this.readStrategy = strategy;
   }
 
   read(location: ReviewReportLocation): ReviewReportContent | null {
     this.lastReadJobType = location.jobType;
     this.readCallCount += 1;
+    if (this.readStrategy !== null) {
+      return this.readStrategy(location);
+    }
     return this.report;
   }
 

--- a/src/tests/units/modules/claude-invocation/usecases/retrieveReviewReport.usecase.test.ts
+++ b/src/tests/units/modules/claude-invocation/usecases/retrieveReviewReport.usecase.test.ts
@@ -63,4 +63,73 @@ describe('retrieveReviewReport use case', () => {
       expect(result.expectedPath).toContain('followup');
     }
   });
+
+  it('falls back to fallbackLocalPath when the primary location is missing', () => {
+    const reportGateway = new StubReviewReportGateway();
+    reportGateway.setReadStrategy((location) => {
+      if (location.localPath === '/wt/repo/frontend') return null;
+      if (location.localPath === '/wt/repo') {
+        return {
+          content: '# Fallback found',
+          path: '/wt/repo/.claude/reviews/2026-05-22-MR-42-review.md',
+        };
+      }
+      return null;
+    });
+
+    const result = retrieveReviewReport(
+      {
+        session: ClaudeSessionFactory.create({ localPath: '/wt/repo/frontend' }),
+        today: new Date('2026-05-22T10:00:00Z'),
+        mergeRequestNumber: 42,
+        fallbackLocalPath: '/wt/repo',
+      },
+      { reportGateway },
+    );
+
+    expect(result.status).toBe('found');
+    if (result.status === 'found') {
+      expect(result.content).toBe('# Fallback found');
+      expect(result.path).toBe('/wt/repo/.claude/reviews/2026-05-22-MR-42-review.md');
+    }
+  });
+
+  it('does not query the fallback when the primary location resolves', () => {
+    const reportGateway = new StubReviewReportGateway();
+    reportGateway.setReadStrategy(() => ({
+      content: '# Primary',
+      path: '/wt/repo/frontend/.claude/reviews/2026-05-22-MR-42-review.md',
+    }));
+
+    const result = retrieveReviewReport(
+      {
+        session: ClaudeSessionFactory.create({ localPath: '/wt/repo/frontend' }),
+        today: new Date('2026-05-22T10:00:00Z'),
+        mergeRequestNumber: 42,
+        fallbackLocalPath: '/wt/repo',
+      },
+      { reportGateway },
+    );
+
+    expect(result.status).toBe('found');
+    expect(reportGateway.readCallCount).toBe(1);
+  });
+
+  it('ignores fallbackLocalPath when it equals the primary path', () => {
+    const reportGateway = new StubReviewReportGateway();
+    reportGateway.setReport(null);
+
+    const result = retrieveReviewReport(
+      {
+        session: ClaudeSessionFactory.create({ localPath: '/wt/repo' }),
+        today: new Date('2026-05-22T10:00:00Z'),
+        mergeRequestNumber: 42,
+        fallbackLocalPath: '/wt/repo',
+      },
+      { reportGateway },
+    );
+
+    expect(result.status).toBe('missing');
+    expect(reportGateway.readCallCount).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `fallbackLocalPath` to `retrieveReviewReport` — retried once if the primary `localPath` lookup misses
- `claudeInvoker` passes `worktreePath` as fallback, covering monorepo projects whose review skill writes the report at the git root (e.g. main-app-v3 `/.claude/reviews/`)
- For repos where `localPath === gitRoot`, the fallback dedupes against the primary and the behaviour is unchanged

## Why
PR #216 restored Claude's cwd to the project sub-path so skills are visible again. But on main-app-v3, the `review-front` skill instructs Claude to write the report into `/.claude/reviews/` — resolved by Claude as the worktree git root, not the sub-path. Reviews ran to completion (7 min) but `retrieveReviewReport` then returned `report-missing` because it only looked in `<worktree>/frontend/.claude/reviews/`.

## Test plan
- [x] 3 new unit tests on `retrieveReviewReport`: fallback hit, primary hit (no fallback call), dedup when identical paths
- [x] `yarn verify` — 2306/2306 tests pass, typecheck OK, lint OK
- [ ] Live verification: re-run a review on a main-app-v3 MR after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)