### PR TITLE
feat(setup-wizard): SPEC-187 read wizard answers from stdin in JSON mode

### DIFF
--- a/docs/feature-tracker.md
+++ b/docs/feature-tracker.md
@@ -53,4 +53,4 @@
 | Setup Wizard Dashboard (Jarvis HUD) | [184-setup-wizard-dashboard-jarvis](specs/184-setup-wizard-dashboard-jarvis.md) — [plan](plans/184-setup-wizard-dashboard-jarvis.plan.md) — [report](reports/184-setup-wizard-dashboard-jarvis.report.md) | partially-implemented (Iteration A) | 2026-05-28 |
 | Setup Wizard MCP agent fallback (deferred) | [185-setup-wizard-mcp-agent-fallback](specs/185-setup-wizard-mcp-agent-fallback.md) | drafted (deferred) | 2026-05-27 |
 | Cap parallel reviews per project | [186-per-project-concurrency-cap](specs/186-per-project-concurrency-cap.md) — [plan](plans/186-per-project-concurrency-cap.plan.md) — [report](reports/186-per-project-concurrency-cap.report.md) | implemented | 2026-05-27 |
-| Read setup wizard answers from stdin in JSON mode | [187-setup-wizard-json-stdin-input](specs/187-setup-wizard-json-stdin-input.md) | drafted | 2026-05-28 |
+| Read setup wizard answers from stdin in JSON mode | [187-setup-wizard-json-stdin-input](specs/187-setup-wizard-json-stdin-input.md) — [plan](plans/187-setup-wizard-json-stdin-input.plan.md) — [report](reports/187-setup-wizard-json-stdin-input.report.md) | implemented | 2026-05-28 |

--- a/docs/plans/187-setup-wizard-json-stdin-input.plan.md
+++ b/docs/plans/187-setup-wizard-json-stdin-input.plan.md
@@ -1,0 +1,332 @@
+# PLAN — SPEC-187: Read setup wizard answers from stdin in JSON mode
+
+> Spec: `docs/specs/187-setup-wizard-json-stdin-input.md`
+> Branch: `feat/187-setup-wizard-json-stdin`
+> Status: planned
+
+```
+PLAN:
+  scope: setup-wizard-json-stdin-input
+  is_new_module: false   # extends existing src/modules/setup-wizard/
+```
+
+## Summary
+
+In `--json` mode the wizard must, for any step that needs an answer, emit an
+`awaiting_input` event and then read exactly one JSON line from stdin instead of
+calling inquirer (TTY). The cleanest implementation is a **new `PromptGateway`
+implementation** (`PromptStdinJsonGateway`) that is selected by the composition
+root when `args.json` is true, plus a tiny **injectable line-reader seam** so it
+is unit-testable with a scripted feed. The existing steps already handle `-y`
+themselves and never touch the prompt gateway in that mode, so SPEC-183 behaviour
+is preserved without touching any step.
+
+The single non-trivial coupling — the gateway needs the **current stepId** for
+`emitAwaitingInput(stepId, prompt)` — is solved by having the orchestrator set a
+`currentStepId` on `WizardContext` (it already iterates steps and calls
+`emitStepStarted(step.id, …)` right before each step), and constructing the
+stdin gateway with a getter that reads that field. This is the smallest
+Clean-Architecture-correct change: no `PromptGateway` signature change, no
+per-step rewrite, no new call sites in the 4 prompting steps.
+
+Verified facts driving this plan:
+- `emitAwaitingInput` exists on `WizardEventEmitter` / both emitters but is
+  **never called by production code today** (`jsonWizardEventEmitter.ts:27`,
+  `humanWizardEventEmitter.ts:34`; only tests reference it). SPEC-187 is the
+  first real caller — via the stdin gateway.
+- All 4 prompting steps already guard `flags.yes` BEFORE calling the prompt
+  gateway (`addProject.step.ts:18,42`, `configurePipeline.step.ts:25,54`,
+  `daemonInstall.step.ts:24`, `generateSecrets.step.ts:29`). So in `-y` mode the
+  prompt gateway is never invoked; the `-y` scenario already passes from SPEC-183.
+  We add a defensive throw in the gateway anyway (decision 6).
+- The orchestrator (`orchestrateSetup.usecase.ts:59`) already calls
+  `context.emitter.emitStepStarted(step.id, …)` before `step.execute` — the
+  natural place to also record `context.currentStepId = step.id`.
+
+## Design Decisions (the hard parts)
+
+1. **stepId coupling** — The orchestrator sets `context.currentStepId = step.id`
+   immediately before `emitStepStarted` (one new line). The stdin gateway is
+   constructed in the composition root with a `() => StepId` getter closing over
+   `context.currentStepId`. `PromptGateway` signatures are untouched; no step
+   call site changes. (Rejected: extending `PromptGateway` with a stepId param →
+   breaks 4 steps + TTY gateway + stub for no gain; rejected: per-step wrapper →
+   more files, more wiring.)
+
+2. **EOF / stream-close → blocked** — The line reader resolves with `null` on
+   stream close. The gateway converts `null` into a thrown typed domain error
+   `AwaitingInputClosedError` (new tiny entity error). It bubbles out of
+   `step.execute`; the orchestrator wraps `step.execute(context)` in a
+   `try/catch` that maps `AwaitingInputClosedError` to
+   `blocked("Aucune réponse reçue, le setup est interrompu", <hint>)`. This keeps
+   the gateway pure (no StepOutcome knowledge in interface-adapters) and the
+   blocked-outcome construction stays in the application layer where
+   `blocked()` lives (`stepOutcome.ts:21`).
+
+3. **Re-announce loop** — On a malformed/wrong-shape/invalid-option answer the
+   gateway emits a `warning` (refusal message) **and re-emits `awaiting_input`**,
+   then reads the next line. Loop continues until a valid answer or EOF (no cap,
+   per spec). Terminable in tests because the injected line reader is a finite
+   scripted queue whose exhaustion = EOF = the blocked path (decision 2), so no
+   test can hang.
+
+4. **stdin reading is I/O → injectable seam** — Introduce a `LineReader`
+   contract in entities: `interface LineReader { read(): Promise<string | null> }`
+   (`null` = stream closed). Production impl wraps `readline.createInterface`
+   over `process.stdin` (one line per `read()`); unit tests inject a scripted
+   array-backed `StubLineReader`. The gateway depends only on the `LineReader`
+   interface — Dependency Rule respected.
+
+5. **value encoding + boundary validation** — One JSON line per answer, validated
+   with Zod at the boundary:
+   - `askText`: raw line is the value (NOT JSON-parsed); empty line → `defaultValue ?? ''`.
+   - `askConfirm`: line must be exactly `true` or `false` (Zod boolean from
+     `JSON.parse`); anything else → refuse `"Réponse invalide"` + re-announce.
+   - `askChoice`: `JSON.parse(line)` must be a string AND ∈ offered values;
+     not-a-string → `"Réponse invalide"`; valid string but not offered →
+     `"Choix invalide, sélectionnez une option proposée"`.
+   - `askMultiSelect`: `JSON.parse(line)` must be `string[]` with every element ∈
+     offered values; shape error → `"Réponse invalide"`; unknown element →
+     `"Sélection invalide, une valeur n'est pas proposée"`.
+   - Any `JSON.parse` throw → `"Réponse illisible"` + re-announce.
+   Validation lives in a new guard `answerLine.guard.ts` (offered-options check is
+   a runtime closure over the choices passed to the method). Note: `askText`
+   never `JSON.parse`es (a raw path like `/home/u/api` is not valid JSON) — the
+   spec scenario `line:"{not json"` is the malformed case for shapes that DO
+   parse; for text the only refusal is never (raw line always accepted, empty →
+   default).
+
+6. **non-interactive `-y` guard** — Wiring already prevents this: steps short-
+   circuit `flags.yes` before prompting, so the TTY/stdin gateway is never called
+   in `-y` mode (verified). To be defensive and satisfy the spec's exact message
+   for any future step that forgets, the stdin gateway throws
+   `NonInteractiveInputError("Mode non-interactif : aucune entrée disponible pour
+   cette étape")` if constructed/called while `flags.yes` is true. The orchestrator
+   `try/catch` maps it to `blocked(...)`. We pick the gateway-throw (not a separate
+   `-y` gateway) because `-y` already implies the JSON-vs-TTY selection is moot —
+   the gateway is simply never reached on the happy path, and the throw is a
+   cheap safety net, not a new code path.
+
+## ENTITIES
+
+```
+ENTITIES:
+  - name: LineReader (contract, port)
+    file: src/modules/setup-wizard/entities/lineReader/lineReader.gateway.ts
+    test: (covered via gateway + stub; no logic to unit-test on the interface)
+    note: interface LineReader { read(): Promise<string | null> }  // null = EOF
+
+  - name: AnswerLine (validation guards for the 4 shapes)
+    schema: src/modules/setup-wizard/entities/answerLine/answerLine.schema.ts
+    guard:  src/modules/setup-wizard/entities/answerLine/answerLine.guard.ts
+    test:   src/tests/units/modules/setup-wizard/entities/answerLine/answerLine.guard.test.ts
+    note: Zod schemas — confirm = z.boolean(); choice = z.string(); multi = z.array(z.string()).
+          Offered-option membership is checked in the gateway (runtime closure), not the schema.
+
+  - name: PromptInputError (typed domain errors)
+    file: src/modules/setup-wizard/entities/promptInputError/promptInputError.ts
+    test: src/tests/units/modules/setup-wizard/entities/promptInputError/promptInputError.test.ts
+    note: AwaitingInputClosedError, NonInteractiveInputError (named classes extending Error,
+          identifiable via instanceof — no `as`). Used by gateway → caught by orchestrator.
+```
+
+> WizardContext gains `currentStepId: StepId | null` (modify existing file, not a new entity).
+
+## USECASES
+
+```
+USECASES:
+  - name: orchestrateSetup (MODIFY existing)
+    file: src/modules/setup-wizard/usecases/orchestrateSetup.usecase.ts
+    test: src/tests/units/modules/setup-wizard/usecases/orchestrateSetup.usecase.test.ts (extend)
+    changes:
+      - set context.currentStepId = step.id before emitStepStarted (decision 1)
+      - wrap step.execute(context) in try/catch; map AwaitingInputClosedError and
+        NonInteractiveInputError to blocked() outcomes (decisions 2 & 6)
+    type: command (no signature change)
+```
+
+No new use case. The 4 prompting steps are **not modified** (they already call
+`context.gateways.prompt.*` and already handle `-y`).
+
+## GATEWAYS
+
+```
+GATEWAYS:
+  - name: PromptStdinJsonGateway   (NEW — implements existing PromptGateway)
+    contract: src/modules/setup-wizard/entities/prompt/prompt.gateway.ts (REUSED, unchanged)
+    implementation: src/modules/setup-wizard/interface-adapters/gateways/prompt.stdinJson.gateway.ts
+    test: src/tests/units/modules/setup-wizard/interface-adapters/gateways/prompt.stdinJson.gateway.test.ts
+    constructor deps (injected): { lineReader: LineReader; emitter: WizardEventEmitter;
+                                   currentStepId: () => StepId; isNonInteractive: () => boolean }
+    methods: askText, askConfirm, askChoice, askMultiSelect
+    behaviour per method: emitAwaitingInput(currentStepId(), prompt) → lineReader.read()
+      → null ? throw AwaitingInputClosedError : validate(decision 5)
+      → invalid ? emit warning(refusal) + loop : return value
+    guards: -y check throws NonInteractiveInputError up front (decision 6)
+
+  - name: NodeStdinLineReader   (NEW — implements LineReader)
+    contract: src/modules/setup-wizard/entities/lineReader/lineReader.gateway.ts
+    implementation: src/modules/setup-wizard/interface-adapters/gateways/lineReader.stdin.gateway.ts
+    test: NOT unit-tested (thin readline wrapper over process.stdin = I/O boundary;
+          covered indirectly + by acceptance). Documented as humble I/O object.
+    methods: read(): Promise<string | null>
+
+  - name: PromptTtyGateway (UNCHANGED — human mode regression baseline)
+```
+
+## CONTROLLERS / PRESENTERS / VIEWS
+
+None. No controller, presenter, or view changes. (The HTTP route + child-process
+gateway from SPEC-184 are out of scope — SPEC-184 Iteration B owns writing to the
+child's stdin; current `setupProcess.childProcess.gateway.ts:86` uses
+`stdio:['ignore',...]` and stays as-is.)
+
+## WIRING
+
+```
+WIRING:
+  file: src/main/commands/setup.command.ts
+  changes:
+    1. WizardContext now carries currentStepId — initialise to null in executeSetup (~line 61).
+    2. buildGateways currently builds prompt unconditionally as PromptTtyGateway and
+       does NOT have the emitter. Two viable shapes — PICK (A):
+       (A) Move prompt selection out of buildGateways into executeSetup, AFTER the
+           emitter is built (emitter built at setup.command.ts:59). executeSetup wires:
+             context.gateways.prompt = args.json
+               ? new PromptStdinJsonGateway({
+                   lineReader: deps.buildLineReader(),
+                   emitter,
+                   currentStepId: () => context.currentStepId,
+                   isNonInteractive: () => context.flags.yes,
+                 })
+               : new PromptTtyGateway();
+           buildGateways drops the prompt field (or keeps a TTY default that
+           executeSetup overrides). Add deps.buildLineReader: () => LineReader
+           (default NodeStdinLineReader) so tests inject a stub.
+       (B) Keep prompt in buildGateways but pass emitter+context getters in —
+           requires threading emitter into buildGateways(args). Rejected: emitter
+           is built separately by buildEmitter; threading it into buildGateways
+           muddies the dependency seams.
+    dependencies:
+      - PromptStdinJsonGateway (json mode only)
+      - NodeStdinLineReader (via new deps.buildLineReader factory, injectable)
+```
+
+## IMPLEMENTATION_ORDER
+
+Walking skeleton = one prompt shape (text) crossing entity → gateway → orchestrator
+→ acceptance, then fan out to the other 3 shapes and edge cases.
+
+```
+IMPLEMENTATION_ORDER:
+  1. src/tests/acceptance/187-setup-wizard-json-stdin-input.acceptance.test.ts
+     — SDD outer loop. Write FIRST, RED. Scripted line feed drives a full --json
+       run that needs input (text answer) to completion. Reuse SPEC-183/184 stub
+       wiring + StubLineReader.
+  2. entities/lineReader/lineReader.gateway.ts (+ StubLineReader stub)
+     — the injectable seam; nothing else compiles without it.
+  3. entities/promptInputError/promptInputError.ts (+ test)
+     — typed errors for EOF + non-interactive; needed by gateway & orchestrator.
+  4. entities/answerLine/answerLine.schema.ts + .guard.ts (+ test)
+     — boundary validation for confirm/choice/multi shapes.
+  5. interface-adapters/gateways/prompt.stdinJson.gateway.ts (+ test)
+     — the core. Drive each shape + each refusal/re-announce + EOF via StubLineReader.
+       This is the bulk of the unit coverage (one test per spec scenario).
+  6. entities/wizardContext/wizardContext.ts — add currentStepId field.
+  7. usecases/orchestrateSetup.usecase.ts (+ extend test)
+     — set currentStepId; try/catch → blocked mapping for both typed errors.
+  8. interface-adapters/gateways/lineReader.stdin.gateway.ts
+     — production readline wrapper (humble object, no unit test).
+  9. main/commands/setup.command.ts — wire selection + buildLineReader (decision A).
+ 10. Run acceptance GREEN; add the human-mode regression assertion (decision: prove
+     TTY path still calls PromptTtyGateway, never the stdin gateway, when json=false).
+```
+
+## ACCEPTANCE_TEST
+
+```
+ACCEPTANCE_TEST:
+  file: src/tests/acceptance/187-setup-wizard-json-stdin-input.acceptance.test.ts
+  note: "SDD outer loop — written first by implementer, RED during impl, GREEN at the end"
+  cases (mirror spec scenarios + DoD):
+    - full --json run with a scripted feed (text + choice + multiSelect + confirm)
+      reaches done/completed (the DoD acceptance).
+    - awaiting_input event emitted before each needed answer (no TTY call).
+    - empty text line → default used.
+    - choice not offered → refusal warning + re-announce, next valid line accepted.
+    - multiSelect unknown value → refusal + re-announce.
+    - malformed line → "Réponse illisible" + re-announce.
+    - EOF before answer → step blocked "Aucune réponse reçue, le setup est interrompu".
+    - REGRESSION: json=false uses PromptTtyGateway, stdin gateway never constructed,
+      human prompt path unchanged (assert via a spy/stub on prompt selection).
+    - -y + step needing input → blocked (already SPEC-183 behaviour; pin it here).
+```
+
+## FILE LIST (create vs modify)
+
+CREATE (10):
+1. `src/modules/setup-wizard/entities/lineReader/lineReader.gateway.ts`
+2. `src/modules/setup-wizard/entities/promptInputError/promptInputError.ts`
+3. `src/modules/setup-wizard/entities/answerLine/answerLine.schema.ts`
+4. `src/modules/setup-wizard/entities/answerLine/answerLine.guard.ts`
+5. `src/modules/setup-wizard/interface-adapters/gateways/prompt.stdinJson.gateway.ts`
+6. `src/modules/setup-wizard/interface-adapters/gateways/lineReader.stdin.gateway.ts`
+7. `src/tests/stubs/setup-wizard/lineReader.stub.ts`
+8. `src/tests/units/modules/setup-wizard/entities/promptInputError/promptInputError.test.ts`
+9. `src/tests/units/modules/setup-wizard/entities/answerLine/answerLine.guard.test.ts`
+10. `src/tests/units/modules/setup-wizard/interface-adapters/gateways/prompt.stdinJson.gateway.test.ts`
+11. `src/tests/acceptance/187-setup-wizard-json-stdin-input.acceptance.test.ts`
+
+MODIFY (3):
+1. `src/modules/setup-wizard/entities/wizardContext/wizardContext.ts` (+ currentStepId field)
+2. `src/modules/setup-wizard/usecases/orchestrateSetup.usecase.ts` (set currentStepId + try/catch→blocked)
+3. `src/main/commands/setup.command.ts` (mode-based prompt selection + buildLineReader)
+
+Plus extend existing test (not a new file): `orchestrateSetup.usecase.test.ts`.
+
+**Count: 11 create + 3 modify = 14 touched files.** Within the ≤15 target; no A/B
+split needed. (Spec rated Small; estimate holds.)
+
+## RISKS
+
+- **TTY-mode regression (HIGH visibility, LOW likelihood)**: selection logic moves
+  out of `buildGateways`. MUST have an explicit regression test proving `json=false`
+  constructs `PromptTtyGateway` and never the stdin gateway (in IMPLEMENTATION_ORDER
+  step 10 / acceptance). The existing SPEC-183 human-mode acceptance test is a
+  secondary guard.
+- **Hanging test**: a real `readline` over `process.stdin` would hang Vitest.
+  Mitigated by the `LineReader` seam — unit + acceptance tests NEVER touch
+  `process.stdin`; the production `NodeStdinLineReader` is the only file with real
+  stdin and is intentionally not unit-tested.
+- **stepId coupling correctness**: if a step calls the prompt gateway during
+  `detect()` (before the orchestrator sets `currentStepId`), the getter would
+  return the previous/`null` id. Verified: no step prompts in `detect()` — all
+  prompt calls are inside `execute()`, which runs after `currentStepId` is set.
+  Re-verify when adding the orchestrator change.
+- **`-y` defensive throw vs existing step guards**: the throw is a safety net only;
+  the happy path never reaches it because steps short-circuit `flags.yes`. Ensure
+  the throw message matches the spec verbatim so the (currently theoretical) path
+  is correct if a future step forgets the guard.
+- **No new runtime dependency**: `readline` is a Node built-in; `zod` already used.
+  No package.json change.
+
+## NEW-DEPENDENCY FLAGS
+
+None. `node:readline` (built-in) + `zod` (already present). No `package.json` edit.
+
+## REFERENCE_FILES
+
+- `src/modules/setup-wizard/entities/prompt/prompt.gateway.ts` — the contract to re-implement (unchanged).
+- `src/modules/setup-wizard/interface-adapters/gateways/prompt.tty.gateway.ts` — the human-mode sibling / regression baseline.
+- `src/modules/setup-wizard/services/jsonWizardEventEmitter.ts` — `emitAwaitingInput` shape (`{step,status:"awaiting_input",prompt}`).
+- `src/modules/setup-wizard/services/wizardEventEmitter.ts` — emitter interface (warning + awaitingInput).
+- `src/modules/setup-wizard/usecases/orchestrateSetup.usecase.ts` — where currentStepId is set + where blocked mapping goes (lines 47-86).
+- `src/modules/setup-wizard/entities/wizardContext/wizardContext.ts` — add `currentStepId`.
+- `src/modules/setup-wizard/entities/stepOutcome/stepOutcome.ts` — `blocked()` factory used for EOF/-y mapping.
+- `src/modules/setup-wizard/usecases/steps/addProject.step.ts`, `configurePipeline.step.ts`, `daemonInstall.step.ts`, `generateSecrets.step.ts` — confirm prompt usage + existing `-y` short-circuits (no edits).
+- `src/main/commands/setup.command.ts` — composition root, `buildGateways`/`buildEmitter`/`executeSetup`.
+- `src/tests/stubs/setup-wizard/prompt.stub.ts` — stub pattern to mirror for `StubLineReader`.
+- `src/tests/acceptance/183-setup-wizard.acceptance.test.ts` — acceptance harness/stub wiring to copy (`jsonLines`, stub map, tmp state file).
+- `src/shared/foundation/guard.base.ts` — `createGuard(schema, instigator)` for answerLine guard.
+```

--- a/docs/reports/187-setup-wizard-json-stdin-input.report.md
+++ b/docs/reports/187-setup-wizard-json-stdin-input.report.md
@@ -1,0 +1,159 @@
+# Implementation Report — SPEC-187: Read setup wizard answers from stdin in JSON mode
+
+> Spec: `docs/specs/187-setup-wizard-json-stdin-input.md`
+> Plan: `docs/plans/187-setup-wizard-json-stdin-input.plan.md`
+> Branch: `feat/187-setup-wizard-json-stdin`
+
+## Status
+
+COMPLETE — acceptance GREEN, full `yarn verify` GREEN, self-review clean (0 violations).
+
+## Summary
+
+In `--json` mode the setup wizard now announces it is waiting (`awaiting_input`)
+and reads each answer as one JSON line from standard input instead of calling the
+interactive TTY prompt. The implementation is a new `PromptGateway` implementation
+(`PromptStdinJsonGateway`) selected by the composition root when `args.json` is
+true, plus an injectable `LineReader` seam so the gateway is unit-testable with a
+scripted feed. This is the first real caller of `emitAwaitingInput`. The human
+(non-JSON) prompt path is untouched, proven by a regression test.
+
+## Files created (11)
+
+| File | Description |
+|------|-------------|
+| `src/modules/setup-wizard/entities/lineReader/lineReader.gateway.ts` | `LineReader` port — `read(): Promise<string \| null>` (null = EOF) |
+| `src/modules/setup-wizard/entities/promptInputError/promptInputError.ts` | Typed domain errors: `AwaitingInputClosedError`, `NonInteractiveInputError` (verbatim French messages, `instanceof`-identifiable) |
+| `src/modules/setup-wizard/entities/answerLine/answerLine.schema.ts` | Zod schemas for confirm / choice / multiSelect shapes |
+| `src/modules/setup-wizard/entities/answerLine/answerLine.guard.ts` | Boundary guards via `createGuard` |
+| `src/modules/setup-wizard/interface-adapters/gateways/prompt.stdinJson.gateway.ts` | Core gateway — announce, read one line, validate per shape, re-announce loop on refusal, EOF/-y throws |
+| `src/modules/setup-wizard/interface-adapters/gateways/lineReader.stdin.gateway.ts` | Production `node:readline` wrapper over `process.stdin` (humble I/O object, not unit-tested) |
+| `src/tests/stubs/setup-wizard/lineReader.stub.ts` | `StubLineReader` — finite scripted queue; exhaustion → null (EOF) |
+| `src/tests/units/modules/setup-wizard/entities/promptInputError/promptInputError.test.ts` | 4 tests |
+| `src/tests/units/modules/setup-wizard/entities/answerLine/answerLine.guard.test.ts` | 6 tests |
+| `src/tests/units/modules/setup-wizard/interface-adapters/gateways/prompt.stdinJson.gateway.test.ts` | 15 tests (one per spec scenario for the gateway) |
+| `src/tests/acceptance/187-setup-wizard-json-stdin-input.acceptance.test.ts` | 8 acceptance tests (SDD outer loop) |
+
+## Files modified (4)
+
+| File | Change |
+|------|--------|
+| `src/modules/setup-wizard/entities/wizardContext/wizardContext.ts` | Added `currentStepId: StepId \| null` |
+| `src/modules/setup-wizard/usecases/orchestrateSetup.usecase.ts` | Set `context.currentStepId = step.id` before `emitStepStarted`; wrap `step.execute` in `runStep` try/catch mapping `AwaitingInputClosedError` / `NonInteractiveInputError` → `blocked()` |
+| `src/main/commands/setup.command.ts` | Added `buildLineReader` dependency; in `--json` mode build `PromptStdinJsonGateway`, otherwise keep the `buildGateways` prompt (TTY); init `currentStepId: null` |
+| `src/tests/units/main/commands/setup.command.test.ts` | Added `buildLineReader` to helper; TTY-mode regression test (never builds a line reader in human mode) + json-mode counterpart |
+
+Plus the 11 existing step/acceptance context literals that gained `currentStepId: null`
+to satisfy the new required field (fixed during the verify pass).
+
+## Design decisions (matched the validated plan)
+
+1. **stepId coupling** — orchestrator sets `context.currentStepId` before each
+   step; the stdin gateway reads it via an injected `() => StepId` getter. No
+   `PromptGateway` signature change, no per-step edits.
+2. **EOF → blocked** — `LineReader.read()` returns `null` on stream close; the
+   gateway throws `AwaitingInputClosedError`; the orchestrator maps it to
+   `blocked("Aucune réponse reçue, le setup est interrompu", …)`. StepOutcome
+   construction stays in the application layer.
+3. **Re-announce loop** — invalid/malformed/wrong-shape → `emitWarning(refusal)`
+   + re-`emitAwaitingInput` + read next line, no cap. Terminable in tests because
+   the stub reader is finite (exhaustion → null → blocked).
+4. **Injectable I/O** — `LineReader` port + `StubLineReader` (tests) +
+   `NodeStdinLineReader` (prod, the only file touching real stdin, intentionally
+   not unit-tested).
+5. **Value encoding** — text = raw line (empty → default, never JSON-parsed);
+   confirm = JSON boolean; choice = JSON string ∈ offered; multiSelect = JSON
+   string[] all ∈ offered. Refusal messages verbatim per spec. JSON parse failure
+   → `"Réponse illisible"`. Wrong shape → `"Réponse invalide"`.
+6. **`-y` non-interactive** — gateway throws `NonInteractiveInputError(...)` up
+   front; orchestrator maps to `blocked`. Steps already short-circuit `flags.yes`
+   before prompting, so this is a defensive net (verified never hit on happy path).
+
+## Test results
+
+`yarn verify` (typecheck + lint + test:ci) — **GREEN**:
+
+- typecheck: `tsc --noEmit` — clean (exit 0)
+- lint: `biome check src/` — 914 files checked, no fixes applied
+- test:ci: **361 test files passed, 2834 tests passed, 0 failed**
+
+SPEC-187 unit + acceptance subset: **35 test files, 206 tests, all passing**
+(includes SPEC-183 acceptance as a regression guard).
+
+New SPEC-187 test counts:
+- `promptInputError.test.ts`: 4
+- `answerLine.guard.test.ts`: 6
+- `prompt.stdinJson.gateway.test.ts`: 15
+- `setup.command.test.ts`: +2 (TTY regression + json counterpart), 4 total
+- acceptance: 8
+- `orchestrateSetup.usecase.test.ts`: +3 (currentStepId set, two error→blocked mappings), 10 total
+
+## Acceptance status
+
+`src/tests/acceptance/187-setup-wizard-json-stdin-input.acceptance.test.ts` — **8/8 GREEN**.
+
+Harness fixes applied this session (test-only; production code untouched):
+
+1. **Full `--json` run to completion** — removed the impossible `localPath: null`
+   path (the `secrets` step runs before `add-project` and blocks on a missing
+   path). The run now uses a real project path, `daemonInactive: true` (so the
+   daemon step prompts a `confirm`, then the stub transitions to active and reports
+   healthy), an ambiguous platform (so `add-project` prompts a `choice`), and a
+   `custom` preset (so `pipeline` prompts a `multiSelect` + `choice`s). It reaches
+   `done`/`completed` with exitCode 0, exercising confirm + choice + multiSelect.
+2. **Empty text → default** — rewritten to run `AddProjectStep` in isolation with
+   `localPath: null` and an empty line, with the gitRemote stub pointed at
+   `process.cwd()`. Asserts the step succeeds and `context.project.localPath`
+   equals the step's default — proving the empty-text→default behaviour through
+   real step + gateway orchestration without depending on `generate-files`.
+3. **`-y` non-interactive** — uses a real project path + ambiguous platform so the
+   wizard reaches `add-project`, which then blocks in `-y` mode (exitCode 2) with
+   an empty `StubLineReader` that is never read.
+
+The text shape's empty→default rule is additionally pinned at the gateway unit
+level (`prompt.stdinJson.gateway.test.ts`).
+
+## Spec coverage mapping
+
+| Rule / Scenario | Covered by |
+|-----------------|------------|
+| JSON mode announces waiting + pauses for stdin | gateway `askText`/`askConfirm`/`askChoice`/`askMultiSelect` announce tests; acceptance "announces awaiting_input" |
+| Each answer = one line; never blocks on a terminal | `LineReader` seam + `StubLineReader`; `NodeStdinLineReader` reads one line per `read()` |
+| Human terminal experience unchanged when JSON off | `setup.command.test.ts` "never builds a line reader in human mode" regression |
+| Four answer shapes supported | gateway tests for text / confirm / choice / multiSelect (15) |
+| text answer → value | gateway "returns the raw line as the value" |
+| empty text uses default | gateway "uses the default value when the line is empty"; acceptance "uses the step default when an empty text line is read" |
+| confirm yes/no → boolean | gateway "returns true/false for the line" |
+| single choice valid → value | gateway "returns the chosen value when it is offered" |
+| single choice not offered → `Choix invalide, sélectionnez une option proposée` | gateway + acceptance "re-announces … single choice is not offered" |
+| multi choice valid → values | gateway "returns the selected values when all are offered" |
+| multi choice unknown value → `Sélection invalide, une valeur n'est pas proposée` | gateway + acceptance "re-announces … multiSelect value is not offered" |
+| wrong shape → `Réponse invalide` + re-announce | gateway confirm/choice/multiSelect wrong-shape tests |
+| malformed line → `Réponse illisible` + re-announce | gateway "malformed input"; acceptance "re-announces … malformed line" |
+| input stream closed → blocked `Aucune réponse reçue, le setup est interrompu` | gateway EOF test; orchestrator mapping test; acceptance "blocks … stream closes" |
+| `-y` needs input → `Mode non-interactif : aucune entrée disponible pour cette étape` | gateway non-interactive test; orchestrator mapping test; acceptance `-y` test |
+
+## Self-review
+
+| Criterion | Result |
+|-----------|--------|
+| Naming (full words, camelCase, suffixes) | PASS |
+| Imports (`@/` + `.js`, no relative, no barrel) | PASS |
+| TypeScript (no `any` / `as` / `!`) | PASS — verified by scan |
+| Architecture (dependency rule, ports in entities, no StepOutcome in gateway) | PASS |
+| Tests (factories/stubs, state-based, mocks only at I/O) | PASS |
+| Clean code (no superfluous comments) | PASS |
+| Domain (`null` for absence, no `undefined` in domain types) | PASS |
+
+Review-fix loop iterations: 0 (no violations found).
+
+## Blockers
+
+None.
+
+## Notes for the orchestrator
+
+- No commit made, spec/tracker status unchanged, no push (per instructions).
+- No new runtime dependency (`node:readline` built-in, `zod` already present).
+- `NodeStdinLineReader` is the only non-unit-tested file (real stdin I/O boundary),
+  covered indirectly by the wiring tests and intended for SPEC-184 Iteration B.

--- a/docs/specs/187-setup-wizard-json-stdin-input.md
+++ b/docs/specs/187-setup-wizard-json-stdin-input.md
@@ -1,6 +1,6 @@
 ---
 title: "SPEC-187: Read setup wizard answers from stdin in JSON mode"
-status: drafted
+status: implemented
 milestone: Setup Wizard Jarvis
 depends_on:
   - "183-setup-wizard-cli-orchestrator"
@@ -9,6 +9,25 @@ related:
 ---
 
 # SPEC-187: Read setup wizard answers from stdin in JSON mode
+
+## Status: implemented
+
+See [implementation report](../reports/187-setup-wizard-json-stdin-input.report.md) and [plan](../plans/187-setup-wizard-json-stdin-input.plan.md). This unblocks SPEC-184 Iteration B (dashboard `POST /api/setup/input` → subprocess stdin).
+
+## Implementation
+
+### Artefacts
+- **Entities**: `lineReader/lineReader.gateway.ts` (injectable stdin line-source port), `promptInputError/promptInputError.ts` (`AwaitingInputClosedError`, `NonInteractiveInputError`), `answerLine/answerLine.schema.ts` + `.guard.ts` (Zod validation of confirm/choice/multiSelect shapes).
+- **Gateway impl**: `prompt.stdinJson.gateway.ts` (`PromptStdinJsonGateway` implements `PromptGateway`: emits `awaiting_input`, reads one JSON line, validates against offered options, re-announces on refusal), `lineReader.stdin.gateway.ts` (prod `node:readline` over `process.stdin`).
+- **Orchestrator**: `orchestrateSetup.usecase.ts` sets `context.currentStepId` before each step and maps `AwaitingInputClosedError`/`NonInteractiveInputError` to `blocked` outcomes.
+- **Context**: `wizardContext.ts` gains `currentStepId: StepId | null`.
+- **Wiring**: `setup.command.ts` selects `PromptStdinJsonGateway` when `--json`, else `PromptTtyGateway`; adds a `buildLineReader` factory.
+
+### Decisions
+- The new gateway keeps the existing `PromptGateway` signatures unchanged; the current step id reaches it via an injected getter reading `context.currentStepId` (set by the orchestrator), so no step call-site changed.
+- EOF on stdin (`LineReader.read()` → `null`) throws a typed domain error that the orchestrator converts to a blocked `StepOutcome` (construction stays in the app layer).
+- Invalid/malformed/wrong-shape answers emit a `warning` and re-announce `awaiting_input` with no retry cap; tests stay terminable via a finite line feed.
+- Human (TTY) mode is unchanged — a regression test proves `json=false` builds `PromptTtyGateway` and never touches stdin.
 
 ## Context
 

--- a/src/main/commands/setup.command.ts
+++ b/src/main/commands/setup.command.ts
@@ -24,11 +24,15 @@ import { ServerConfigFileSystemGateway } from '@/modules/setup-wizard/interface-
 import { ValidationAdapterGateway } from '@/modules/setup-wizard/interface-adapters/gateways/validation.adapter.gateway.js';
 import { AiFallbackNoopGateway } from '@/modules/setup-wizard/interface-adapters/gateways/aiFallback.noop.gateway.js';
 import { PromptTtyGateway } from '@/modules/setup-wizard/interface-adapters/gateways/prompt.tty.gateway.js';
+import { PromptStdinJsonGateway } from '@/modules/setup-wizard/interface-adapters/gateways/prompt.stdinJson.gateway.js';
+import { NodeStdinLineReader } from '@/modules/setup-wizard/interface-adapters/gateways/lineReader.stdin.gateway.js';
 import { HumanWizardEventEmitter } from '@/modules/setup-wizard/services/humanWizardEventEmitter.js';
 import { JsonWizardEventEmitter } from '@/modules/setup-wizard/services/jsonWizardEventEmitter.js';
 import type { SetupStep } from '@/modules/setup-wizard/entities/setupStep/setupStep.js';
 import type { WizardContext, WizardGateways } from '@/modules/setup-wizard/entities/wizardContext/wizardContext.js';
 import type { WizardEventEmitter } from '@/modules/setup-wizard/services/wizardEventEmitter.js';
+import type { PromptGateway } from '@/modules/setup-wizard/entities/prompt/prompt.gateway.js';
+import type { LineReader } from '@/modules/setup-wizard/entities/lineReader/lineReader.gateway.js';
 import { getConfigDir } from '@/shared/services/configDir.js';
 
 const DEFAULT_DAEMON_PORT = 3847;
@@ -47,10 +51,24 @@ export interface SetupDependencies {
   buildSteps: () => SetupStep[];
   buildGateways: (args: SetupCliArgs) => WizardGateways;
   buildEmitter: (args: SetupCliArgs, write: (line: string) => void) => WizardEventEmitter;
+  buildLineReader: () => LineReader;
   resolveProjectPath: (args: SetupCliArgs) => string | null;
   log: (line: string) => void;
   exit: (code: number) => void;
   now: () => Date;
+}
+
+function buildStdinPromptGateway(
+  emitter: WizardEventEmitter,
+  context: WizardContext,
+  deps: SetupDependencies,
+): PromptGateway {
+  return new PromptStdinJsonGateway({
+    lineReader: deps.buildLineReader(),
+    emitter,
+    currentStepId: () => context.currentStepId ?? 'dependencies',
+    isNonInteractive: () => context.flags.yes,
+  });
 }
 
 export async function executeSetup(args: SetupCliArgs, deps: SetupDependencies): Promise<void> {
@@ -60,6 +78,7 @@ export async function executeSetup(args: SetupCliArgs, deps: SetupDependencies):
 
   const context: WizardContext = {
     state: null,
+    currentStepId: null,
     project: {
       localPath: projectPath,
       platform: null,
@@ -79,6 +98,10 @@ export async function executeSetup(args: SetupCliArgs, deps: SetupDependencies):
     emitter,
     now: deps.now,
   };
+
+  if (args.json) {
+    context.gateways.prompt = buildStdinPromptGateway(emitter, context, deps);
+  }
 
   const orchestrator = new OrchestrateSetupUseCase();
   const result = await orchestrator.execute({ context, steps: deps.buildSteps() });
@@ -134,6 +157,7 @@ export function createSetupDependencies(): SetupDependencies {
     },
     buildEmitter: (args, write) =>
       args.json ? new JsonWizardEventEmitter(write) : new HumanWizardEventEmitter(write),
+    buildLineReader: () => new NodeStdinLineReader(),
     resolveProjectPath: (args) => args.path ?? process.cwd(),
     log: (line) => console.log(line),
     exit: (code) => process.exit(code),

--- a/src/modules/setup-wizard/entities/answerLine/answerLine.guard.ts
+++ b/src/modules/setup-wizard/entities/answerLine/answerLine.guard.ts
@@ -1,0 +1,10 @@
+import { createGuard } from '@/shared/foundation/guard.base.js';
+import {
+  confirmAnswerSchema,
+  choiceAnswerSchema,
+  multiSelectAnswerSchema,
+} from '@/modules/setup-wizard/entities/answerLine/answerLine.schema.js';
+
+export const confirmAnswerGuard = createGuard(confirmAnswerSchema, 'confirmAnswer');
+export const choiceAnswerGuard = createGuard(choiceAnswerSchema, 'choiceAnswer');
+export const multiSelectAnswerGuard = createGuard(multiSelectAnswerSchema, 'multiSelectAnswer');

--- a/src/modules/setup-wizard/entities/answerLine/answerLine.schema.ts
+++ b/src/modules/setup-wizard/entities/answerLine/answerLine.schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const confirmAnswerSchema = z.boolean();
+export const choiceAnswerSchema = z.string();
+export const multiSelectAnswerSchema = z.array(z.string());
+
+export type ConfirmAnswer = z.infer<typeof confirmAnswerSchema>;
+export type ChoiceAnswer = z.infer<typeof choiceAnswerSchema>;
+export type MultiSelectAnswer = z.infer<typeof multiSelectAnswerSchema>;

--- a/src/modules/setup-wizard/entities/lineReader/lineReader.gateway.ts
+++ b/src/modules/setup-wizard/entities/lineReader/lineReader.gateway.ts
@@ -1,0 +1,3 @@
+export interface LineReader {
+  read(): Promise<string | null>;
+}

--- a/src/modules/setup-wizard/entities/promptInputError/promptInputError.ts
+++ b/src/modules/setup-wizard/entities/promptInputError/promptInputError.ts
@@ -1,0 +1,13 @@
+export class AwaitingInputClosedError extends Error {
+  constructor() {
+    super('Aucune réponse reçue, le setup est interrompu');
+    this.name = 'AwaitingInputClosedError';
+  }
+}
+
+export class NonInteractiveInputError extends Error {
+  constructor() {
+    super('Mode non-interactif : aucune entrée disponible pour cette étape');
+    this.name = 'NonInteractiveInputError';
+  }
+}

--- a/src/modules/setup-wizard/entities/wizardContext/wizardContext.ts
+++ b/src/modules/setup-wizard/entities/wizardContext/wizardContext.ts
@@ -1,4 +1,5 @@
 import type { SetupState } from '@/modules/setup-wizard/entities/setupState/setupState.schema.js';
+import type { StepId } from '@/modules/setup-wizard/entities/stepId/stepId.schema.js';
 import type { ProjectContext } from '@/modules/setup-wizard/entities/projectContext/projectContext.schema.js';
 import type { SetupStateGateway } from '@/modules/setup-wizard/entities/setupState/setupState.gateway.js';
 import type { DependencyProbeGateway } from '@/modules/setup-wizard/entities/dependencyProbe/dependencyProbe.gateway.js';
@@ -42,6 +43,7 @@ export interface WizardGateways {
 
 export interface WizardContext {
   state: SetupState | null;
+  currentStepId: StepId | null;
   project: ProjectContext;
   flags: WizardFlags;
   gateways: WizardGateways;

--- a/src/modules/setup-wizard/interface-adapters/gateways/lineReader.stdin.gateway.ts
+++ b/src/modules/setup-wizard/interface-adapters/gateways/lineReader.stdin.gateway.ts
@@ -1,0 +1,44 @@
+import { createInterface, type Interface } from 'node:readline';
+import type { Readable } from 'node:stream';
+import type { LineReader } from '@/modules/setup-wizard/entities/lineReader/lineReader.gateway.js';
+
+type PendingResolver = (line: string | null) => void;
+
+export class NodeStdinLineReader implements LineReader {
+  private readonly readline: Interface;
+  private readonly buffered: string[] = [];
+  private readonly waiting: PendingResolver[] = [];
+  private closed = false;
+
+  constructor(input: Readable = process.stdin) {
+    this.readline = createInterface({ input });
+    this.readline.on('line', (line) => this.enqueue(line));
+    this.readline.on('close', () => this.finish());
+  }
+
+  async read(): Promise<string | null> {
+    const buffered = this.buffered.shift();
+    if (buffered !== undefined) return buffered;
+    if (this.closed) return null;
+    return new Promise<string | null>((resolve) => {
+      this.waiting.push(resolve);
+    });
+  }
+
+  private enqueue(line: string): void {
+    const resolver = this.waiting.shift();
+    if (resolver) {
+      resolver(line);
+      return;
+    }
+    this.buffered.push(line);
+  }
+
+  private finish(): void {
+    this.closed = true;
+    while (this.waiting.length > 0) {
+      const resolver = this.waiting.shift();
+      if (resolver) resolver(null);
+    }
+  }
+}

--- a/src/modules/setup-wizard/interface-adapters/gateways/prompt.stdinJson.gateway.ts
+++ b/src/modules/setup-wizard/interface-adapters/gateways/prompt.stdinJson.gateway.ts
@@ -1,0 +1,108 @@
+import type { PromptGateway, PromptChoice } from '@/modules/setup-wizard/entities/prompt/prompt.gateway.js';
+import type { LineReader } from '@/modules/setup-wizard/entities/lineReader/lineReader.gateway.js';
+import type { WizardEventEmitter } from '@/modules/setup-wizard/services/wizardEventEmitter.js';
+import type { StepId } from '@/modules/setup-wizard/entities/stepId/stepId.schema.js';
+import {
+  AwaitingInputClosedError,
+  NonInteractiveInputError,
+} from '@/modules/setup-wizard/entities/promptInputError/promptInputError.js';
+import {
+  confirmAnswerGuard,
+  choiceAnswerGuard,
+  multiSelectAnswerGuard,
+} from '@/modules/setup-wizard/entities/answerLine/answerLine.guard.js';
+
+export interface PromptStdinJsonGatewayDependencies {
+  lineReader: LineReader;
+  emitter: WizardEventEmitter;
+  currentStepId: () => StepId;
+  isNonInteractive: () => boolean;
+}
+
+type Accepted<T> = { accepted: true; value: T };
+type Refused = { accepted: false; refusal: string };
+type Validation<T> = Accepted<T> | Refused;
+
+function accept<T>(value: T): Accepted<T> {
+  return { accepted: true, value };
+}
+
+function refuse(refusal: string): Refused {
+  return { accepted: false, refusal };
+}
+
+function parseJson(line: string): Validation<unknown> {
+  try {
+    return accept(JSON.parse(line));
+  } catch {
+    return refuse('Réponse illisible');
+  }
+}
+
+export class PromptStdinJsonGateway implements PromptGateway {
+  constructor(private readonly dependencies: PromptStdinJsonGatewayDependencies) {}
+
+  async askText(prompt: string, defaultValue?: string): Promise<string> {
+    const line = await this.requestLine(prompt);
+    if (line.length === 0) return defaultValue ?? '';
+    return line;
+  }
+
+  async askConfirm(prompt: string): Promise<boolean> {
+    return this.requestValidated(prompt, (line) => {
+      const parsed = parseJson(line);
+      if (!parsed.accepted) return parsed;
+      if (!confirmAnswerGuard.isValid(parsed.value)) return refuse('Réponse invalide');
+      return accept(parsed.value);
+    });
+  }
+
+  async askChoice(prompt: string, choices: PromptChoice[]): Promise<string> {
+    const offered = choices.map((choice) => choice.value);
+    return this.requestValidated(prompt, (line) => {
+      const parsed = parseJson(line);
+      if (!parsed.accepted) return parsed;
+      if (!choiceAnswerGuard.isValid(parsed.value)) return refuse('Réponse invalide');
+      if (!offered.includes(parsed.value)) {
+        return refuse('Choix invalide, sélectionnez une option proposée');
+      }
+      return accept(parsed.value);
+    });
+  }
+
+  async askMultiSelect(prompt: string, choices: PromptChoice[]): Promise<string[]> {
+    const offered = choices.map((choice) => choice.value);
+    return this.requestValidated(prompt, (line) => {
+      const parsed = parseJson(line);
+      if (!parsed.accepted) return parsed;
+      if (!multiSelectAnswerGuard.isValid(parsed.value)) return refuse('Réponse invalide');
+      if (!parsed.value.every((value) => offered.includes(value))) {
+        return refuse("Sélection invalide, une valeur n'est pas proposée");
+      }
+      return accept(parsed.value);
+    });
+  }
+
+  private guardInteractive(): void {
+    if (this.dependencies.isNonInteractive()) {
+      throw new NonInteractiveInputError();
+    }
+  }
+
+  private async requestLine(prompt: string): Promise<string> {
+    this.guardInteractive();
+    this.dependencies.emitter.emitAwaitingInput(this.dependencies.currentStepId(), prompt);
+    const line = await this.dependencies.lineReader.read();
+    if (line === null) throw new AwaitingInputClosedError();
+    return line;
+  }
+
+  private async requestValidated<T>(prompt: string, validate: (line: string) => Validation<T>): Promise<T> {
+    for (;;) {
+      const line = await this.requestLine(prompt);
+      const validation = validate(line);
+      if (validation.accepted) return validation.value;
+      this.dependencies.emitter.emitWarning(validation.refusal);
+    }
+  }
+}

--- a/src/modules/setup-wizard/usecases/orchestrateSetup.usecase.ts
+++ b/src/modules/setup-wizard/usecases/orchestrateSetup.usecase.ts
@@ -4,7 +4,11 @@ import type { StepOutcome } from '@/modules/setup-wizard/entities/stepOutcome/st
 import type { SetupStep } from '@/modules/setup-wizard/entities/setupStep/setupStep.js';
 import type { WizardContext } from '@/modules/setup-wizard/entities/wizardContext/wizardContext.js';
 import { createInitialState, markStep, findFirstIncomplete } from '@/modules/setup-wizard/entities/setupState/setupState.js';
-import { isFinalSuccess, isBlocking } from '@/modules/setup-wizard/entities/stepOutcome/stepOutcome.js';
+import { isFinalSuccess, isBlocking, blocked } from '@/modules/setup-wizard/entities/stepOutcome/stepOutcome.js';
+import {
+  AwaitingInputClosedError,
+  NonInteractiveInputError,
+} from '@/modules/setup-wizard/entities/promptInputError/promptInputError.js';
 
 export interface OrchestrateSetupInput {
   context: WizardContext;
@@ -19,6 +23,20 @@ export interface OrchestrateSetupResult {
 }
 
 export class OrchestrateSetupUseCase {
+  private async runStep(step: SetupStep, context: WizardContext): Promise<StepOutcome> {
+    try {
+      return await step.execute(context);
+    } catch (error) {
+      if (error instanceof AwaitingInputClosedError) {
+        return blocked(error.message, 'Fournissez une réponse sur stdin ou relancez sans --json');
+      }
+      if (error instanceof NonInteractiveInputError) {
+        return blocked(error.message, 'Relancez sans -y pour répondre interactivement');
+      }
+      throw error;
+    }
+  }
+
   async execute(input: OrchestrateSetupInput): Promise<OrchestrateSetupResult> {
     const { context, steps } = input;
     const loadResult = context.gateways.setupState.load();
@@ -56,6 +74,7 @@ export class OrchestrateSetupUseCase {
         }
       }
 
+      context.currentStepId = step.id;
       context.emitter.emitStepStarted(step.id, step.title);
       const detected = await step.detect(context);
       let outcome: StepOutcome;
@@ -64,7 +83,7 @@ export class OrchestrateSetupUseCase {
       } else if (detected && isBlocking(detected)) {
         outcome = detected;
       } else {
-        outcome = await step.execute(context);
+        outcome = await this.runStep(step, context);
       }
       context.emitter.emitStepCompleted(step.id, outcome);
       state = markStep(state, step.id, outcome, context.now);

--- a/src/tests/acceptance/183-setup-wizard.acceptance.test.ts
+++ b/src/tests/acceptance/183-setup-wizard.acceptance.test.ts
@@ -102,6 +102,7 @@ describe('Acceptance — SPEC-183: Setup Wizard CLI orchestrator', () => {
       : new HumanWizardEventEmitter(() => undefined);
     return {
       state: null,
+      currentStepId: null,
       project: {
         localPath: projectPath,
         platform: null,

--- a/src/tests/acceptance/187-setup-wizard-json-stdin-input.acceptance.test.ts
+++ b/src/tests/acceptance/187-setup-wizard-json-stdin-input.acceptance.test.ts
@@ -1,0 +1,300 @@
+/**
+ * SPEC-187 — Read setup wizard answers from stdin in JSON mode
+ *
+ * Spec: docs/specs/187-setup-wizard-json-stdin-input.md
+ * Plan: docs/plans/187-setup-wizard-json-stdin-input.plan.md
+ *
+ * Outer-loop acceptance test (SDD). Stays RED while inside-out TDD builds the
+ * stdin prompt gateway + the line-reader seam, turns GREEN when a scripted JSON
+ * line feed drives a full --json run that needs input to completion.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { OrchestrateSetupUseCase } from '@/modules/setup-wizard/usecases/orchestrateSetup.usecase.js';
+import { CheckDependenciesStep } from '@/modules/setup-wizard/usecases/steps/checkDependencies.step.js';
+import { ClaudeLoginStep } from '@/modules/setup-wizard/usecases/steps/claudeLogin.step.js';
+import { DaemonInstallStep } from '@/modules/setup-wizard/usecases/steps/daemonInstall.step.js';
+import { GenerateSecretsStep } from '@/modules/setup-wizard/usecases/steps/generateSecrets.step.js';
+import { AddProjectStep } from '@/modules/setup-wizard/usecases/steps/addProject.step.js';
+import { ConfigurePipelineStep } from '@/modules/setup-wizard/usecases/steps/configurePipeline.step.js';
+import { GenerateFilesStep } from '@/modules/setup-wizard/usecases/steps/generateFiles.step.js';
+import { RegisterProjectStep } from '@/modules/setup-wizard/usecases/steps/registerProject.step.js';
+import { ValidateSetupStep } from '@/modules/setup-wizard/usecases/steps/validateSetup.step.js';
+import { DisplayNextActionsStep } from '@/modules/setup-wizard/usecases/steps/displayNextActions.step.js';
+import { StubDependencyProbeGateway } from '@/tests/stubs/setup-wizard/dependencyProbe.stub.js';
+import { StubClaudeAuthGateway } from '@/tests/stubs/setup-wizard/claudeAuth.stub.js';
+import { StubDaemonServiceGateway } from '@/tests/stubs/setup-wizard/daemonService.stub.js';
+import { StubDaemonHealthProbeGateway } from '@/tests/stubs/setup-wizard/daemonHealthProbe.stub.js';
+import { StubEnvFileGateway } from '@/tests/stubs/setup-wizard/envFile.stub.js';
+import { StubGitRemoteGateway } from '@/tests/stubs/setup-wizard/gitRemote.stub.js';
+import { StubProjectConfigGateway } from '@/tests/stubs/setup-wizard/projectConfig.stub.js';
+import { StubSkillTemplateGateway } from '@/tests/stubs/setup-wizard/skillTemplate.stub.js';
+import { StubServerConfigGateway } from '@/tests/stubs/setup-wizard/serverConfig.stub.js';
+import { StubValidationGateway } from '@/tests/stubs/setup-wizard/validation.stub.js';
+import { StubAiFallbackGateway } from '@/tests/stubs/setup-wizard/aiFallback.stub.js';
+import { StubLineReader } from '@/tests/stubs/setup-wizard/lineReader.stub.js';
+import { SetupStateFileSystemGateway } from '@/modules/setup-wizard/interface-adapters/gateways/setupState.fileSystem.gateway.js';
+import { PromptStdinJsonGateway } from '@/modules/setup-wizard/interface-adapters/gateways/prompt.stdinJson.gateway.js';
+import { JsonWizardEventEmitter } from '@/modules/setup-wizard/services/jsonWizardEventEmitter.js';
+import type { WizardContext } from '@/modules/setup-wizard/entities/wizardContext/wizardContext.js';
+import type { SetupStep } from '@/modules/setup-wizard/entities/setupStep/setupStep.js';
+
+interface WizardEvent {
+  step: string;
+  status: string;
+  prompt?: string;
+  message?: string;
+}
+
+interface BuildContextOptions {
+  lines: string[];
+  ambiguousPlatform?: boolean;
+  daemonInactive?: boolean;
+  yes?: boolean;
+}
+
+describe('Acceptance — SPEC-187: Read setup wizard answers from stdin in JSON mode', () => {
+  let rootDir: string;
+  let stateFilePath: string;
+  let projectPath: string;
+
+  beforeEach(() => {
+    rootDir = mkdtempSync(join(tmpdir(), 'reviewflow-setup-187-'));
+    stateFilePath = join(rootDir, 'setup-state.json');
+    projectPath = join(rootDir, 'my-project');
+    mkdirSync(projectPath, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  function buildSteps(): SetupStep[] {
+    return [
+      new CheckDependenciesStep(),
+      new ClaudeLoginStep(),
+      new DaemonInstallStep(),
+      new GenerateSecretsStep(),
+      new AddProjectStep(),
+      new ConfigurePipelineStep(),
+      new GenerateFilesStep(),
+      new RegisterProjectStep(),
+      new ValidateSetupStep(),
+      new DisplayNextActionsStep(),
+    ];
+  }
+
+  function buildContext(options: BuildContextOptions): { context: WizardContext; events: WizardEvent[] } {
+    const events: WizardEvent[] = [];
+    const emitter = new JsonWizardEventEmitter((line) => events.push(JSON.parse(line)));
+    const platform = options.ambiguousPlatform ? 'unknown' : 'github';
+    const remoteUrl = options.ambiguousPlatform
+      ? 'git@custom.com:org/repo.git'
+      : 'git@github.com:org/repo.git';
+
+    const context: WizardContext = {
+      state: null,
+      currentStepId: null,
+      project: {
+        localPath: projectPath,
+        platform: null,
+        preset: null,
+        language: null,
+        remoteUrl: null,
+      },
+      flags: {
+        path: projectPath,
+        json: true,
+        force: false,
+        ai: false,
+        yes: options.yes ?? false,
+        showSecrets: false,
+      },
+      gateways: {
+        setupState: new SetupStateFileSystemGateway({ filePath: stateFilePath }),
+        dependencyProbe: new StubDependencyProbeGateway(),
+        claudeAuth: new StubClaudeAuthGateway(),
+        daemonService: new StubDaemonServiceGateway(
+          options.daemonInactive ? { initialStatus: { status: 'inactive' } } : {},
+        ),
+        daemonHealthProbe: new StubDaemonHealthProbeGateway(),
+        envFile: new StubEnvFileGateway(),
+        gitRemote: new StubGitRemoteGateway({ projectPath, platform, remoteUrl }),
+        projectConfig: new StubProjectConfigGateway(),
+        skillTemplate: new StubSkillTemplateGateway(),
+        serverConfig: new StubServerConfigGateway(),
+        validation: new StubValidationGateway(),
+        aiFallback: new StubAiFallbackGateway(),
+        prompt: new PromptStdinJsonGateway({
+          lineReader: new StubLineReader(options.lines),
+          emitter,
+          currentStepId: () => context.currentStepId ?? 'add-project',
+          isNonInteractive: () => context.flags.yes,
+        }),
+      },
+      emitter,
+      now: () => new Date('2026-05-28T10:00:00.000Z'),
+    };
+    return { context, events };
+  }
+
+  it('drives a full --json run that exercises confirm, choice and multiSelect to completion', async () => {
+    const orchestrator = new OrchestrateSetupUseCase();
+    const { context, events } = buildContext({
+      ambiguousPlatform: true,
+      daemonInactive: true,
+      lines: [
+        'true', // daemon confirm
+        '"github"', // add-project choice (platform)
+        '"custom"', // pipeline preset choice
+        '["solid","testing"]', // pipeline multiSelect agents
+        '"en"', // pipeline language choice
+      ],
+    });
+
+    const result = await orchestrator.execute({ context, steps: buildSteps() });
+
+    expect(result.exitCode).toBe(0);
+    expect(context.project.platform).toBe('github');
+    expect(context.project.preset).toBe('custom');
+    const done = events[events.length - 1];
+    expect(done.step).toBe('done');
+    expect(done.status).toBe('completed');
+  });
+
+  it('announces awaiting_input before reading an answer', async () => {
+    const orchestrator = new OrchestrateSetupUseCase();
+    const { context, events } = buildContext({
+      ambiguousPlatform: true,
+      lines: ['"gitlab"', '"backend"', '"en"'],
+    });
+
+    await orchestrator.execute({ context, steps: buildSteps() });
+
+    const awaiting = events.filter((event) => event.status === 'awaiting_input');
+    expect(awaiting.length).toBeGreaterThan(0);
+    expect(awaiting[0].step).toBe('add-project');
+  });
+
+  it('uses the step default when an empty text line is read', async () => {
+    const events: WizardEvent[] = [];
+    const emitter = new JsonWizardEventEmitter((line) => events.push(JSON.parse(line)));
+    const defaultPath = process.cwd();
+    const context: WizardContext = {
+      state: null,
+      currentStepId: 'add-project',
+      project: { localPath: null, platform: null, preset: null, language: null, remoteUrl: null },
+      flags: { path: null, json: true, force: false, ai: false, yes: false, showSecrets: false },
+      gateways: {
+        setupState: new SetupStateFileSystemGateway({ filePath: stateFilePath }),
+        dependencyProbe: new StubDependencyProbeGateway(),
+        claudeAuth: new StubClaudeAuthGateway(),
+        daemonService: new StubDaemonServiceGateway(),
+        daemonHealthProbe: new StubDaemonHealthProbeGateway(),
+        envFile: new StubEnvFileGateway(),
+        gitRemote: new StubGitRemoteGateway({
+          projectPath: defaultPath,
+          platform: 'github',
+          remoteUrl: 'git@github.com:org/repo.git',
+        }),
+        projectConfig: new StubProjectConfigGateway(),
+        skillTemplate: new StubSkillTemplateGateway(),
+        serverConfig: new StubServerConfigGateway(),
+        validation: new StubValidationGateway(),
+        aiFallback: new StubAiFallbackGateway(),
+        prompt: new PromptStdinJsonGateway({
+          lineReader: new StubLineReader(['']),
+          emitter,
+          currentStepId: () => context.currentStepId ?? 'add-project',
+          isNonInteractive: () => context.flags.yes,
+        }),
+      },
+      emitter,
+      now: () => new Date('2026-05-28T10:00:00.000Z'),
+    };
+
+    const outcome = await new AddProjectStep().execute(context);
+
+    expect(outcome.status).toBe('succeeded');
+    expect(context.project.localPath).toBe(defaultPath);
+  });
+
+  it('re-announces and accepts the next line when a single choice is not offered', async () => {
+    const orchestrator = new OrchestrateSetupUseCase();
+    const { context, events } = buildContext({
+      ambiguousPlatform: true,
+      lines: ['"mobile"', '"gitlab"', '"backend"', '"en"'],
+    });
+
+    const result = await orchestrator.execute({ context, steps: buildSteps() });
+
+    expect(result.exitCode).toBe(0);
+    expect(context.project.platform).toBe('gitlab');
+    const warnings = events.filter((event) => event.status === 'warning');
+    expect(warnings.some((event) => event.message === 'Choix invalide, sélectionnez une option proposée')).toBe(true);
+    const awaiting = events.filter((event) => event.status === 'awaiting_input' && event.step === 'add-project');
+    expect(awaiting.length).toBe(2);
+  });
+
+  it('re-announces and accepts the next line when a multiSelect value is not offered', async () => {
+    const orchestrator = new OrchestrateSetupUseCase();
+    const { context, events } = buildContext({
+      lines: ['"custom"', '["solid","mobile"]', '["solid"]', '"en"'],
+    });
+
+    const result = await orchestrator.execute({ context, steps: buildSteps() });
+
+    expect(result.exitCode).toBe(0);
+    expect(context.project.preset).toBe('custom');
+    const warnings = events.filter((event) => event.status === 'warning');
+    expect(warnings.some((event) => event.message === "Sélection invalide, une valeur n'est pas proposée")).toBe(true);
+  });
+
+  it('re-announces and accepts the next line when a malformed line arrives', async () => {
+    const orchestrator = new OrchestrateSetupUseCase();
+    const { context, events } = buildContext({
+      ambiguousPlatform: true,
+      lines: ['{not json', '"github"', '"backend"', '"en"'],
+    });
+
+    const result = await orchestrator.execute({ context, steps: buildSteps() });
+
+    expect(result.exitCode).toBe(0);
+    expect(context.project.platform).toBe('github');
+    const warnings = events.filter((event) => event.status === 'warning');
+    expect(warnings.some((event) => event.message === 'Réponse illisible')).toBe(true);
+  });
+
+  it('blocks the step when the input stream closes before an answer', async () => {
+    const orchestrator = new OrchestrateSetupUseCase();
+    const { context } = buildContext({
+      ambiguousPlatform: true,
+      lines: [],
+    });
+
+    const result = await orchestrator.execute({ context, steps: buildSteps() });
+
+    expect(result.exitCode).toBe(1);
+    const outcome = result.finalState.steps['add-project'];
+    expect(outcome?.status).toBe('blocked');
+    expect(outcome?.message).toBe('Aucune réponse reçue, le setup est interrompu');
+  });
+
+  it('blocks a step needing input in non-interactive (-y) mode without reading stdin', async () => {
+    const orchestrator = new OrchestrateSetupUseCase();
+    const { context } = buildContext({
+      ambiguousPlatform: true,
+      yes: true,
+      lines: [],
+    });
+
+    const result = await orchestrator.execute({ context, steps: buildSteps() });
+
+    expect(result.exitCode).toBe(2);
+    const outcome = result.finalState.steps['add-project'];
+    expect(outcome?.status).toBe('blocked');
+  });
+});

--- a/src/tests/stubs/setup-wizard/lineReader.stub.ts
+++ b/src/tests/stubs/setup-wizard/lineReader.stub.ts
@@ -1,0 +1,15 @@
+import type { LineReader } from '@/modules/setup-wizard/entities/lineReader/lineReader.gateway.js';
+
+export class StubLineReader implements LineReader {
+  private readonly lines: string[];
+
+  constructor(lines: string[]) {
+    this.lines = [...lines];
+  }
+
+  async read(): Promise<string | null> {
+    const next = this.lines.shift();
+    if (next === undefined) return null;
+    return next;
+  }
+}

--- a/src/tests/units/main/commands/setup.command.test.ts
+++ b/src/tests/units/main/commands/setup.command.test.ts
@@ -18,6 +18,8 @@ import { StubServerConfigGateway } from '@/tests/stubs/setup-wizard/serverConfig
 import { StubValidationGateway } from '@/tests/stubs/setup-wizard/validation.stub.js';
 import { StubAiFallbackGateway } from '@/tests/stubs/setup-wizard/aiFallback.stub.js';
 import { StubPromptGateway } from '@/tests/stubs/setup-wizard/prompt.stub.js';
+import { StubLineReader } from '@/tests/stubs/setup-wizard/lineReader.stub.js';
+import type { LineReader } from '@/modules/setup-wizard/entities/lineReader/lineReader.gateway.js';
 import { CheckDependenciesStep } from '@/modules/setup-wizard/usecases/steps/checkDependencies.step.js';
 import { ClaudeLoginStep } from '@/modules/setup-wizard/usecases/steps/claudeLogin.step.js';
 import { DaemonInstallStep } from '@/modules/setup-wizard/usecases/steps/daemonInstall.step.js';
@@ -29,7 +31,13 @@ import { RegisterProjectStep } from '@/modules/setup-wizard/usecases/steps/regis
 import { ValidateSetupStep } from '@/modules/setup-wizard/usecases/steps/validateSetup.step.js';
 import { DisplayNextActionsStep } from '@/modules/setup-wizard/usecases/steps/displayNextActions.step.js';
 
-function buildDependencies(rootDir: string, projectPath: string, log: (line: string) => void, exitCodes: number[]): SetupDependencies {
+function buildDependencies(
+  rootDir: string,
+  projectPath: string,
+  log: (line: string) => void,
+  exitCodes: number[],
+  buildLineReader: () => LineReader = () => new StubLineReader([]),
+): SetupDependencies {
   return {
     buildSteps: () => [
       new CheckDependenciesStep(),
@@ -60,6 +68,7 @@ function buildDependencies(rootDir: string, projectPath: string, log: (line: str
     }),
     buildEmitter: (args, write) =>
       args.json ? new JsonWizardEventEmitter(write) : new HumanWizardEventEmitter(write),
+    buildLineReader,
     resolveProjectPath: (args) => args.path ?? projectPath,
     log,
     exit: (code) => {
@@ -79,6 +88,47 @@ describe('executeSetup', () => {
       const args: SetupCliArgs = { path: projectPath, json: false, force: false, ai: false, yes: false, showSecrets: false };
       await executeSetup(args, buildDependencies(rootDir, projectPath, (line) => lines.push(line), exitCodes));
       expect(exitCodes).toEqual([0]);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('never builds a line reader in human (non-JSON) mode', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'reviewflow-setup-cmd-tty-'));
+    try {
+      const projectPath = join(rootDir, 'project');
+      const exitCodes: number[] = [];
+      let lineReaderBuilt = 0;
+      const args: SetupCliArgs = { path: projectPath, json: false, force: false, ai: false, yes: false, showSecrets: false };
+      const deps = buildDependencies(rootDir, projectPath, () => undefined, exitCodes, () => {
+        lineReaderBuilt++;
+        return new StubLineReader([]);
+      });
+
+      await executeSetup(args, deps);
+
+      expect(lineReaderBuilt).toBe(0);
+      expect(exitCodes).toEqual([0]);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('builds a line reader in --json mode', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'reviewflow-setup-cmd-json-reader-'));
+    try {
+      const projectPath = join(rootDir, 'project');
+      const exitCodes: number[] = [];
+      let lineReaderBuilt = 0;
+      const args: SetupCliArgs = { path: projectPath, json: true, force: false, ai: false, yes: false, showSecrets: false };
+      const deps = buildDependencies(rootDir, projectPath, () => undefined, exitCodes, () => {
+        lineReaderBuilt++;
+        return new StubLineReader([]);
+      });
+
+      await executeSetup(args, deps);
+
+      expect(lineReaderBuilt).toBe(1);
     } finally {
       rmSync(rootDir, { recursive: true, force: true });
     }

--- a/src/tests/units/modules/setup-wizard/entities/answerLine/answerLine.guard.test.ts
+++ b/src/tests/units/modules/setup-wizard/entities/answerLine/answerLine.guard.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import {
+  confirmAnswerGuard,
+  choiceAnswerGuard,
+  multiSelectAnswerGuard,
+} from '@/modules/setup-wizard/entities/answerLine/answerLine.guard.js';
+
+describe('confirmAnswerGuard', () => {
+  it('accepts a boolean', () => {
+    expect(confirmAnswerGuard.isValid(true)).toBe(true);
+    expect(confirmAnswerGuard.isValid(false)).toBe(true);
+  });
+
+  it('rejects a non-boolean', () => {
+    expect(confirmAnswerGuard.isValid('maybe')).toBe(false);
+    expect(confirmAnswerGuard.isValid(1)).toBe(false);
+  });
+});
+
+describe('choiceAnswerGuard', () => {
+  it('accepts a string', () => {
+    expect(choiceAnswerGuard.isValid('backend')).toBe(true);
+  });
+
+  it('rejects a non-string', () => {
+    expect(choiceAnswerGuard.isValid(42)).toBe(false);
+    expect(choiceAnswerGuard.isValid(['backend'])).toBe(false);
+  });
+});
+
+describe('multiSelectAnswerGuard', () => {
+  it('accepts an array of strings', () => {
+    expect(multiSelectAnswerGuard.isValid(['solid', 'testing'])).toBe(true);
+    expect(multiSelectAnswerGuard.isValid([])).toBe(true);
+  });
+
+  it('rejects a value that is not an array of strings', () => {
+    expect(multiSelectAnswerGuard.isValid('solid')).toBe(false);
+    expect(multiSelectAnswerGuard.isValid([1, 2])).toBe(false);
+  });
+});

--- a/src/tests/units/modules/setup-wizard/entities/promptInputError/promptInputError.test.ts
+++ b/src/tests/units/modules/setup-wizard/entities/promptInputError/promptInputError.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AwaitingInputClosedError,
+  NonInteractiveInputError,
+} from '@/modules/setup-wizard/entities/promptInputError/promptInputError.js';
+
+describe('AwaitingInputClosedError', () => {
+  it('is an Error identifiable via instanceof', () => {
+    const error = new AwaitingInputClosedError();
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(AwaitingInputClosedError);
+  });
+
+  it('carries the French remediation message', () => {
+    const error = new AwaitingInputClosedError();
+
+    expect(error.message).toBe('Aucune réponse reçue, le setup est interrompu');
+  });
+});
+
+describe('NonInteractiveInputError', () => {
+  it('is an Error identifiable via instanceof', () => {
+    const error = new NonInteractiveInputError();
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(NonInteractiveInputError);
+  });
+
+  it('carries the French non-interactive message', () => {
+    const error = new NonInteractiveInputError();
+
+    expect(error.message).toBe('Mode non-interactif : aucune entrée disponible pour cette étape');
+  });
+});

--- a/src/tests/units/modules/setup-wizard/interface-adapters/gateways/lineReader.stdin.gateway.test.ts
+++ b/src/tests/units/modules/setup-wizard/interface-adapters/gateways/lineReader.stdin.gateway.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { NodeStdinLineReader } from '@/modules/setup-wizard/interface-adapters/gateways/lineReader.stdin.gateway.js';
+
+describe('NodeStdinLineReader', () => {
+  it('parks read() until a line arrives, then resolves it', async () => {
+    const input = new PassThrough();
+    const reader = new NodeStdinLineReader(input);
+
+    const pending = reader.read();
+    input.write('hello\n');
+
+    expect(await pending).toBe('hello');
+  });
+
+  it('buffers a line that arrives before read() and returns it on the next read()', async () => {
+    const input = new PassThrough();
+    const reader = new NodeStdinLineReader(input);
+
+    input.write('queued\n');
+
+    expect(await reader.read()).toBe('queued');
+  });
+
+  it('returns buffered lines in FIFO order', async () => {
+    const input = new PassThrough();
+    const reader = new NodeStdinLineReader(input);
+
+    input.write('first\nsecond\n');
+
+    expect(await reader.read()).toBe('first');
+    expect(await reader.read()).toBe('second');
+  });
+
+  it('returns null to a reader waiting when the stream closes', async () => {
+    const input = new PassThrough();
+    const reader = new NodeStdinLineReader(input);
+
+    const pending = reader.read();
+    input.end();
+
+    expect(await pending).toBeNull();
+  });
+
+  it('returns null on read() once the stream is already closed', async () => {
+    const input = new PassThrough();
+    const reader = new NodeStdinLineReader(input);
+    input.end();
+    await new Promise((resolve) => input.on('close', resolve));
+
+    expect(await reader.read()).toBeNull();
+  });
+});

--- a/src/tests/units/modules/setup-wizard/interface-adapters/gateways/prompt.stdinJson.gateway.test.ts
+++ b/src/tests/units/modules/setup-wizard/interface-adapters/gateways/prompt.stdinJson.gateway.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest';
+import { PromptStdinJsonGateway } from '@/modules/setup-wizard/interface-adapters/gateways/prompt.stdinJson.gateway.js';
+import { AwaitingInputClosedError, NonInteractiveInputError } from '@/modules/setup-wizard/entities/promptInputError/promptInputError.js';
+import { StubLineReader } from '@/tests/stubs/setup-wizard/lineReader.stub.js';
+import type { StepId } from '@/modules/setup-wizard/entities/stepId/stepId.schema.js';
+import type { StepOutcome } from '@/modules/setup-wizard/entities/stepOutcome/stepOutcome.schema.js';
+import type { WizardEventEmitter } from '@/modules/setup-wizard/services/wizardEventEmitter.js';
+
+interface AwaitingEvent {
+  stepId: StepId;
+  prompt: string;
+}
+
+class RecordingEmitter implements WizardEventEmitter {
+  public awaiting: AwaitingEvent[] = [];
+  public warnings: string[] = [];
+
+  emitStepStarted(): void {}
+  emitStepCompleted(_stepId: StepId, _outcome: StepOutcome): void {}
+  emitAwaitingInput(stepId: StepId, prompt: string): void {
+    this.awaiting.push({ stepId, prompt });
+  }
+  emitInstructions(): void {}
+  emitWarning(message: string): void {
+    this.warnings.push(message);
+  }
+  emitResumeBanner(): void {}
+  emitDone(): void {}
+}
+
+interface BuildOptions {
+  lines: string[];
+  emitter?: RecordingEmitter;
+  nonInteractive?: boolean;
+  stepId?: StepId;
+}
+
+function build(options: BuildOptions): { gateway: PromptStdinJsonGateway; emitter: RecordingEmitter } {
+  const emitter = options.emitter ?? new RecordingEmitter();
+  const gateway = new PromptStdinJsonGateway({
+    lineReader: new StubLineReader(options.lines),
+    emitter,
+    currentStepId: () => options.stepId ?? 'add-project',
+    isNonInteractive: () => options.nonInteractive ?? false,
+  });
+  return { gateway, emitter };
+}
+
+describe('PromptStdinJsonGateway', () => {
+  describe('askText', () => {
+    it('returns the raw line as the value', async () => {
+      const { gateway } = build({ lines: ['/home/u/api'] });
+
+      const value = await gateway.askText('Project path?');
+
+      expect(value).toBe('/home/u/api');
+    });
+
+    it('announces awaiting_input before reading', async () => {
+      const { gateway, emitter } = build({ lines: ['/home/u/api'], stepId: 'add-project' });
+
+      await gateway.askText('Project path?');
+
+      expect(emitter.awaiting).toEqual([{ stepId: 'add-project', prompt: 'Project path?' }]);
+    });
+
+    it('uses the default value when the line is empty', async () => {
+      const { gateway } = build({ lines: [''] });
+
+      const value = await gateway.askText('Project path?', '/home/u/api');
+
+      expect(value).toBe('/home/u/api');
+    });
+
+    it('throws AwaitingInputClosedError when the stream closes before an answer', async () => {
+      const { gateway } = build({ lines: [] });
+
+      await expect(gateway.askText('Project path?')).rejects.toBeInstanceOf(AwaitingInputClosedError);
+    });
+
+    it('throws NonInteractiveInputError when constructed for non-interactive mode', async () => {
+      const { gateway } = build({ lines: ['/home/u/api'], nonInteractive: true });
+
+      await expect(gateway.askText('Project path?')).rejects.toBeInstanceOf(NonInteractiveInputError);
+    });
+  });
+
+  describe('askConfirm', () => {
+    it('returns true for the line "true"', async () => {
+      const { gateway } = build({ lines: ['true'] });
+
+      expect(await gateway.askConfirm('Continue?')).toBe(true);
+    });
+
+    it('returns false for the line "false"', async () => {
+      const { gateway } = build({ lines: ['false'] });
+
+      expect(await gateway.askConfirm('Continue?')).toBe(false);
+    });
+
+    it('refuses a wrong-shape answer, re-announces, then accepts the next valid line', async () => {
+      const { gateway, emitter } = build({ lines: ['"maybe"', 'true'] });
+
+      const value = await gateway.askConfirm('Continue?');
+
+      expect(value).toBe(true);
+      expect(emitter.warnings).toContain('Réponse invalide');
+      expect(emitter.awaiting).toHaveLength(2);
+    });
+  });
+
+  describe('askChoice', () => {
+    const choices = [
+      { label: 'Backend', value: 'backend' },
+      { label: 'Frontend', value: 'frontend' },
+    ];
+
+    it('returns the chosen value when it is offered', async () => {
+      const { gateway } = build({ lines: ['"backend"'] });
+
+      expect(await gateway.askChoice('Preset?', choices)).toBe('backend');
+    });
+
+    it('refuses an unoffered choice, re-announces, then accepts the next valid line', async () => {
+      const { gateway, emitter } = build({ lines: ['"mobile"', '"frontend"'] });
+
+      const value = await gateway.askChoice('Preset?', choices);
+
+      expect(value).toBe('frontend');
+      expect(emitter.warnings).toContain('Choix invalide, sélectionnez une option proposée');
+      expect(emitter.awaiting).toHaveLength(2);
+    });
+
+    it('refuses a non-string answer with the generic invalid message', async () => {
+      const { gateway, emitter } = build({ lines: ['42', '"backend"'] });
+
+      const value = await gateway.askChoice('Preset?', choices);
+
+      expect(value).toBe('backend');
+      expect(emitter.warnings).toContain('Réponse invalide');
+    });
+  });
+
+  describe('askMultiSelect', () => {
+    const choices = [
+      { label: 'SOLID', value: 'solid' },
+      { label: 'Testing', value: 'testing' },
+      { label: 'Security', value: 'security' },
+    ];
+
+    it('returns the selected values when all are offered', async () => {
+      const { gateway } = build({ lines: ['["solid","testing"]'] });
+
+      expect(await gateway.askMultiSelect('Skills?', choices)).toEqual(['solid', 'testing']);
+    });
+
+    it('refuses a selection with an unknown value, re-announces, then accepts the next valid line', async () => {
+      const { gateway, emitter } = build({ lines: ['["solid","mobile"]', '["solid"]'] });
+
+      const value = await gateway.askMultiSelect('Skills?', choices);
+
+      expect(value).toEqual(['solid']);
+      expect(emitter.warnings).toContain("Sélection invalide, une valeur n'est pas proposée");
+      expect(emitter.awaiting).toHaveLength(2);
+    });
+
+    it('refuses a wrong-shape answer with the generic invalid message', async () => {
+      const { gateway, emitter } = build({ lines: ['"solid"', '["solid"]'] });
+
+      const value = await gateway.askMultiSelect('Skills?', choices);
+
+      expect(value).toEqual(['solid']);
+      expect(emitter.warnings).toContain('Réponse invalide');
+    });
+  });
+
+  describe('malformed input', () => {
+    it('refuses an unparseable line, re-announces, then accepts the next valid line', async () => {
+      const { gateway, emitter } = build({ lines: ['{not json', 'true'] });
+
+      const value = await gateway.askConfirm('Continue?');
+
+      expect(value).toBe(true);
+      expect(emitter.warnings).toContain('Réponse illisible');
+      expect(emitter.awaiting).toHaveLength(2);
+    });
+  });
+});

--- a/src/tests/units/modules/setup-wizard/usecases/orchestrateSetup.usecase.test.ts
+++ b/src/tests/units/modules/setup-wizard/usecases/orchestrateSetup.usecase.test.ts
@@ -8,6 +8,10 @@ import type { SetupStateGateway, SetupStateLoadResult } from '@/modules/setup-wi
 import type { WizardContext } from '@/modules/setup-wizard/entities/wizardContext/wizardContext.js';
 import type { WizardEventEmitter } from '@/modules/setup-wizard/services/wizardEventEmitter.js';
 import { succeeded, blocked } from '@/modules/setup-wizard/entities/stepOutcome/stepOutcome.js';
+import {
+  AwaitingInputClosedError,
+  NonInteractiveInputError,
+} from '@/modules/setup-wizard/entities/promptInputError/promptInputError.js';
 import { SetupStateFactory } from '@/tests/factories/setupState.factory.js';
 import { StubDependencyProbeGateway } from '@/tests/stubs/setup-wizard/dependencyProbe.stub.js';
 import { StubClaudeAuthGateway } from '@/tests/stubs/setup-wizard/claudeAuth.stub.js';
@@ -87,6 +91,7 @@ class RecordingStateGateway implements SetupStateGateway {
 function buildContext(emitter: WizardEventEmitter, stateGateway: SetupStateGateway, yes = false): WizardContext {
   return {
     state: null,
+    currentStepId: null,
     project: { localPath: '/tmp/p', platform: 'github', preset: 'backend', language: 'en', remoteUrl: null },
     flags: { path: '/tmp/p', json: false, force: false, ai: false, yes, showSecrets: false },
     gateways: {
@@ -208,6 +213,71 @@ describe('OrchestrateSetupUseCase', () => {
 
     expect(result.exitCode).toBe(1);
     expect(steps[1].executeCalls).toBe(0);
+  });
+
+  it('maps an AwaitingInputClosedError thrown by a step to a blocked outcome', async () => {
+    const emitter = new RecordingEmitter();
+    const stateGateway = new RecordingStateGateway({ state: null, corrupted: false });
+    const throwingStep: SetupStep = {
+      id: 'add-project',
+      title: 'Add project',
+      async detect() {
+        return null;
+      },
+      async execute() {
+        throw new AwaitingInputClosedError();
+      },
+    };
+
+    const result = await orchestrator.execute({ context: buildContext(emitter, stateGateway), steps: [throwingStep] });
+
+    expect(result.exitCode).toBe(1);
+    const outcome = result.finalState.steps['add-project'];
+    expect(outcome?.status).toBe('blocked');
+    expect(outcome?.message).toBe('Aucune réponse reçue, le setup est interrompu');
+  });
+
+  it('maps a NonInteractiveInputError thrown by a step to a blocked outcome', async () => {
+    const emitter = new RecordingEmitter();
+    const stateGateway = new RecordingStateGateway({ state: null, corrupted: false });
+    const throwingStep: SetupStep = {
+      id: 'add-project',
+      title: 'Add project',
+      async detect() {
+        return null;
+      },
+      async execute() {
+        throw new NonInteractiveInputError();
+      },
+    };
+
+    const result = await orchestrator.execute({ context: buildContext(emitter, stateGateway, true), steps: [throwingStep] });
+
+    expect(result.exitCode).toBe(2);
+    const outcome = result.finalState.steps['add-project'];
+    expect(outcome?.status).toBe('blocked');
+    expect(outcome?.message).toBe('Mode non-interactif : aucune entrée disponible pour cette étape');
+  });
+
+  it('exposes the current step id on the context while a step executes', async () => {
+    const emitter = new RecordingEmitter();
+    const stateGateway = new RecordingStateGateway({ state: null, corrupted: false });
+    let seen: StepId | null = null;
+    const observingStep: SetupStep = {
+      id: 'daemon',
+      title: 'Daemon',
+      async detect() {
+        return null;
+      },
+      async execute(context: WizardContext) {
+        seen = context.currentStepId;
+        return succeeded();
+      },
+    };
+
+    await orchestrator.execute({ context: buildContext(emitter, stateGateway), steps: [observingStep] });
+
+    expect(seen).toBe('daemon');
   });
 
   it('warns and starts fresh when the loaded state is corrupted', async () => {

--- a/src/tests/units/modules/setup-wizard/usecases/steps/addProject.step.test.ts
+++ b/src/tests/units/modules/setup-wizard/usecases/steps/addProject.step.test.ts
@@ -33,6 +33,7 @@ function buildContext(gitRemote: GitRemoteGateway, options: ContextOptions = {})
   const projectPath = options.projectPath ?? '/tmp/p';
   return {
     state: null,
+    currentStepId: null,
     project: { localPath: projectPath, platform: null, preset: null, language: null, remoteUrl: null },
     flags: {
       path: projectPath,

--- a/src/tests/units/modules/setup-wizard/usecases/steps/checkDependencies.step.test.ts
+++ b/src/tests/units/modules/setup-wizard/usecases/steps/checkDependencies.step.test.ts
@@ -28,6 +28,7 @@ function noopStateGateway(): SetupStateGateway {
 function buildContext(probe: DependencyProbeGateway): WizardContext {
   return {
     state: null,
+    currentStepId: null,
     project: { localPath: '/tmp/p', platform: null, preset: null, language: null, remoteUrl: null },
     flags: { path: '/tmp/p', json: false, force: false, ai: false, yes: false, showSecrets: false },
     gateways: {

--- a/src/tests/units/modules/setup-wizard/usecases/steps/claudeLogin.step.test.ts
+++ b/src/tests/units/modules/setup-wizard/usecases/steps/claudeLogin.step.test.ts
@@ -28,6 +28,7 @@ function noopStateGateway(): SetupStateGateway {
 function buildContext(claudeAuth: ClaudeAuthGateway, yes = false): WizardContext {
   return {
     state: null,
+    currentStepId: null,
     project: { localPath: '/tmp/p', platform: null, preset: null, language: null, remoteUrl: null },
     flags: { path: '/tmp/p', json: false, force: false, ai: false, yes, showSecrets: false },
     gateways: {

--- a/src/tests/units/modules/setup-wizard/usecases/steps/configurePipeline.step.test.ts
+++ b/src/tests/units/modules/setup-wizard/usecases/steps/configurePipeline.step.test.ts
@@ -23,6 +23,7 @@ function noopStateGateway(): SetupStateGateway {
 function buildContext(prompt: StubPromptGateway, yes = false): WizardContext {
   return {
     state: null,
+    currentStepId: null,
     project: { localPath: '/tmp/p', platform: 'github', preset: null, language: null, remoteUrl: null },
     flags: { path: '/tmp/p', json: false, force: false, ai: false, yes, showSecrets: false },
     gateways: {

--- a/src/tests/units/modules/setup-wizard/usecases/steps/daemonInstall.step.test.ts
+++ b/src/tests/units/modules/setup-wizard/usecases/steps/daemonInstall.step.test.ts
@@ -29,6 +29,7 @@ interface BuildOptions {
 function buildContext(options: BuildOptions = {}): WizardContext {
   return {
     state: null,
+    currentStepId: null,
     project: { localPath: '/tmp/p', platform: 'github', preset: 'backend', language: 'en', remoteUrl: null },
     flags: { path: '/tmp/p', json: false, force: false, ai: false, yes: options.yes ?? false, showSecrets: false },
     gateways: {

--- a/src/tests/units/modules/setup-wizard/usecases/steps/displayNextActions.step.test.ts
+++ b/src/tests/units/modules/setup-wizard/usecases/steps/displayNextActions.step.test.ts
@@ -33,6 +33,7 @@ function buildContext(options: BuildOptions = {}): WizardContext {
   const platform = options.platform === undefined ? 'github' : options.platform;
   return {
     state: null,
+    currentStepId: null,
     project: { localPath: '/tmp/p', platform, preset: 'backend', language: 'en', remoteUrl: null },
     flags: { path: '/tmp/p', json: false, force: false, ai: false, yes: false, showSecrets: options.showSecrets ?? false },
     gateways: {

--- a/src/tests/units/modules/setup-wizard/usecases/steps/generateFiles.step.test.ts
+++ b/src/tests/units/modules/setup-wizard/usecases/steps/generateFiles.step.test.ts
@@ -23,6 +23,7 @@ function noopStateGateway(): SetupStateGateway {
 function buildContext(options: { projectConfig?: StubProjectConfigGateway; skillTemplate?: StubSkillTemplateGateway; force?: boolean } = {}): WizardContext {
   return {
     state: null,
+    currentStepId: null,
     project: { localPath: '/tmp/p', platform: 'github', preset: 'backend', language: 'en', remoteUrl: null },
     flags: { path: '/tmp/p', json: false, force: options.force ?? false, ai: false, yes: false, showSecrets: false },
     gateways: {

--- a/src/tests/units/modules/setup-wizard/usecases/steps/generateSecrets.step.test.ts
+++ b/src/tests/units/modules/setup-wizard/usecases/steps/generateSecrets.step.test.ts
@@ -25,6 +25,7 @@ function noopStateGateway(): SetupStateGateway {
 function buildContext(envFile: EnvFileGateway, options: { prompt?: StubPromptGateway; yes?: boolean } = {}): WizardContext {
   return {
     state: null,
+    currentStepId: null,
     project: { localPath: '/tmp/p', platform: null, preset: null, language: null, remoteUrl: null },
     flags: { path: '/tmp/p', json: false, force: false, ai: false, yes: options.yes ?? false, showSecrets: false },
     gateways: {

--- a/src/tests/units/modules/setup-wizard/usecases/steps/registerProject.step.test.ts
+++ b/src/tests/units/modules/setup-wizard/usecases/steps/registerProject.step.test.ts
@@ -23,6 +23,7 @@ function noopStateGateway(): SetupStateGateway {
 function buildContext(serverConfig: StubServerConfigGateway, healthProbe: StubDaemonHealthProbeGateway): WizardContext {
   return {
     state: null,
+    currentStepId: null,
     project: { localPath: '/tmp/p', platform: 'github', preset: 'backend', language: 'en', remoteUrl: null },
     flags: { path: '/tmp/p', json: false, force: false, ai: false, yes: false, showSecrets: false },
     gateways: {

--- a/src/tests/units/modules/setup-wizard/usecases/steps/validateSetup.step.test.ts
+++ b/src/tests/units/modules/setup-wizard/usecases/steps/validateSetup.step.test.ts
@@ -24,6 +24,7 @@ function noopStateGateway(): SetupStateGateway {
 function buildContext(validation: ValidationGateway): WizardContext {
   return {
     state: null,
+    currentStepId: null,
     project: { localPath: '/tmp/p', platform: 'github', preset: 'backend', language: 'en', remoteUrl: null },
     flags: { path: '/tmp/p', json: false, force: false, ai: false, yes: false, showSecrets: false },
     gateways: {


### PR DESCRIPTION
## Summary
Implements **SPEC-187** — in `--json` mode the setup wizard now announces it is waiting (`awaiting_input` event) and reads each answer as ONE JSON line from stdin, for the 4 prompt shapes (text / confirm / choice / multiSelect), instead of blocking on a TTY. First real caller of `emitAwaitingInput`. **Unblocks SPEC-184 Iteration B** (dashboard `POST /api/setup/input` → subprocess stdin).

- New `PromptStdinJsonGateway` (same `PromptGateway` interface) selected by the composition root when `--json`; TTY path unchanged (regression-tested).
- Injectable `LineReader` port (prod = `node:readline` over stdin; stub for tests).
- Orchestrator sets `currentStepId` and maps `AwaitingInputClosedError` / `NonInteractiveInputError` to `blocked` outcomes.
- Zod `answerLine` guard validates confirm/choice/multiSelect; choice/multiSelect values validated against offered options; invalid/malformed → `warning` + re-announce (no retry cap); EOF → blocked; `-y` never reads stdin.

## Test plan
- [x] `yarn verify` green — 361 files / 2834 tests
- [x] Acceptance 8/8: scripted JSON line feed drives a full `--json` run (confirm+text+choice+multiSelect) to completion; default-on-empty; re-announce on bad choice/multiSelect/malformed; EOF→blocked; `-y`→blocked
- [x] TTY-mode regression: `json=false` builds `PromptTtyGateway`, never touches stdin