### PR TITLE
fix(docs): unblock vitepress build and refresh setup-wizard docs

### DIFF
--- a/docs/architecture/current.md
+++ b/docs/architecture/current.md
@@ -73,6 +73,7 @@ src/
 │   ├── token-accounting/                          # Token usage + budget cap
 │   ├── statistics-insights/                       # Stats recalculation + developer insights
 │   ├── cli-configuration/                         # init, validate, discover commands
+│   ├── setup-wizard/                              # Interactive `reviewflow setup`: deps check, daemon install, file generation, registration
 │   ├── data-lifecycle/                            # Periodic cleanup of stale tracking data
 │   └── shared-kernel/                             # Cross-module shared types (diff stats, ...)
 │

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -32,8 +32,8 @@ cd ~/reviewflow
 yarn install && yarn build
 yarn start
 
-# Terminal 2: Tunnel
-cloudflared tunnel --url http://localhost:3000
+# Terminal 2: Tunnel (3847 is the default config port)
+cloudflared tunnel --url http://localhost:3847
 ```
 
 Copy the generated URL and use it for your webhook configuration.

--- a/docs/deployment/templates/cloudflared-config.yml
+++ b/docs/deployment/templates/cloudflared-config.yml
@@ -19,7 +19,7 @@ credentials-file: /home/YOUR_USER/.cloudflared/YOUR_TUNNEL_ID.json
 ingress:
   # Route your domain to the local server
   - hostname: review.your-domain.com
-    service: http://localhost:3000
+    service: http://localhost:3847
 
   # Catch-all for unmatched requests
   - service: http_status:404

--- a/docs/feature-tracker.md
+++ b/docs/feature-tracker.md
@@ -28,7 +28,7 @@
 | Split stats service | [80-split-stats-service](specs/80-split-stats-service.md) | drafted | 2026-03-14 |
 | EventBus queue state | [82-eventbus-queue-state](specs/82-eventbus-queue-state.md) | implemented | 2026-03-14 |
 | Delete services folder | [83-delete-services-folder](specs/83-delete-services-folder.md) | implemented | 2026-03-14 |
-| Dashboard multi-project overview | [91-dashboard-multi-project-overview](specs/91-dashboard-multi-project-overview.md) — [plan](plans/91-dashboard-multi-project-overview.plan.md) — [report](reports/91-dashboard-multi-project-overview.report.md) | implemented | 2026-05-25 |
+| Dashboard multi-project overview | [91-dashboard-multi-project-overview](specs/91-dashboard-multi-project-overview.md) — [report](reports/91-dashboard-multi-project-overview.report.md) | implemented | 2026-05-25 |
 | Split CLI god file | [92-split-cli-god-file](specs/92-split-cli-god-file.md) — [plan](plans/92-split-cli-god-file.plan.md) | implemented | 2026-05-24 |
 | Developer & team insights | [125-developer-team-insights](specs/125-developer-team-insights.md) | implemented | 2026-04-01 |
 | Hybrid model routing + token tracking | (no spec — see report) | implemented | 2026-05-14 |

--- a/docs/guide/assets/setup-wizard-flow.svg
+++ b/docs/guide/assets/setup-wizard-flow.svg
@@ -1,0 +1,121 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 430" font-family="'JetBrains Mono','Fira Code',ui-monospace,monospace" role="img" aria-label="ReviewFlow setup wizard: ten ordered steps">
+  <defs>
+    <style>
+      .bg{fill:#16130e}
+      .card{fill:#1f1a13}
+      .br{fill:none;stroke:#e9a83a;stroke-width:2}
+      .br-final{stroke:#5fd97a}
+      .num{fill:#16130e;font-size:13px;font-weight:700}
+      .badge{fill:#e9a83a}
+      .badge-final{fill:#5fd97a}
+      .label{fill:#e8e0d0;font-size:12.5px;letter-spacing:.5px}
+      .sub{fill:#8a7f6a;font-size:10px;letter-spacing:.5px}
+      .flow{fill:none;stroke:#5fd97a;stroke-width:2}
+      .down{fill:none;stroke:#e9a83a;stroke-width:2;stroke-dasharray:4 4}
+      .kw{fill:#5fd97a;font-size:13px;letter-spacing:1px}
+      .title{fill:#f6c66b;font-size:18px;font-weight:700;letter-spacing:1px}
+      .note{fill:#8a7f6a;font-size:11px;letter-spacing:.3px}
+    </style>
+    <marker id="ah" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#5fd97a"/>
+    </marker>
+    <marker id="ah-a" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#e9a83a"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" x="0" y="0" width="960" height="430" rx="10"/>
+
+  <text class="kw" x="30" y="42">// REVIEWFLOW</text>
+  <text class="title" x="30" y="68">SETUP WIZARD</text>
+  <text class="sub" x="30" y="88">$ reviewflow setup  —  10 ordered steps, stops at the first blocking error</text>
+
+  <!-- flow arrows: top row left to right -->
+  <path class="flow" d="M190,150 L210,150" marker-end="url(#ah)"/>
+  <path class="flow" d="M370,150 L390,150" marker-end="url(#ah)"/>
+  <path class="flow" d="M550,150 L570,150" marker-end="url(#ah)"/>
+  <path class="flow" d="M730,150 L750,150" marker-end="url(#ah)"/>
+  <!-- down connector 5 -> 6 -->
+  <path class="down" d="M830,190 L830,270" marker-end="url(#ah-a)"/>
+  <!-- flow arrows: bottom row right to left -->
+  <path class="flow" d="M750,310 L730,310" marker-end="url(#ah)"/>
+  <path class="flow" d="M570,310 L550,310" marker-end="url(#ah)"/>
+  <path class="flow" d="M390,310 L370,310" marker-end="url(#ah)"/>
+  <path class="flow" d="M210,310 L190,310" marker-end="url(#ah)"/>
+
+  <!-- TOP ROW -->
+  <g transform="translate(30,110)">
+    <rect class="card" width="160" height="80" rx="3"/>
+    <path class="br" d="M0,16 L0,0 L16,0 M144,0 L160,0 L160,16 M0,64 L0,80 L16,80 M144,80 L160,80 L160,64"/>
+    <circle class="badge" cx="18" cy="18" r="11"/><text class="num" x="18" y="22.5" text-anchor="middle">1</text>
+    <text class="label" x="80" y="52" text-anchor="middle">CHECK DEPS</text>
+    <text class="sub" x="80" y="68" text-anchor="middle">git · claude · cli</text>
+  </g>
+  <g transform="translate(210,110)">
+    <rect class="card" width="160" height="80" rx="3"/>
+    <path class="br" d="M0,16 L0,0 L16,0 M144,0 L160,0 L160,16 M0,64 L0,80 L16,80 M144,80 L160,80 L160,64"/>
+    <circle class="badge" cx="18" cy="18" r="11"/><text class="num" x="18" y="22.5" text-anchor="middle">2</text>
+    <text class="label" x="80" y="52" text-anchor="middle">CLAUDE LOGIN</text>
+    <text class="sub" x="80" y="68" text-anchor="middle">oauth · no api key</text>
+  </g>
+  <g transform="translate(390,110)">
+    <rect class="card" width="160" height="80" rx="3"/>
+    <path class="br" d="M0,16 L0,0 L16,0 M144,0 L160,0 L160,16 M0,64 L0,80 L16,80 M144,80 L160,80 L160,64"/>
+    <circle class="badge" cx="18" cy="18" r="11"/><text class="num" x="18" y="22.5" text-anchor="middle">3</text>
+    <text class="label" x="80" y="52" text-anchor="middle">INSTALL DAEMON</text>
+    <text class="sub" x="80" y="68" text-anchor="middle">background service</text>
+  </g>
+  <g transform="translate(570,110)">
+    <rect class="card" width="160" height="80" rx="3"/>
+    <path class="br" d="M0,16 L0,0 L16,0 M144,0 L160,0 L160,16 M0,64 L0,80 L16,80 M144,80 L160,80 L160,64"/>
+    <circle class="badge" cx="18" cy="18" r="11"/><text class="num" x="18" y="22.5" text-anchor="middle">4</text>
+    <text class="label" x="80" y="52" text-anchor="middle">GEN SECRETS</text>
+    <text class="sub" x="80" y="68" text-anchor="middle">webhook · .env</text>
+  </g>
+  <g transform="translate(750,110)">
+    <rect class="card" width="160" height="80" rx="3"/>
+    <path class="br" d="M0,16 L0,0 L16,0 M144,0 L160,0 L160,16 M0,64 L0,80 L16,80 M144,80 L160,80 L160,64"/>
+    <circle class="badge" cx="18" cy="18" r="11"/><text class="num" x="18" y="22.5" text-anchor="middle">5</text>
+    <text class="label" x="80" y="52" text-anchor="middle">ADD PROJECT</text>
+    <text class="sub" x="80" y="68" text-anchor="middle">remote · platform</text>
+  </g>
+
+  <!-- BOTTOM ROW -->
+  <g transform="translate(750,270)">
+    <rect class="card" width="160" height="80" rx="3"/>
+    <path class="br" d="M0,16 L0,0 L16,0 M144,0 L160,0 L160,16 M0,64 L0,80 L16,80 M144,80 L160,80 L160,64"/>
+    <circle class="badge" cx="18" cy="18" r="11"/><text class="num" x="18" y="22.5" text-anchor="middle">6</text>
+    <text class="label" x="80" y="52" text-anchor="middle">CONFIG PIPELINE</text>
+    <text class="sub" x="80" y="68" text-anchor="middle">preset · agents</text>
+  </g>
+  <g transform="translate(570,270)">
+    <rect class="card" width="160" height="80" rx="3"/>
+    <path class="br" d="M0,16 L0,0 L16,0 M144,0 L160,0 L160,16 M0,64 L0,80 L16,80 M144,80 L160,80 L160,64"/>
+    <circle class="badge" cx="18" cy="18" r="11"/><text class="num" x="18" y="22.5" text-anchor="middle">7</text>
+    <text class="label" x="80" y="52" text-anchor="middle">GEN FILES</text>
+    <text class="sub" x="80" y="68" text-anchor="middle">config · skills · mcp</text>
+  </g>
+  <g transform="translate(390,270)">
+    <rect class="card" width="160" height="80" rx="3"/>
+    <path class="br" d="M0,16 L0,0 L16,0 M144,0 L160,0 L160,16 M0,64 L0,80 L16,80 M144,80 L160,80 L160,64"/>
+    <circle class="badge" cx="18" cy="18" r="11"/><text class="num" x="18" y="22.5" text-anchor="middle">8</text>
+    <text class="label" x="80" y="52" text-anchor="middle">REGISTER</text>
+    <text class="sub" x="80" y="68" text-anchor="middle">daemon repo list</text>
+  </g>
+  <g transform="translate(210,270)">
+    <rect class="card" width="160" height="80" rx="3"/>
+    <path class="br" d="M0,16 L0,0 L16,0 M144,0 L160,0 L160,16 M0,64 L0,80 L16,80 M144,80 L160,80 L160,64"/>
+    <circle class="badge" cx="18" cy="18" r="11"/><text class="num" x="18" y="22.5" text-anchor="middle">9</text>
+    <text class="label" x="80" y="52" text-anchor="middle">VALIDATE</text>
+    <text class="sub" x="80" y="68" text-anchor="middle">schema · env · paths</text>
+  </g>
+  <g transform="translate(30,270)">
+    <rect class="card" width="160" height="80" rx="3"/>
+    <path class="br br-final" d="M0,16 L0,0 L16,0 M144,0 L160,0 L160,16 M0,64 L0,80 L16,80 M144,80 L160,80 L160,64"/>
+    <circle class="badge-final" cx="18" cy="18" r="11"/><text class="num" x="18" y="22.5" text-anchor="middle">10</text>
+    <text class="label" x="80" y="52" text-anchor="middle">NEXT ACTIONS</text>
+    <text class="sub" x="80" y="68" text-anchor="middle">webhook url · secret</text>
+  </g>
+
+  <text class="note" x="30" y="400">▸ amber dashed = step transition  ·  green = flow  ·  step 10 done = ready for first review</text>
+</svg>

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -51,7 +51,7 @@ The wizard walks you through:
 3. Scanning for local repositories to register
 4. Generating webhook secrets automatically
 
-Your configuration is saved to `~/.claude-review/config.json` and `~/.claude-review/.env`.
+Your configuration is saved to your platform config directory — on Linux `~/.config/reviewflow/config.json` and `~/.config/reviewflow/.env` (macOS: `~/Library/Application Support/reviewflow/`, Windows: `%APPDATA%\reviewflow\`). Set `XDG_CONFIG_HOME` to override.
 
 ::: tip Non-interactive mode
 Use `reviewflow init --yes` to accept all defaults. You can also pass `--scan-path /path/to/projects` to target specific directories.
@@ -60,6 +60,38 @@ Use `reviewflow init --yes` to accept all defaults. You can also pass `--scan-pa
 ::: tip Add repositories later
 Use `reviewflow discover` to scan for and add new repositories to your existing configuration.
 :::
+
+### Full setup wizard
+
+`reviewflow init` only writes configuration. For a guided end-to-end setup that also checks dependencies, signs you into Claude, installs the background daemon, and registers your project, run:
+
+```bash
+reviewflow setup
+```
+
+![Setup wizard flow](./assets/setup-wizard-flow.svg)
+
+The wizard runs ten ordered steps and stops at the first blocking error:
+
+1. **Check dependencies** — verify `git`, `claude`, and the platform CLI (`glab` / `gh`) are installed
+2. **Claude login** — confirm an authenticated `claude` session (OAuth, never an API key)
+3. **Install daemon** — set up the ReviewFlow background service
+4. **Generate secrets** — create webhook secrets and the `.env` file
+5. **Add project** — detect the git remote and target platform
+6. **Configure pipeline** — pick a review preset (`backend`, `frontend`, `fullstack`, `basic`, or `custom`)
+7. **Generate files** — write `.claude/reviews/config.json`, the review skills, and `.mcp.json`
+8. **Register project** — add the project to the daemon's repository list
+9. **Validate setup** — run final checks across schema, environment, paths, and remotes
+10. **Display next actions** — print the webhook URL and secret to finish configuration
+
+| Flag | Purpose |
+|------|---------|
+| `--path <dir>` | Target project directory (defaults to the current directory) |
+| `--json` | Emit a JSON event stream and read answers from stdin (non-interactive) |
+| `--force` | Overwrite existing project files (backs up the previous `config.json`) |
+| `--yes` | Accept suggested defaults without prompting |
+| `--ai` | Enable AI-assisted fallback for ambiguous prompts |
+| `--show-secrets` | Print full secret values instead of masking them |
 
 ## 3. Configure webhook
 

--- a/docs/plans/176-job-history-persistence.plan.md
+++ b/docs/plans/176-job-history-persistence.plan.md
@@ -45,11 +45,11 @@ USECASES:
     test: src/tests/units/modules/review-execution/usecases/jobHistory/persistJobRecord.usecase.test.ts
     type: command
     input: { jobStatus: JobStatus, abortSignalAborted: boolean, now: () => Date }
-    output: Promise<void>             # best-effort, swallows errors and logs
+    output: `Promise<void>`             # best-effort, swallows errors and logs
     responsibility:
       - Build `JobRecord` from `JobStatus` (status mapping + duration computation)
       - Delegate to `JobHistoryGateway.appendRecord(record)`
-      - Catch any error: log warning ("Échec persistance job <id> : <reason>") then return
+      - Catch any error: log warning ("Échec persistance job `<id>` : `<reason>`") then return
     dependencies: { jobHistoryGateway: JobHistoryGateway, logger: Logger }
 
   - name: loadRecentJobHistory
@@ -57,7 +57,7 @@ USECASES:
     test: src/tests/units/modules/review-execution/usecases/jobHistory/loadRecentJobHistory.usecase.test.ts
     type: query
     input: { retentionDays: number, now: () => Date }
-    output: Promise<JobRecord[]>      # ordered most-recent-first
+    output: `Promise<JobRecord[]>`      # ordered most-recent-first
     responsibility:
       - Call `JobHistoryGateway.loadRecordsWithinWindow(retentionDays, now)`
       - Skip malformed lines (the gateway already filters; this use case just sorts + caps)
@@ -82,14 +82,14 @@ GATEWAYS:
     impl_test: src/tests/units/modules/review-execution/interface-adapters/gateways/fileSystem/jobHistory.fileSystem.gateway.test.ts
     stub: src/tests/stubs/jobHistory.stub.ts
     methods:
-      - appendRecord(record: JobRecord): Promise<void>
+      - `appendRecord(record: JobRecord): Promise<void>`
           • Writes one JSON line atomically using `fs/promises.appendFile` (POSIX append is atomic for sizes < PIPE_BUF, which our small JSON lines respect — satisfies "concurrent writes don't corrupt")
           • Ensures `~/.claude-review/jobs/` directory exists (mkdir recursive on first write)
           • Filename derived from `record.completedAt` slice 0..10 → `<YYYY-MM-DD>.jsonl`
-      - loadRecordsWithinWindow(retentionDays: number, now: Date): Promise<JobRecord[]>
+      - `loadRecordsWithinWindow(retentionDays: number, now: Date): Promise<JobRecord[]>`
           • Lists `.jsonl` files in the storage dir
           • Filters files by date in filename ≥ now - retentionDays
-          • For each file: read, split by `\n`, parse each line via `jobRecordGuard.safeParse`; on failure log "Ligne <n> illisible, ignorée"
+          • For each file: read, split by `\n`, parse each line via `jobRecordGuard.safeParse`; on failure log "Ligne `<n>` illisible, ignorée"
           • Returns flat array of valid records
       - deleteRecordsOutsideWindow(retentionDays: number, now: Date): Promise<{ deletedFilenames: string[] }>
           • Lists files, deletes those with date < now - retentionDays via `fs/promises.unlink`

--- a/docs/plans/180-quality-threshold-block-approval-iter-B.plan.md
+++ b/docs/plans/180-quality-threshold-block-approval-iter-B.plan.md
@@ -154,7 +154,7 @@ PLAN:
         - GitHub: src/modules/platform-integration/interface-adapters/gateways/cli/noteCommentPost.github.cli.gateway.ts
       stub: src/tests/stubs/noteCommentPost.stub.ts
       methods:
-        - postComment(input: { projectPath: string; mrNumber: number; body: string }): Promise<void>
+        - `postComment(input: { projectPath: string; mrNumber: number; body: string }): Promise<void>`
       decisions:
         - Required for scenario 5 (FR rejection comment back to the MR) and scenario 10
           (acknowledgement is optional — see scope decision below).
@@ -375,7 +375,7 @@ PLAN:
        src/modules/platform-integration/interface-adapters/gateways/cli/noteCommentPost.github.cli.gateway.ts
        src/tests/stubs/noteCommentPost.stub.ts
        — CLI implementations reusing `glab api`/`gh api` patterns from
-         reviewAction.<platform>.cli.gateway.ts. Stub for tests.
+         `reviewAction.<platform>.cli.gateway.ts`. Stub for tests.
     10. src/modules/platform-integration/interface-adapters/controllers/webhook/eventFilter.ts
         (extend)
         — Add NoteFilterResult + filterGitLabNoteEvent + filterGitHubIssueCommentEvent.

--- a/docs/plans/180-quality-threshold-block-approval-iter-C.plan.md
+++ b/docs/plans/180-quality-threshold-block-approval-iter-C.plan.md
@@ -262,7 +262,7 @@ PLAN:
         - GitHub: src/modules/platform-integration/interface-adapters/gateways/cli/approvalRevocation.github.cli.gateway.ts
       stub: src/tests/stubs/approvalRevocation.stub.ts
       methods:
-        - revoke(input: { projectPath: string; mrNumber: number; reviewId?: number; dismissalMessage?: string }): Promise<void>
+        - `revoke(input: { projectPath: string; mrNumber: number; reviewId?: number; dismissalMessage?: string }): Promise<void>`
       decisions:
         - One method, one verb. The optional `reviewId` and `dismissalMessage` are present
           to accommodate GitHub's `reviews/<id>/dismissals` endpoint. GitLab impl ignores them.
@@ -374,7 +374,7 @@ PLAN:
       - new: GitHubApprovalRevocationCliGateway(defaultGitHubExecutor)
     no_new_executor_needed:
       Reuses `defaultGitLabExecutor` and `defaultGitHubExecutor` exported from
-      threadFetch.<platform>.gateway.ts.
+      `threadFetch.<platform>.gateway.ts`.
 
   MODIFICATIONS_TO_EXISTING_FILES:
     1. src/modules/platform-integration/interface-adapters/controllers/webhook/eventFilter.ts
@@ -620,7 +620,7 @@ PLAN:
     Visible end-to-end path:
       Platform webhook (GitLab "Merge Request Hook" with action=approved, OR GitHub
       "pull_request_review" with state=approved) → controller calls `transitionState`
-      with gate → gate fails (score<threshold, no bypass) → controller calls
+      with gate → gate fails (`score<threshold`, no bypass) → controller calls
       `handlePlatformApproval` → verdict `kind: 'reverted'` → controller calls
       `approvalRevocationGateway.revoke()` (unapprove on platform) → controller calls
       `noteCommentPostGateway.postComment()` (FR explanation) → 200 status 'unapproved'.

--- a/docs/plans/182-mark-pending-fix-as-merged.plan.md
+++ b/docs/plans/182-mark-pending-fix-as-merged.plan.md
@@ -257,8 +257,8 @@ PLAN:
     file: docs/feature-tracker.md
     line: 50
     change: |
-      Before: | Manually mark a pending-fix MR as merged | [182-mark-pending-fix-as-merged](specs/182-mark-pending-fix-as-merged.md) | drafted | 2026-05-27 |
-      After:  | Manually mark a pending-fix MR as merged | [182-mark-pending-fix-as-merged](specs/182-mark-pending-fix-as-merged.md) — [plan](plans/182-mark-pending-fix-as-merged.plan.md) | planned | 2026-05-27 |
+      Before: `| Manually mark a pending-fix MR as merged | [182-mark-pending-fix-as-merged](specs/182-mark-pending-fix-as-merged.md) | drafted | 2026-05-27 |`
+      After:  `| Manually mark a pending-fix MR as merged | [182-mark-pending-fix-as-merged](specs/182-mark-pending-fix-as-merged.md) — [plan](plans/182-mark-pending-fix-as-merged.plan.md) | planned | 2026-05-27 |`
 
   VALIDATION_GATES:
     - yarn typecheck

--- a/docs/plans/183-setup-wizard-cli-orchestrator.plan.md
+++ b/docs/plans/183-setup-wizard-cli-orchestrator.plan.md
@@ -374,7 +374,7 @@ The project convention is `src/main/commands/<name>.command.ts`, not `interface-
   test: src/tests/units/modules/setup-wizard/interface-adapters/presenters/nextActions.presenter.test.ts
   input: `{ platform, host, port, webhookSecret, projectPath, showSecrets }`
   output: `NextActionsViewModel { lines: string[], maskedSecret: string, fullSecret?: string, webhookUrl: string, eventType: string }`
-  purpose: builds the "Configurez le webhook sur <platform>..." instructions, masks secrets unless `--show-secrets` flag is on. Pure transformation.
+  purpose: builds the "Configurez le webhook sur `<platform>`..." instructions, masks secrets unless `--show-secrets` flag is on. Pure transformation.
 
 - name: WizardSummaryPresenter
   file: src/modules/setup-wizard/interface-adapters/presenters/wizardSummary.presenter.ts

--- a/docs/plans/184-setup-wizard-dashboard-jarvis.plan.md
+++ b/docs/plans/184-setup-wizard-dashboard-jarvis.plan.md
@@ -148,7 +148,7 @@ No NEW domain entity is required. The wizard event shapes are already implicitly
       SSE is implemented via Fastify `reply.raw` (Node http.ServerResponse) since the
       project has no SSE helper. Controller contains ZERO presentation logic: it forwards
       validated raw events; the browser humble object maps status→visuals. Follows the
-      typed-options DI pattern of every existing *.routes.ts (FastifyPluginAsync<Options>).
+      typed-options DI pattern of every existing *.routes.ts (`FastifyPluginAsync<Options>`).
 
 ---
 
@@ -329,7 +329,7 @@ faithfully requires a SPEC-183 change first.
   - src/main/websocket.ts — confirms project uses WS not SSE (R5) [VERIFIED]
   - src/shared/services/daemonSpawner.ts — node:child_process.spawn pattern to mirror [VERIFIED]
   - src/main/routes.ts — composition root + @fastify/static + redirect pattern [VERIFIED]
-  - src/modules/worktree-management/interface-adapters/controllers/http/worktreeOverview.routes.ts — FastifyPluginAsync<Options> route + zod boundary pattern [VERIFIED]
+  - src/modules/worktree-management/interface-adapters/controllers/http/worktreeOverview.routes.ts — `FastifyPluginAsync<Options>` route + zod boundary pattern [VERIFIED]
   - src/modules/worktree-management/interface-adapters/controllers/http/...routes.test.ts — route test via Fastify pattern [VERIFIED]
   - src/dashboard/styles.css :root — real design tokens (R6) [VERIFIED]
   - src/dashboard/modules/worktreePanel.js + tabBar.js — humble-object JSDoc/style for browser views [VERIFIED]

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -12,7 +12,7 @@ The system uses two configuration files:
 
 | File | Location | Purpose |
 |------|----------|---------|
-| `config.json` | `~/.claude-review/` (created by `reviewflow init`) | Server configuration, repositories |
+| `config.json` | `~/.config/reviewflow/` (created by `reviewflow init` or `reviewflow setup`) | Server configuration, repositories |
 | `.claude/reviews/config.json` | Each project | Project-specific review settings |
 
 ---
@@ -21,7 +21,7 @@ The system uses two configuration files:
 
 ### Location
 
-`~/.claude-review/config.json`, created automatically by `reviewflow init`.
+`~/.config/reviewflow/config.json` on Linux (macOS: `~/Library/Application Support/reviewflow/`, Windows: `%APPDATA%\reviewflow\`; override with `XDG_CONFIG_HOME`), created automatically by `reviewflow init` or `reviewflow setup`.
 
 ### Schema
 

--- a/docs/reports/180-quality-threshold-block-approval.report.md
+++ b/docs/reports/180-quality-threshold-block-approval.report.md
@@ -11,7 +11,7 @@
 | File | Purpose |
 |------|---------|
 | `src/modules/tracking/entities/qualityGate/qualityGate.ts` | Pure evaluator: `evaluateQualityGate({ latestScore, blockingIssues, threshold }) → { allowed: true } \| { allowed: false; reason; message }`. French messages produced here. |
-| `src/tests/units/modules/tracking/entities/qualityGate/qualityGate.test.ts` | Unit tests covering: threshold=null, latestScore=null, blockers>0, score<threshold, score>=threshold, boundary cases. |
+| `src/tests/units/modules/tracking/entities/qualityGate/qualityGate.test.ts` | Unit tests covering: threshold=null, latestScore=null, blockers>0, `score<threshold`, score>=threshold, boundary cases. |
 | `src/tests/units/modules/tracking/interface-adapters/controllers/http/mrTracking.routes.test.ts` | Unit tests for the `POST /api/mr-tracking/approve` gate (200/409 + French messages). |
 | `src/tests/acceptance/180-quality-threshold-block-approval.acceptance.test.ts` | SDD acceptance test, 5 scenarios exercising the Fastify route end-to-end via `app.inject()`. |
 

--- a/docs/reports/91-dashboard-multi-project-overview.report.md
+++ b/docs/reports/91-dashboard-multi-project-overview.report.md
@@ -1,7 +1,7 @@
 # Report — SPEC-91 Dashboard Multi-Project Overview
 
 - **Spec**: [`docs/specs/91-dashboard-multi-project-overview.md`](../specs/91-dashboard-multi-project-overview.md)
-- **Plan**: [`docs/plans/91-dashboard-multi-project-overview.plan.md`](../plans/91-dashboard-multi-project-overview.plan.md)
+- **Plan**: _not persisted_
 - **Status**: implemented
 - **Date**: 2026-05-25
 - **Effort**: ~2 AI-days (matches estimate)

--- a/docs/specs/183-setup-wizard-cli-orchestrator.md
+++ b/docs/specs/183-setup-wizard-cli-orchestrator.md
@@ -185,7 +185,7 @@ A single `reviewflow setup` command must replace this fragmented experience with
 
 ### Step 10 — Display next actions
 
-- nominal end: {all steps: ok} → output "Configurez le webhook sur <platform>: URL=http://YOUR_HOST:PORT/webhooks/<platform>, Secret=<masked>, Events=<event-type>"
+- nominal end: {all steps: ok} → output "Configurez le webhook sur `<platform>`: URL=http://YOUR_HOST:PORT/webhooks/`<platform>`, Secret=`<masked>`, Events=`<event-type>`"
 - with --show-secrets: {flag: --show-secrets} → show full secret value in output
 
 ### JSON event stream mode


### PR DESCRIPTION
## Summary
- **Unblock Deploy Docs CI** (was failing on every push): VitePress compiles each `.md` as a Vue SFC, so bare angle brackets in prose — TS generics (`Promise<void>`, `FastifyPluginAsync<Options>`), `<platform>`-style placeholders, `score<threshold` — broke the build across specs/plans/reports. Escaped them in backticks.
- Fixed **5 pre-existing dead links** that only surfaced once compilation passed: non-existent `plan-91` references (report 91 + feature-tracker) and wrong relative paths in plan 182.
- **Doc freshness** (verified against code): corrected the config path `~/.claude-review/` → `~/.config/reviewflow/` (`getConfigDir()`); documented the new `reviewflow setup` wizard (10 steps + flags) with an illustrative SVG; aligned the deployment tunnel port `3000` → `3847` (default config port); added the `setup-wizard` module to the architecture overview.

## Notes
- `reviewflow setup` logic verified in `src/modules/setup-wizard/` + `src/main/commands/setup.command.ts`.
- The Release Please failure referenced alongside this was a **transient state collision** at the #234 merge; the next run succeeded and `v3.28.0` is published. The stale duplicate PR #241 is being closed separately.

## Test plan
- [x] `yarn docs:build` passes locally (exit 0, no compile errors, no dead links)
- [ ] Deploy Docs workflow green on merge to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)