### PR TITLE
fix(worktree): drop false-positive missing-build-artifacts signal

### DIFF
--- a/docs/reports/175-worktree-failure-visibility.report.md
+++ b/docs/reports/175-worktree-failure-visibility.report.md
@@ -6,6 +6,8 @@
 - **Date**: 2026-05-27
 - **Status**: implemented
 
+> **Amendment (2026-05-28)**: the `missing-build-artifacts` signal documented below was removed. Review worktrees are never prebuilt with `node_modules`, so the check flagged every worktree as degraded. The three remaining signals (`stale`, `orphan-git-lock`, `unresolved-conflict`) are unaffected.
+
 ---
 
 ## Summary

--- a/docs/specs/175-worktree-failure-visibility.md
+++ b/docs/specs/175-worktree-failure-visibility.md
@@ -6,16 +6,22 @@
 
 ---
 
+## Amendment (2026-05-28)
+
+The `missing-build-artifacts` degraded state was **removed**. Review worktrees are created via `git worktree add` with no dependency install step — they never carry `node_modules` because a code review reads source, it does not build. The signal therefore flagged every freshly created worktree as degraded ("Artefacts de build manquants" / "Cleanup forcé recommandé"), a 100% false positive. The three remaining signals (`stale`, `orphan-git-lock`, `unresolved-conflict`) are genuine stuck-worktree conditions and are kept. References to the removed signal below are struck through for historical context.
+
+---
+
 ## Implementation
 
 See `docs/reports/175-worktree-failure-visibility.report.md` for the full implementation report.
 
 ### Artefacts
 
-- **Entities**: `WorktreeHealth` discriminated union (`healthy` | `degraded` with `DegradedReason` of kind `stale` | `orphan-git-lock` | `unresolved-conflict` | `missing-build-artifacts`), `WorktreeHealthReport`, `WorktreeHealthProbeGateway` contract.
+- **Entities**: `WorktreeHealth` discriminated union (`healthy` | `degraded` with `DegradedReason` of kind `stale` | `orphan-git-lock` | `unresolved-conflict`), `WorktreeHealthReport`, `WorktreeHealthProbeGateway` contract.
 - **Use cases**: `detectDegradedWorktrees` (ordered first-match detection), `removeWorktree` extended with `force?: boolean` for registry-only cleanup when FS path is absent.
 - **Services**: `InMemoryForceCleanupLockService` (concurrency guard keyed by `${platform}:${projectPath}:${mrNumber}`).
-- **Gateways**: `WorktreeHealthProbeFileSystemGateway` (resolves worktree-local `.git` pointer → `<main-repo>/.git/worktrees/<name>/`, probes `index.lock`/`HEAD.lock` ages, runs `git status --porcelain=v1` for unresolved conflicts, `existsSync(<worktree>/node_modules)` for build artifacts).
+- **Gateways**: `WorktreeHealthProbeFileSystemGateway` (resolves worktree-local `.git` pointer → `<main-repo>/.git/worktrees/<name>/`, probes `index.lock`/`HEAD.lock` ages, runs `git status --porcelain=v1` for unresolved conflicts).
 - **Presenter**: `worktreePanel.presenter.ts` extended with `degradedCount` + `degraded[]` carrying French user-facing reason labels and ready-to-POST cleanup payloads.
 - **Controller**: `worktreeOverview.routes.ts` extended (GET payload + new POST endpoint).
 - **View**: `dashboard/modules/worktreePanel.js` gains `renderDegradedAlerts` and `triggerForceCleanup`; `index.html` binds the click handlers; `styles.css` adds the alert chrome.
@@ -50,7 +56,7 @@ The dashboard needs to (1) flag degraded worktrees explicitly and (2) offer a fo
 ## Rules
 
 - A worktree in a degraded state must display a visual alert in the dashboard worktree panel
-- Detected degraded states: stale (inactive beyond threshold), orphan git lock, unresolved git conflict, missing build artifacts
+- Detected degraded states: stale (inactive beyond threshold), orphan git lock, unresolved git conflict
 - Stale threshold is configurable (default: 24h)
 - Each degraded worktree shows: reason, detection timestamp, recommended action
 - Force-cleanup action removes the worktree from filesystem AND from git worktree registry (`git worktree prune`)
@@ -67,7 +73,7 @@ The dashboard needs to (1) flag degraded worktrees explicitly and (2) offer a fo
 - stale detected: {state: "active", lastActivity: "26h", staleThreshold: "24h"} → status "stale" + alert "Worktree inactif depuis 26h"
 - orphan git lock: {gitLockPresent: true, lockAge: "2h"} → status "degraded" + alert "Lock git orphelin depuis 2h"
 - unresolved git conflict: {gitStatus: "conflict"} → status "degraded" + alert "Conflit git non résolu"
-- missing build artifacts: {buildArtifactsPresent: false} → status "degraded" + alert "Artefacts de build manquants"
+- ~~missing build artifacts: {buildArtifactsPresent: false} → status "degraded" + alert "Artefacts de build manquants"~~ (removed 2026-05-28 — false positive on every review worktree)
 - force-cleanup success: {worktree: "stale", action: "force-cleanup"} → removed + log entry "Force cleanup (raison : inactif 26h)"
 - force-cleanup failure: {worktree: "stale", action: "force-cleanup", filesystemError: "EACCES"} → reject "Cleanup échoué : permission refusée" + alert preserved + failure log entry
 - force-cleanup already running: {worktree: "stale", action: "force-cleanup", inProgress: true} → reject "Cleanup déjà en cours sur ce worktree"
@@ -93,9 +99,8 @@ The dashboard needs to (1) flag degraded worktrees explicitly and (2) offer a fo
 |------|------------|
 | Worktree | Working directory created via `git worktree add` and used as the isolated checkout for a single MR review |
 | Stale | A worktree whose last activity timestamp is older than the configured threshold (default 24h) |
-| Degraded | A worktree in a state preventing its normal lifecycle: stale, orphan lock, conflict, or missing build artifacts |
+| Degraded | A worktree in a state preventing its normal lifecycle: stale, orphan lock, or conflict |
 | Force-cleanup | An operator-triggered removal of a worktree that bypasses the normal lifecycle checks |
-| Build artifacts | The files produced by the project's build (e.g., `node_modules`, `dist`) whose absence indicates an interrupted setup |
 
 ---
 

--- a/src/dashboard/modules/worktreePanel.js
+++ b/src/dashboard/modules/worktreePanel.js
@@ -36,7 +36,7 @@
  */
 
 /**
- * @typedef {'stale' | 'orphan-git-lock' | 'unresolved-conflict' | 'missing-build-artifacts'} DegradedReasonCode
+ * @typedef {'stale' | 'orphan-git-lock' | 'unresolved-conflict'} DegradedReasonCode
  */
 
 /**

--- a/src/modules/worktree-management/entities/worktree/worktreeHealth.schema.ts
+++ b/src/modules/worktree-management/entities/worktree/worktreeHealth.schema.ts
@@ -15,10 +15,6 @@ export const degradedReasonSchema = z.discriminatedUnion('kind', [
   z.object({
     kind: z.literal('unresolved-conflict'),
   }),
-  z.object({
-    kind: z.literal('missing-build-artifacts'),
-    expectedPath: z.string().min(1),
-  }),
 ]);
 
 export type DegradedReason = z.infer<typeof degradedReasonSchema>;

--- a/src/modules/worktree-management/entities/worktree/worktreeHealthProbe.gateway.ts
+++ b/src/modules/worktree-management/entities/worktree/worktreeHealthProbe.gateway.ts
@@ -6,16 +6,10 @@ export interface OrphanLockSignal {
   ageMs: number;
 }
 
-export interface MissingArtifactsSignal {
-  missing: boolean;
-  expectedPath: string;
-}
-
 export interface HealthSignals {
   mtime: Date;
   orphanLock: OrphanLockSignal | null;
   unresolvedConflict: boolean;
-  missingBuildArtifacts: MissingArtifactsSignal;
 }
 
 export interface WorktreeHealthProbeGateway {

--- a/src/modules/worktree-management/interface-adapters/gateways/worktreeHealthProbe.fileSystem.gateway.ts
+++ b/src/modules/worktree-management/interface-adapters/gateways/worktreeHealthProbe.fileSystem.gateway.ts
@@ -94,17 +94,10 @@ export class WorktreeHealthProbeFileSystemGateway implements WorktreeHealthProbe
       unresolvedConflict = false;
     }
 
-    const expectedPath = join(entry.path, 'node_modules');
-    const missingBuildArtifacts = {
-      missing: !existsSync(expectedPath),
-      expectedPath,
-    };
-
     return {
       mtime,
       orphanLock,
       unresolvedConflict,
-      missingBuildArtifacts,
     };
   }
 }

--- a/src/modules/worktree-management/interface-adapters/presenters/worktreePanel.presenter.ts
+++ b/src/modules/worktree-management/interface-adapters/presenters/worktreePanel.presenter.ts
@@ -109,14 +109,8 @@ function describeReason(reason: DegradedReason): { label: string; action: string
       action: 'Cleanup forcé recommandé',
     };
   }
-  if (reason.kind === 'unresolved-conflict') {
-    return {
-      label: 'Conflit git non résolu',
-      action: 'Cleanup forcé recommandé',
-    };
-  }
   return {
-    label: 'Artefacts de build manquants',
+    label: 'Conflit git non résolu',
     action: 'Cleanup forcé recommandé',
   };
 }

--- a/src/modules/worktree-management/usecases/detectDegradedWorktrees.usecase.ts
+++ b/src/modules/worktree-management/usecases/detectDegradedWorktrees.usecase.ts
@@ -38,12 +38,6 @@ function decideReason(
   if (signals.unresolvedConflict) {
     return { kind: 'unresolved-conflict' };
   }
-  if (signals.missingBuildArtifacts.missing) {
-    return {
-      kind: 'missing-build-artifacts',
-      expectedPath: signals.missingBuildArtifacts.expectedPath,
-    };
-  }
   return null;
 }
 

--- a/src/tests/acceptance/175-worktree-failure-visibility.acceptance.test.ts
+++ b/src/tests/acceptance/175-worktree-failure-visibility.acceptance.test.ts
@@ -114,7 +114,6 @@ async function buildAcceptanceApp(options: BuildAppOptions): Promise<AcceptanceA
     mtime: new Date(NOW.getTime() - 60 * 1000),
     orphanLock: null,
     unresolvedConflict: false,
-    missingBuildArtifacts: { missing: false, expectedPath: '' },
   };
   healthProbe.setDefault(fallbackSignals);
 
@@ -168,7 +167,6 @@ describe('Acceptance — SPEC-175: Worktree Failure Visibility & Force-Cleanup',
         mtime: staleMtime,
         orphanLock: null,
         unresolvedConflict: false,
-        missingBuildArtifacts: { missing: false, expectedPath: '' },
       };
       const signalsByPath = new Map<string, HealthSignals>([[stalePath, signals]]);
 
@@ -212,7 +210,6 @@ describe('Acceptance — SPEC-175: Worktree Failure Visibility & Force-Cleanup',
         mtime: staleMtime,
         orphanLock: null,
         unresolvedConflict: false,
-        missingBuildArtifacts: { missing: false, expectedPath: '' },
       };
       const signalsByPath = new Map<string, HealthSignals>([[path, signals]]);
 
@@ -256,7 +253,6 @@ describe('Acceptance — SPEC-175: Worktree Failure Visibility & Force-Cleanup',
         mtime: staleMtime,
         orphanLock: null,
         unresolvedConflict: false,
-        missingBuildArtifacts: { missing: false, expectedPath: '' },
       };
       const signalsByPath = new Map<string, HealthSignals>([[path, signals]]);
 
@@ -302,7 +298,6 @@ describe('Acceptance — SPEC-175: Worktree Failure Visibility & Force-Cleanup',
         mtime: staleMtime,
         orphanLock: null,
         unresolvedConflict: false,
-        missingBuildArtifacts: { missing: false, expectedPath: '' },
       };
       const signalsByPath = new Map<string, HealthSignals>([[path, signals]]);
 
@@ -351,7 +346,6 @@ describe('Acceptance — SPEC-175: Worktree Failure Visibility & Force-Cleanup',
           mtime: staleMtime,
           orphanLock: null,
           unresolvedConflict: false,
-          missingBuildArtifacts: { missing: false, expectedPath: '' },
         });
       }
 

--- a/src/tests/factories/worktreeHealth.factory.ts
+++ b/src/tests/factories/worktreeHealth.factory.ts
@@ -8,7 +8,6 @@ const DEFAULT_STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_STALE_AGE_MS = 26 * 60 * 60 * 1000;
 const DEFAULT_LOCK_AGE_MS = 2 * 60 * 60 * 1000;
 const DEFAULT_LOCK_PATH = '/main/.git/worktrees/example/index.lock';
-const DEFAULT_NODE_MODULES_PATH = '/tmp/worktrees/example/node_modules';
 
 export class WorktreeHealthFactory {
   static healthy(): WorktreeHealth {
@@ -49,17 +48,6 @@ export class WorktreeHealthFactory {
     return {
       status: 'degraded',
       reason: { kind: 'unresolved-conflict' },
-      detectedAt: overrides?.detectedAt ?? DEFAULT_DETECTED_AT,
-    };
-  }
-
-  static missingArtifacts(overrides?: { expectedPath?: string; detectedAt?: Date }): WorktreeHealth {
-    return {
-      status: 'degraded',
-      reason: {
-        kind: 'missing-build-artifacts',
-        expectedPath: overrides?.expectedPath ?? DEFAULT_NODE_MODULES_PATH,
-      },
       detectedAt: overrides?.detectedAt ?? DEFAULT_DETECTED_AT,
     };
   }

--- a/src/tests/stubs/worktreeHealthProbe.stub.ts
+++ b/src/tests/stubs/worktreeHealthProbe.stub.ts
@@ -26,7 +26,6 @@ export class StubWorktreeHealthProbeGateway implements WorktreeHealthProbeGatewa
       mtime: entry.mtime,
       orphanLock: null,
       unresolvedConflict: false,
-      missingBuildArtifacts: { missing: false, expectedPath: '' },
     };
   }
 }

--- a/src/tests/units/dashboard/modules/worktreePanel.test.ts
+++ b/src/tests/units/dashboard/modules/worktreePanel.test.ts
@@ -36,7 +36,7 @@ interface DegradedRowFactoryOverrides {
   platform?: 'gitlab' | 'github';
   projectPath?: string;
   path?: string;
-  reasonCode?: 'stale' | 'orphan-git-lock' | 'unresolved-conflict' | 'missing-build-artifacts';
+  reasonCode?: 'stale' | 'orphan-git-lock' | 'unresolved-conflict';
   reasonLabel?: string;
   detectedAtIso?: string;
   recommendedAction?: string;

--- a/src/tests/units/modules/worktree-management/entities/worktree/worktreeHealth.schema.test.ts
+++ b/src/tests/units/modules/worktree-management/entities/worktree/worktreeHealth.schema.test.ts
@@ -49,15 +49,6 @@ describe('degradedReasonSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('accepts missing-build-artifacts with expectedPath', () => {
-    const result = degradedReasonSchema.safeParse({
-      kind: 'missing-build-artifacts',
-      expectedPath: '/tmp/worktrees/foo/node_modules',
-    });
-
-    expect(result.success).toBe(true);
-  });
-
   it('rejects an unknown kind', () => {
     const result = degradedReasonSchema.safeParse({ kind: 'unknown-disaster' });
 

--- a/src/tests/units/modules/worktree-management/interface-adapters/gateways/worktreeHealthProbe.fileSystem.gateway.test.ts
+++ b/src/tests/units/modules/worktree-management/interface-adapters/gateways/worktreeHealthProbe.fileSystem.gateway.test.ts
@@ -128,27 +128,4 @@ describe('WorktreeHealthProbeFileSystemGateway', () => {
       expect(signals.unresolvedConflict).toBe(true);
     });
   });
-
-  describe('missingBuildArtifacts', () => {
-    it('reports missing: true when node_modules is absent', async () => {
-      const gateway = new WorktreeHealthProbeFileSystemGateway({ executor });
-      const entry = buildEntry(scaffold.worktreeDirectory);
-
-      const signals = await gateway.probe(entry);
-
-      expect(signals.missingBuildArtifacts.missing).toBe(true);
-      expect(signals.missingBuildArtifacts.expectedPath).toBe(join(scaffold.worktreeDirectory, 'node_modules'));
-    });
-
-    it('reports missing: false when node_modules exists', async () => {
-      mkdirSync(join(scaffold.worktreeDirectory, 'node_modules'));
-
-      const gateway = new WorktreeHealthProbeFileSystemGateway({ executor });
-      const entry = buildEntry(scaffold.worktreeDirectory);
-
-      const signals = await gateway.probe(entry);
-
-      expect(signals.missingBuildArtifacts.missing).toBe(false);
-    });
-  });
 });

--- a/src/tests/units/modules/worktree-management/interface-adapters/presenters/worktreePanel.presenter.test.ts
+++ b/src/tests/units/modules/worktree-management/interface-adapters/presenters/worktreePanel.presenter.test.ts
@@ -411,30 +411,6 @@ describe('WorktreePanelPresenter', () => {
       expect(row?.reasonLabel).toBe('Conflit git non résolu');
     });
 
-    it('formats missing-build-artifacts with a static French label', async () => {
-      const identity: WorktreeIdentity = { platform: 'gitlab', projectPath: 'group/no-deps', mrNumber: 7 };
-      const path = '/tmp/worktrees/gitlab-group-no-deps-7';
-      const entry = buildEntry(identity, new Date(NOW.getTime() - 60_000), path);
-      const report: WorktreeHealthReport = {
-        entry,
-        health: WorktreeHealthFactory.missingArtifacts({
-          expectedPath: `${path}/node_modules`,
-          detectedAt: NOW,
-        }),
-      };
-
-      const viewModel = await presenter.present({
-        worktrees: [entry],
-        lastSweep: null,
-        nextSweepAt: NOW,
-        healthReports: [report],
-      });
-
-      const row = viewModel.degraded[0];
-      expect(row?.reasonCode).toBe('missing-build-artifacts');
-      expect(row?.reasonLabel).toBe('Artefacts de build manquants');
-    });
-
     it('excludes healthy reports from the degraded list', async () => {
       const identity: WorktreeIdentity = { platform: 'gitlab', projectPath: 'group/healthy', mrNumber: 8 };
       const path = '/tmp/worktrees/gitlab-group-healthy-8';

--- a/src/tests/units/modules/worktree-management/usecases/detectDegradedWorktrees.usecase.test.ts
+++ b/src/tests/units/modules/worktree-management/usecases/detectDegradedWorktrees.usecase.test.ts
@@ -22,7 +22,6 @@ function freshSignals(): HealthSignals {
     mtime: new Date(NOW.getTime() - 5 * 60 * 1000),
     orphanLock: null,
     unresolvedConflict: false,
-    missingBuildArtifacts: { missing: false, expectedPath: '' },
   };
 }
 
@@ -98,26 +97,7 @@ describe('detectDegradedWorktrees use case', () => {
     }
   });
 
-  it('flags missing-build-artifacts when node_modules is absent', async () => {
-    const probe = new StubWorktreeHealthProbeGateway();
-    const entry = buildEntry(5, new Date(NOW.getTime() - 5 * 60 * 1000), '/tmp/worktrees/gitlab-group-project-5');
-    probe.setSignals(entry.path, {
-      ...freshSignals(),
-      missingBuildArtifacts: { missing: true, expectedPath: `${entry.path}/node_modules` },
-    });
-
-    const reports = await detectDegradedWorktrees(
-      { entries: [entry], staleThresholdMs: STALE_THRESHOLD_MS, now: () => NOW },
-      { healthProbe: probe },
-    );
-
-    expect(reports[0]?.health.status).toBe('degraded');
-    if (reports[0]?.health.status === 'degraded' && reports[0].health.reason.kind === 'missing-build-artifacts') {
-      expect(reports[0].health.reason.expectedPath).toBe(`${entry.path}/node_modules`);
-    }
-  });
-
-  it('returns stale first when stale and orphan-lock both apply (detection order is stale → orphan-lock → conflict → missing-artifacts)', async () => {
+  it('returns stale first when stale and orphan-lock both apply (detection order is stale → orphan-lock → conflict)', async () => {
     const probe = new StubWorktreeHealthProbeGateway();
     const staleMtime = new Date(NOW.getTime() - 30 * ONE_HOUR_MS);
     const entry = buildEntry(6, staleMtime, '/tmp/worktrees/gitlab-group-project-6');
@@ -125,7 +105,6 @@ describe('detectDegradedWorktrees use case', () => {
       mtime: staleMtime,
       orphanLock: { present: true, path: '/main/.git/worktrees/x/index.lock', ageMs: 1 * ONE_HOUR_MS },
       unresolvedConflict: true,
-      missingBuildArtifacts: { missing: true, expectedPath: `${entry.path}/node_modules` },
     });
 
     const reports = await detectDegradedWorktrees(


### PR DESCRIPTION
## Summary
- Le health check des worktrees flaggeait **chaque** worktree de review comme dégradé ("Artefacts de build manquants" / "Cleanup forcé recommandé") — un faux positif à 100 %.
- Cause racine : une review crée le worktree via `git worktree add` sans étape d'install de dépendances ; elle lit le code, ne build pas, donc `node_modules` n'est jamais présent.
- Supprime le signal `missing-build-artifacts` du schéma Zod, du use case de détection, du probe gateway, du presenter et de la vue dashboard.
- Les 3 vrais signaux (`stale`, `orphan-git-lock`, `unresolved-conflict`) sont inchangés. SPEC-175 amendée (note datée).

## Test plan
- [x] `yarn verify` vert (typecheck + lint + 2791 tests)
- [x] Acceptance SPEC-175 verte
- [ ] Vérifier sur le dashboard qu'un worktree fraîchement créé n'affiche plus l'alerte

🤖 Generated with Claude Code