### PR TITLE
docs(changelog): restore missing #239 worktree fix entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **setup-wizard:** SPEC-184 Iteration B — dashboard wizard interactive forms ([#238](https://github.com/DGouron/review-flow/issues/238)) ([806515b](https://github.com/DGouron/review-flow/commit/806515b4a69efbfaf8022185e545393dc7525623))
 * **setup-wizard:** SPEC-187 read wizard answers from stdin in JSON mode ([#237](https://github.com/DGouron/review-flow/issues/237)) ([8476550](https://github.com/DGouron/review-flow/commit/8476550edbfce72743e882e2c4a907d60c5ab9a4))
 
+
+### Fixed
+
+* **worktree:** drop false-positive missing-build-artifacts signal ([#239](https://github.com/DGouron/review-flow/issues/239)) ([41a3a79](https://github.com/DGouron/review-flow/commit/41a3a79b5bec924f895ebfa35197d003fde95dd3))
+
 ## [3.27.0](https://github.com/DGouron/review-flow/compare/reviewflow-v3.26.0...reviewflow-v3.27.0) (2026-05-27)
 
 


### PR DESCRIPTION
## Summary

- Restores the `### Fixed` entry for the worktree fix #239 in the 3.28.0 CHANGELOG section.
- The 3.28.0 release-please PR (#234) was finalized before #239 was captured, so this line was dropped. The duplicate release-please PR #241 carried it but targeted a duplicate 3.28.0 release and has been closed.
- #239 is already shipped in 3.28.0 (it is the release tag's parent commit), so release-please will never re-list it — hence this manual restore.

This is the exact 5-line CHANGELOG delta that #241 contained, nothing else.

## Test plan

- [ ] CHANGELOG renders correctly with the new `### Fixed` section under 3.28.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)