### PR TITLE
fix(settings): persist runtime settings across restarts

### DIFF
--- a/src/frameworks/settings/runtimeSettings.ts
+++ b/src/frameworks/settings/runtimeSettings.ts
@@ -1,23 +1,23 @@
 import { existsSync, readFileSync } from 'node:fs';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, rename, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { z } from 'zod';
 import { languageSchema, type Language } from '@/modules/shared-kernel/entities/language/language.schema.js';
 
-export type ClaudeModel = 'haiku' | 'sonnet' | 'opus';
-
-const claudeModelSchema = z.enum(['haiku', 'sonnet', 'opus']);
+export const claudeModelSchema = z.enum(['haiku', 'sonnet', 'opus']);
+export type ClaudeModel = z.infer<typeof claudeModelSchema>;
 
 const runtimeSettingsSchema = z.object({
   language: languageSchema,
   model: claudeModelSchema,
 });
 
-interface RuntimeSettings {
-  model: ClaudeModel;
-  language: Language;
-}
+type RuntimeSettings = z.infer<typeof runtimeSettingsSchema>;
+
+type SettingsLogger = {
+  warn: (message: string) => void;
+};
 
 const DEFAULT_SETTINGS: RuntimeSettings = {
   model: 'opus',
@@ -26,6 +26,8 @@ const DEFAULT_SETTINGS: RuntimeSettings = {
 
 let settings: RuntimeSettings = { ...DEFAULT_SETTINGS };
 let settingsPath: string | null = null;
+let logger: SettingsLogger = { warn: (message) => console.warn(message) };
+let writeQueue: Promise<void> = Promise.resolve();
 
 export function getDefaultSettingsPath(): string {
   return join(homedir(), '.claude-review', 'settings.json');
@@ -33,6 +35,10 @@ export function getDefaultSettingsPath(): string {
 
 export function configureSettingsPath(path: string): void {
   settingsPath = path;
+}
+
+export function configureSettingsLogger(injected: SettingsLogger): void {
+  logger = injected;
 }
 
 export async function loadSettingsFromDisk(): Promise<void> {
@@ -44,18 +50,28 @@ export async function loadSettingsFromDisk(): Promise<void> {
     return;
   }
 
+  let raw: string;
+  try {
+    raw = readFileSync(settingsPath, 'utf-8');
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    logger.warn(`[runtimeSettings] failed to read settings file at ${settingsPath}: ${reason}; using defaults`);
+    settings = { ...DEFAULT_SETTINGS };
+    return;
+  }
+
   let parsed: unknown;
   try {
-    parsed = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    parsed = JSON.parse(raw);
   } catch {
-    console.warn(`[runtimeSettings] malformed JSON at ${settingsPath}, using defaults`);
+    logger.warn(`[runtimeSettings] malformed JSON at ${settingsPath}; using defaults`);
     settings = { ...DEFAULT_SETTINGS };
     return;
   }
 
   const result = runtimeSettingsSchema.safeParse(parsed);
   if (!result.success) {
-    console.warn(`[runtimeSettings] invalid settings at ${settingsPath}, using defaults`);
+    logger.warn(`[runtimeSettings] invalid settings at ${settingsPath}; using defaults`);
     settings = { ...DEFAULT_SETTINGS };
     return;
   }
@@ -63,10 +79,22 @@ export async function loadSettingsFromDisk(): Promise<void> {
   settings = result.data;
 }
 
-async function persistAsync(): Promise<void> {
-  if (!settingsPath) return;
-  await mkdir(dirname(settingsPath), { recursive: true });
-  await writeFile(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
+async function writeAtomically(path: string, payload: string): Promise<void> {
+  const temporaryPath = `${path}.tmp`;
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(temporaryPath, payload, 'utf-8');
+  await rename(temporaryPath, path);
+}
+
+function persistAsync(): Promise<void> {
+  if (!settingsPath) return Promise.resolve();
+  const path = settingsPath;
+  const enqueue = writeQueue.then(
+    () => writeAtomically(path, JSON.stringify(settings, null, 2)),
+    () => writeAtomically(path, JSON.stringify(settings, null, 2)),
+  );
+  writeQueue = enqueue;
+  return enqueue;
 }
 
 export function getModel(): ClaudeModel {
@@ -87,7 +115,11 @@ export function getDefaultLanguage(): Language {
 }
 
 export async function setDefaultLanguage(language: Language): Promise<void> {
-  settings.language = language;
+  const result = languageSchema.safeParse(language);
+  if (!result.success) {
+    throw new Error(`Invalid language: ${language}`);
+  }
+  settings.language = result.data;
   await persistAsync();
 }
 
@@ -95,7 +127,15 @@ export function getSettings(): RuntimeSettings {
   return { ...settings };
 }
 
-export function resetSettingsForTesting(): void {
+/**
+ * Test-only helper. Resets module-level state (settings, path, logger, write queue).
+ * Exposed because this module owns module-level mutable state; production code must
+ * never call this. A proper fix would extract a SettingsRepository class with
+ * constructor-injected dependencies; see PR #221 review for context.
+ */
+export function __resetForTestsOnly(): void {
   settings = { ...DEFAULT_SETTINGS };
   settingsPath = null;
+  logger = { warn: (message) => console.warn(message) };
+  writeQueue = Promise.resolve();
 }

--- a/src/frameworks/settings/runtimeSettings.ts
+++ b/src/frameworks/settings/runtimeSettings.ts
@@ -1,40 +1,101 @@
-/**
- * Runtime settings that can be changed without restart
- */
-
-import type { Language } from '@/modules/shared-kernel/entities/language/language.schema.js';
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { z } from 'zod';
+import { languageSchema, type Language } from '@/modules/shared-kernel/entities/language/language.schema.js';
 
 export type ClaudeModel = 'haiku' | 'sonnet' | 'opus';
+
+const claudeModelSchema = z.enum(['haiku', 'sonnet', 'opus']);
+
+const runtimeSettingsSchema = z.object({
+  language: languageSchema,
+  model: claudeModelSchema,
+});
 
 interface RuntimeSettings {
   model: ClaudeModel;
   language: Language;
 }
 
-const settings: RuntimeSettings = {
+const DEFAULT_SETTINGS: RuntimeSettings = {
   model: 'opus',
   language: 'en',
 };
+
+let settings: RuntimeSettings = { ...DEFAULT_SETTINGS };
+let settingsPath: string | null = null;
+
+export function getDefaultSettingsPath(): string {
+  return join(homedir(), '.claude-review', 'settings.json');
+}
+
+export function configureSettingsPath(path: string): void {
+  settingsPath = path;
+}
+
+export async function loadSettingsFromDisk(): Promise<void> {
+  if (!settingsPath) return;
+
+  if (!existsSync(settingsPath)) {
+    settings = { ...DEFAULT_SETTINGS };
+    await persistAsync();
+    return;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+  } catch {
+    console.warn(`[runtimeSettings] malformed JSON at ${settingsPath}, using defaults`);
+    settings = { ...DEFAULT_SETTINGS };
+    return;
+  }
+
+  const result = runtimeSettingsSchema.safeParse(parsed);
+  if (!result.success) {
+    console.warn(`[runtimeSettings] invalid settings at ${settingsPath}, using defaults`);
+    settings = { ...DEFAULT_SETTINGS };
+    return;
+  }
+
+  settings = result.data;
+}
+
+async function persistAsync(): Promise<void> {
+  if (!settingsPath) return;
+  await mkdir(dirname(settingsPath), { recursive: true });
+  await writeFile(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
+}
 
 export function getModel(): ClaudeModel {
   return settings.model;
 }
 
-export function setModel(model: ClaudeModel): void {
-  if (model !== 'haiku' && model !== 'sonnet' && model !== 'opus') {
+export async function setModel(model: ClaudeModel): Promise<void> {
+  const result = claudeModelSchema.safeParse(model);
+  if (!result.success) {
     throw new Error(`Invalid model: ${model}`);
   }
-  settings.model = model;
+  settings.model = result.data;
+  await persistAsync();
 }
 
 export function getDefaultLanguage(): Language {
   return settings.language;
 }
 
-export function setDefaultLanguage(language: Language): void {
+export async function setDefaultLanguage(language: Language): Promise<void> {
   settings.language = language;
+  await persistAsync();
 }
 
 export function getSettings(): RuntimeSettings {
   return { ...settings };
+}
+
+export function resetSettingsForTesting(): void {
+  settings = { ...DEFAULT_SETTINGS };
+  settingsPath = null;
 }

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -17,6 +17,7 @@ import { SupervisorLockFileSystemGateway, createDefaultSupervisorLockFileSystem,
 import { runReviewRecovery } from '@/modules/review-execution/services/reviewRecovery.service.js';
 import { executeActionsFromContext } from '@/modules/review-execution/services/contextActionsExecutor.js';
 import { defaultCommandExecutor } from '@/modules/review-execution/services/threadActionsExecutor.js';
+import { configureSettingsPath, getDefaultSettingsPath, loadSettingsFromDisk } from '@/frameworks/settings/runtimeSettings.js';
 
 export interface ServerOptions {
   config?: Config;
@@ -59,6 +60,9 @@ export async function createServer(options: ServerOptions = {}): Promise<Fastify
 export async function startServer(options: ServerOptions = {}): Promise<FastifyInstance> {
   const config = options.config ?? loadConfig();
   const deps = createDependencies(config);
+
+  configureSettingsPath(getDefaultSettingsPath());
+  await loadSettingsFromDisk();
 
   initQueue(deps.logger);
   setupWebSocketCallbacks({

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -17,7 +17,7 @@ import { SupervisorLockFileSystemGateway, createDefaultSupervisorLockFileSystem,
 import { runReviewRecovery } from '@/modules/review-execution/services/reviewRecovery.service.js';
 import { executeActionsFromContext } from '@/modules/review-execution/services/contextActionsExecutor.js';
 import { defaultCommandExecutor } from '@/modules/review-execution/services/threadActionsExecutor.js';
-import { configureSettingsPath, getDefaultSettingsPath, loadSettingsFromDisk } from '@/frameworks/settings/runtimeSettings.js';
+import { configureSettingsLogger, configureSettingsPath, getDefaultSettingsPath, loadSettingsFromDisk } from '@/frameworks/settings/runtimeSettings.js';
 
 export interface ServerOptions {
   config?: Config;
@@ -62,6 +62,7 @@ export async function startServer(options: ServerOptions = {}): Promise<FastifyI
   const deps = createDependencies(config);
 
   configureSettingsPath(getDefaultSettingsPath());
+  configureSettingsLogger(deps.logger);
   await loadSettingsFromDisk();
 
   initQueue(deps.logger);

--- a/src/modules/cli-configuration/interface-adapters/controllers/http/settings.routes.ts
+++ b/src/modules/cli-configuration/interface-adapters/controllers/http/settings.routes.ts
@@ -25,7 +25,7 @@ export const settingsRoutes: FastifyPluginAsync = async (fastify) => {
       return { success: false, error: 'Invalid model. Use: opus, sonnet' };
     }
 
-    setModel(model);
+    await setModel(model);
     return { success: true, model: getModel() };
   });
 
@@ -38,7 +38,7 @@ export const settingsRoutes: FastifyPluginAsync = async (fastify) => {
       return { success: false, error: 'Invalid language. Use: en, fr' };
     }
 
-    setDefaultLanguage(parsed.data);
+    await setDefaultLanguage(parsed.data);
     return { success: true, language: getDefaultLanguage() };
   });
 };

--- a/src/modules/cli-configuration/interface-adapters/controllers/http/settings.routes.ts
+++ b/src/modules/cli-configuration/interface-adapters/controllers/http/settings.routes.ts
@@ -1,5 +1,12 @@
 import type { FastifyPluginAsync } from 'fastify';
-import { getModel, setModel, getDefaultLanguage, setDefaultLanguage, getSettings, type ClaudeModel } from '@/frameworks/settings/runtimeSettings.js';
+import {
+  claudeModelSchema,
+  getModel,
+  setModel,
+  getDefaultLanguage,
+  setDefaultLanguage,
+  getSettings,
+} from '@/frameworks/settings/runtimeSettings.js';
 import { languageSchema } from '@/modules/shared-kernel/entities/language/language.schema.js';
 
 export const settingsRoutes: FastifyPluginAsync = async (fastify) => {
@@ -12,30 +19,25 @@ export const settingsRoutes: FastifyPluginAsync = async (fastify) => {
   });
 
   fastify.post('/api/settings/model', async (request, reply) => {
-    const { model } = request.body as { model?: ClaudeModel };
+    const { model } = request.body as { model?: unknown };
 
-    if (!model) {
+    const parsed = claudeModelSchema.safeParse(model);
+    if (!parsed.success) {
       reply.code(400);
-      return { success: false, error: 'Model is required' };
+      return { success: false, error: `Invalid model. Use: ${claudeModelSchema.options.join(', ')}` };
     }
 
-    const validModels: ClaudeModel[] = ['opus', 'sonnet'];
-    if (!validModels.includes(model)) {
-      reply.code(400);
-      return { success: false, error: 'Invalid model. Use: opus, sonnet' };
-    }
-
-    await setModel(model);
+    await setModel(parsed.data);
     return { success: true, model: getModel() };
   });
 
   fastify.post('/api/settings/language', async (request, reply) => {
-    const { language } = request.body as { language?: string };
+    const { language } = request.body as { language?: unknown };
 
     const parsed = languageSchema.safeParse(language);
     if (!parsed.success) {
       reply.code(400);
-      return { success: false, error: 'Invalid language. Use: en, fr' };
+      return { success: false, error: `Invalid language. Use: ${languageSchema.options.join(', ')}` };
     }
 
     await setDefaultLanguage(parsed.data);

--- a/src/tests/units/frameworks/settings/runtimeSettings.test.ts
+++ b/src/tests/units/frameworks/settings/runtimeSettings.test.ts
@@ -1,23 +1,130 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { getDefaultLanguage, setDefaultLanguage, getSettings } from '@/frameworks/settings/runtimeSettings.js';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  configureSettingsPath,
+  loadSettingsFromDisk,
+  getDefaultLanguage,
+  setDefaultLanguage,
+  getModel,
+  setModel,
+  getSettings,
+  resetSettingsForTesting,
+} from '@/frameworks/settings/runtimeSettings.js';
 
-describe('runtimeSettings language', () => {
-  beforeEach(() => {
-    setDefaultLanguage('en');
+describe('runtimeSettings', () => {
+  describe('in-memory API (no path configured)', () => {
+    beforeEach(() => {
+      resetSettingsForTesting();
+    });
+
+    it('defaults language to "en"', () => {
+      expect(getDefaultLanguage()).toBe('en');
+    });
+
+    it('changes language to "fr"', async () => {
+      await setDefaultLanguage('fr');
+      expect(getDefaultLanguage()).toBe('fr');
+    });
+
+    it('includes language in getSettings()', async () => {
+      await setDefaultLanguage('fr');
+      expect(getSettings().language).toBe('fr');
+    });
   });
 
-  it('should default language to "en"', () => {
-    expect(getDefaultLanguage()).toBe('en');
-  });
+  describe('persistence', () => {
+    let directory: string;
+    let settingsPath: string;
 
-  it('should change language to "fr"', () => {
-    setDefaultLanguage('fr');
-    expect(getDefaultLanguage()).toBe('fr');
-  });
+    beforeEach(() => {
+      directory = mkdtempSync(join(tmpdir(), 'reviewflow-settings-'));
+      settingsPath = join(directory, 'settings.json');
+      resetSettingsForTesting();
+      configureSettingsPath(settingsPath);
+    });
 
-  it('should include language in getSettings()', () => {
-    setDefaultLanguage('fr');
-    const settings = getSettings();
-    expect(settings.language).toBe('fr');
+    afterEach(() => {
+      resetSettingsForTesting();
+      rmSync(directory, { recursive: true, force: true });
+    });
+
+    describe('loadSettingsFromDisk', () => {
+      it('restores language and model from existing file', async () => {
+        writeFileSync(settingsPath, JSON.stringify({ language: 'fr', model: 'sonnet' }));
+
+        await loadSettingsFromDisk();
+
+        expect(getDefaultLanguage()).toBe('fr');
+        expect(getModel()).toBe('sonnet');
+      });
+
+      it('creates the file with defaults when it does not exist', async () => {
+        await loadSettingsFromDisk();
+
+        expect(existsSync(settingsPath)).toBe(true);
+        const written = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+        expect(written).toEqual({ language: 'en', model: 'opus' });
+      });
+
+      it('falls back to defaults silently when file is malformed JSON', async () => {
+        writeFileSync(settingsPath, '{ this is not valid json');
+
+        await loadSettingsFromDisk();
+
+        expect(getDefaultLanguage()).toBe('en');
+        expect(getModel()).toBe('opus');
+      });
+
+      it('falls back to defaults silently when language is unknown', async () => {
+        writeFileSync(settingsPath, JSON.stringify({ language: 'es', model: 'opus' }));
+
+        await loadSettingsFromDisk();
+
+        expect(getDefaultLanguage()).toBe('en');
+      });
+
+      it('falls back to defaults silently when model is unknown', async () => {
+        writeFileSync(settingsPath, JSON.stringify({ language: 'fr', model: 'gpt-5' }));
+
+        await loadSettingsFromDisk();
+
+        expect(getModel()).toBe('opus');
+      });
+    });
+
+    describe('persistence on set', () => {
+      it('persists language to disk after setDefaultLanguage', async () => {
+        await loadSettingsFromDisk();
+
+        await setDefaultLanguage('fr');
+
+        const written = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+        expect(written.language).toBe('fr');
+      });
+
+      it('persists model to disk after setModel', async () => {
+        await loadSettingsFromDisk();
+
+        await setModel('sonnet');
+
+        const written = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+        expect(written.model).toBe('sonnet');
+      });
+
+      it('survives a simulated process restart', async () => {
+        await loadSettingsFromDisk();
+        await setDefaultLanguage('fr');
+        await setModel('sonnet');
+
+        resetSettingsForTesting();
+        configureSettingsPath(settingsPath);
+        await loadSettingsFromDisk();
+
+        expect(getDefaultLanguage()).toBe('fr');
+        expect(getModel()).toBe('sonnet');
+      });
+    });
   });
 });

--- a/src/tests/units/frameworks/settings/runtimeSettings.test.ts
+++ b/src/tests/units/frameworks/settings/runtimeSettings.test.ts
@@ -1,22 +1,24 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, readdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   configureSettingsPath,
+  configureSettingsLogger,
   loadSettingsFromDisk,
   getDefaultLanguage,
   setDefaultLanguage,
   getModel,
   setModel,
   getSettings,
-  resetSettingsForTesting,
+  __resetForTestsOnly,
+  type ClaudeModel,
 } from '@/frameworks/settings/runtimeSettings.js';
 
 describe('runtimeSettings', () => {
   describe('in-memory API (no path configured)', () => {
     beforeEach(() => {
-      resetSettingsForTesting();
+      __resetForTestsOnly();
     });
 
     it('defaults language to "en"', () => {
@@ -41,12 +43,12 @@ describe('runtimeSettings', () => {
     beforeEach(() => {
       directory = mkdtempSync(join(tmpdir(), 'reviewflow-settings-'));
       settingsPath = join(directory, 'settings.json');
-      resetSettingsForTesting();
+      __resetForTestsOnly();
       configureSettingsPath(settingsPath);
     });
 
     afterEach(() => {
-      resetSettingsForTesting();
+      __resetForTestsOnly();
       rmSync(directory, { recursive: true, force: true });
     });
 
@@ -118,12 +120,60 @@ describe('runtimeSettings', () => {
         await setDefaultLanguage('fr');
         await setModel('sonnet');
 
-        resetSettingsForTesting();
+        __resetForTestsOnly();
         configureSettingsPath(settingsPath);
         await loadSettingsFromDisk();
 
         expect(getDefaultLanguage()).toBe('fr');
         expect(getModel()).toBe('sonnet');
+      });
+
+      it('writes atomically (no .tmp leftover after persist)', async () => {
+        await loadSettingsFromDisk();
+
+        await setDefaultLanguage('fr');
+
+        const entries = readdirSync(directory);
+        expect(entries.filter((name) => name.endsWith('.tmp'))).toEqual([]);
+      });
+
+      it('preserves both fields across concurrent setModel and setDefaultLanguage', async () => {
+        await loadSettingsFromDisk();
+
+        await Promise.all([setModel('sonnet'), setDefaultLanguage('fr')]);
+
+        const written = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+        expect(written).toEqual({ language: 'fr', model: 'sonnet' });
+      });
+    });
+
+    describe('validation', () => {
+      it('throws when setModel receives an unknown model', async () => {
+        await expect(setModel('gpt-5' as ClaudeModel)).rejects.toThrow(/Invalid model/);
+      });
+    });
+
+    describe('logger injection', () => {
+      it('reports malformed JSON via the injected logger instead of console', async () => {
+        const warnings: string[] = [];
+        configureSettingsLogger({ warn: (message: string) => warnings.push(message) });
+        writeFileSync(settingsPath, '{ not valid json');
+
+        await loadSettingsFromDisk();
+
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]).toMatch(/malformed json/i);
+      });
+
+      it('reports schema violation via the injected logger', async () => {
+        const warnings: string[] = [];
+        configureSettingsLogger({ warn: (message: string) => warnings.push(message) });
+        writeFileSync(settingsPath, JSON.stringify({ language: 'es', model: 'opus' }));
+
+        await loadSettingsFromDisk();
+
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]).toMatch(/invalid settings/i);
       });
     });
   });

--- a/src/tests/units/interface-adapters/controllers/http/settings.routes.test.ts
+++ b/src/tests/units/interface-adapters/controllers/http/settings.routes.test.ts
@@ -15,7 +15,7 @@ describe('settings routes', () => {
 
   describe('GET /api/settings/model', () => {
     it('should return current model', async () => {
-      setModel('sonnet')
+      await setModel('sonnet')
 
       const response = await application.inject({
         method: 'GET',


### PR DESCRIPTION
## Summary
- Runtime settings (UI language, Claude model) lived only in memory in `src/frameworks/settings/runtimeSettings.ts`, so every systemd restart reset them to defaults — the dashboard "lost" its language on every `yarn build` + restart.
- Persist settings to `~/.claude-review/settings.json` (JSON, zod-validated). Load at server boot; `setModel` / `setDefaultLanguage` are now async and write on every change.
- Missing file → auto-created with defaults. Malformed JSON or unknown enum → silent fallback to defaults + `console.warn`.

## Files
- `src/frameworks/settings/runtimeSettings.ts` — add `configureSettingsPath`, `loadSettingsFromDisk`, `getDefaultSettingsPath`, `resetSettingsForTesting`; turn setters async.
- `src/main/server.ts` — wire `configureSettingsPath` + `await loadSettingsFromDisk` at boot.
- `src/modules/cli-configuration/.../settings.routes.ts` — `await` the async setters.
- `src/tests/units/frameworks/settings/runtimeSettings.test.ts` — 11 tests covering load/persist/restart scenarios.
- `src/tests/units/.../settings.routes.test.ts` — `await setModel`.

## Test plan
- [x] `yarn verify` — typecheck + lint + 2315 tests green
- [x] RED → GREEN TDD cycle (11 new tests for persistence)
- [ ] Manual smoke after merge: change language in dashboard → `systemctl --user restart reviewflow-app` → language preserved

🤖 Generated with Claude Code