### PR TITLE
fix(followup): resolve sourceBranch from TrackedMr instead of 'unknown'

### DIFF
--- a/src/modules/tracking/interface-adapters/controllers/http/mrTrackingAdvanced.routes.ts
+++ b/src/modules/tracking/interface-adapters/controllers/http/mrTrackingAdvanced.routes.ts
@@ -105,6 +105,7 @@ export const mrTrackingAdvancedRoutes: FastifyPluginAsync<MrTrackingAdvancedRout
 
     const [, platform, , mrNumberStr] = match;
     const mrNumber = Number.parseInt(mrNumberStr, 10);
+    const platformLiteral: Platform = platform === 'github' ? 'github' : 'gitlab';
 
     const repo = getRepositories().find(
       (r) => r.localPath === validation.path && r.enabled
@@ -112,6 +113,16 @@ export const mrTrackingAdvancedRoutes: FastifyPluginAsync<MrTrackingAdvancedRout
     if (!repo) {
       reply.code(404);
       return { success: false, error: 'Repository not configured' };
+    }
+
+    const trackedMr = reviewRequestTrackingGateway.getByNumber(
+      validation.path,
+      mrNumber,
+      platformLiteral,
+    );
+    if (!trackedMr) {
+      reply.code(404);
+      return { success: false, error: 'MR not tracked' };
     }
 
     const projectConfig = loadProjectConfig(validation.path);
@@ -133,7 +144,6 @@ export const mrTrackingAdvancedRoutes: FastifyPluginAsync<MrTrackingAdvancedRout
         .map((repository) => repository.localPath),
     });
     if (!budgetDecision.accepted) {
-      const platformLiteral: 'gitlab' | 'github' = platform === 'github' ? 'github' : 'gitlab';
       logger.warn(
         {
           mrNumber,
@@ -155,14 +165,14 @@ export const mrTrackingAdvancedRoutes: FastifyPluginAsync<MrTrackingAdvancedRout
 
     const manualFollowupJob: ReviewJob = {
       id: jobId,
-      platform: platform as 'gitlab' | 'github',
+      platform: platformLiteral,
       projectPath: gitProjectPath,
       localPath: repo.localPath,
       mrNumber,
       mrUrl,
       skill,
-      sourceBranch: 'unknown',
-      targetBranch: 'unknown',
+      sourceBranch: trackedMr.sourceBranch,
+      targetBranch: trackedMr.targetBranch,
       jobType: 'followup',
     };
 

--- a/src/tests/units/modules/tracking/interface-adapters/controllers/http/mrTrackingAdvanced.routes.test.ts
+++ b/src/tests/units/modules/tracking/interface-adapters/controllers/http/mrTrackingAdvanced.routes.test.ts
@@ -30,17 +30,21 @@ import Fastify, { type FastifyInstance } from 'fastify';
 import { mrTrackingAdvancedRoutes } from '@/modules/tracking/interface-adapters/controllers/http/mrTrackingAdvanced.routes.js';
 import { enqueueReview } from '@/frameworks/queue/pQueueAdapter.js';
 import { createStubLogger } from '@/tests/stubs/logger.stub.js';
+import { TrackedMrFactory } from '@/tests/factories/trackedMr.factory.js';
+import type { TrackedMr } from '@/modules/tracking/entities/tracking/trackedMr.js';
 
 interface BuildAppOptions {
   enforceBudgetAccepted: boolean;
   consumedUsd?: number;
   limitUsd?: number;
+  trackedMr?: TrackedMr | null;
 }
 
 interface AppBundle {
   app: FastifyInstance;
   broadcastBudgetExceeded: ReturnType<typeof vi.fn>;
   enforceBudgetExecute: ReturnType<typeof vi.fn>;
+  getByNumber: ReturnType<typeof vi.fn>;
 }
 
 async function buildApp(options: BuildAppOptions): Promise<AppBundle> {
@@ -59,6 +63,9 @@ async function buildApp(options: BuildAppOptions): Promise<AppBundle> {
     },
   }));
 
+  const trackedMrValue = options.trackedMr === undefined ? null : options.trackedMr;
+  const getByNumber = vi.fn(() => trackedMrValue);
+
   const app = Fastify();
   await app.register(mrTrackingAdvancedRoutes, {
     getRepositories: () => [
@@ -73,7 +80,7 @@ async function buildApp(options: BuildAppOptions): Promise<AppBundle> {
     ],
     reviewRequestTrackingGateway: {
       getById: vi.fn(() => null),
-      getByNumber: vi.fn(() => null),
+      getByNumber,
       create: vi.fn(),
       update: vi.fn(),
       getByState: vi.fn(() => []),
@@ -96,7 +103,7 @@ async function buildApp(options: BuildAppOptions): Promise<AppBundle> {
     logger: createStubLogger(),
   });
 
-  return { app, broadcastBudgetExceeded, enforceBudgetExecute };
+  return { app, broadcastBudgetExceeded, enforceBudgetExecute, getByNumber };
 }
 
 describe('mrTrackingAdvancedRoutes POST /api/mr-tracking/followup', () => {
@@ -109,6 +116,13 @@ describe('mrTrackingAdvancedRoutes POST /api/mr-tracking/followup', () => {
       enforceBudgetAccepted: false,
       consumedUsd: 200.1,
       limitUsd: 200,
+      trackedMr: TrackedMrFactory.create({
+        id: 'gitlab-test-org/test-project-42',
+        mrNumber: 42,
+        project: 'test-org/test-project',
+        sourceBranch: 'feature/refresh',
+        targetBranch: 'main',
+      }),
     });
 
     const response = await app.inject({
@@ -136,9 +150,16 @@ describe('mrTrackingAdvancedRoutes POST /api/mr-tracking/followup', () => {
     await app.close();
   });
 
-  it('enqueues the followup when enforceBudget accepts', async () => {
-    const { app, broadcastBudgetExceeded, enforceBudgetExecute } = await buildApp({
+  it('enqueues the followup with sourceBranch and targetBranch from TrackedMr when MR is tracked', async () => {
+    const { app, broadcastBudgetExceeded, enforceBudgetExecute, getByNumber } = await buildApp({
       enforceBudgetAccepted: true,
+      trackedMr: TrackedMrFactory.create({
+        id: 'gitlab-test-org/test-project-42',
+        mrNumber: 42,
+        project: 'test-org/test-project',
+        sourceBranch: 'feature/refresh',
+        targetBranch: 'main',
+      }),
     });
 
     await app.inject({
@@ -150,9 +171,40 @@ describe('mrTrackingAdvancedRoutes POST /api/mr-tracking/followup', () => {
       },
     });
 
+    expect(getByNumber).toHaveBeenCalledWith('/home/user/projects/test', 42, 'gitlab');
     expect(enforceBudgetExecute).toHaveBeenCalled();
-    expect(enqueueReview).toHaveBeenCalled();
+    expect(enqueueReview).toHaveBeenCalledTimes(1);
+    const enqueuedJob = (enqueueReview as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(enqueuedJob).toMatchObject({
+      mrNumber: 42,
+      sourceBranch: 'feature/refresh',
+      targetBranch: 'main',
+      jobType: 'followup',
+    });
     expect(broadcastBudgetExceeded).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('rejects with 404 and does not enqueue when the MR is not tracked', async () => {
+    const { app, enforceBudgetExecute } = await buildApp({
+      enforceBudgetAccepted: true,
+      trackedMr: null,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/followup',
+      payload: {
+        mrId: 'gitlab-test-org/test-project-42',
+        projectPath: '/home/user/projects/test',
+      },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toEqual({ success: false, error: 'MR not tracked' });
+    expect(enforceBudgetExecute).not.toHaveBeenCalled();
+    expect(enqueueReview).not.toHaveBeenCalled();
 
     await app.close();
   });


### PR DESCRIPTION
## Summary

- Manual followup route (`POST /api/mr-tracking/followup`) hardcoded `sourceBranch: 'unknown'` / `targetBranch: 'unknown'` in the enqueued `ReviewJob`.
- Downstream, `ensureWorktree` then ran `git fetch origin unknown` and consistently failed with `branch-not-found`, breaking every manually-triggered followup (visible in logs as "Préparation worktree échouée { reason: branch-not-found }").
- The route now looks up the `TrackedMr` via `reviewRequestTrackingGateway.getByNumber(...)` and uses its real `sourceBranch` / `targetBranch`.
- If the MR is not tracked, the route responds `404 { error: 'MR not tracked' }` without consuming budget.
- Drive-by: removed an unsafe `platform as 'gitlab' | 'github'` cast (forbidden by `coding-standards.md`) and replaced it with a narrowed `platformLiteral` introduced at handler scope.

## Known gap (not in this PR)

If the source branch has been deleted on GitLab/GitHub, `git fetch origin <branch>` will still fail even with the correct branch name. A follow-up scope can add a `refs/merge-requests/<N>/head` (GitLab) / `refs/pull/<N>/head` (GitHub) fallback inside `ensureWorktree`.

## Test plan

- [x] New test: route enqueues a job with `sourceBranch` / `targetBranch` taken from `TrackedMr`
- [x] New test: route returns 404 and skips `enforceBudget` when MR is not tracked
- [x] Existing test (budget-exceeded path) still green
- [x] `yarn verify` passes locally (typecheck + lint + 2307 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)