### PR TITLE
feat(dashboard): SPEC-189 Ember flame wireframe avatar + sidebar layout

### DIFF
--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -101,24 +101,24 @@
 
     <div class="dashboard-layout">
       <aside class="dashboard-sidebar" aria-label="Project tools">
-        <button type="button" id="open-settings-modal-btn" class="sidebar-settings-button" hidden>
-          <span class="sidebar-settings-button__prefix">// SETTINGS</span>
-        </button>
-        <button type="button" id="open-economics-sheet-btn" class="sidebar-settings-button" onclick="openEconomicsSheet()">
-          <span class="sidebar-settings-button__prefix">// CLAUDE ECONOMICS</span>
-        </button>
-        <button type="button" id="open-stats-sheet-btn" class="sidebar-settings-button" onclick="openStatsSheet()" disabled aria-disabled="true">
-          <span class="sidebar-settings-button__prefix">// PROJECT STATS</span>
-        </button>
+        <div class="sidebar-tool-buttons">
+          <button type="button" id="open-settings-modal-btn" class="sidebar-settings-button" hidden>
+            <span class="sidebar-settings-button__prefix">// SETTINGS</span>
+          </button>
+          <button type="button" id="open-economics-sheet-btn" class="sidebar-settings-button" onclick="openEconomicsSheet()">
+            <span class="sidebar-settings-button__prefix">// ECONOMICS</span>
+          </button>
+          <button type="button" id="open-stats-sheet-btn" class="sidebar-settings-button" onclick="openStatsSheet()" disabled aria-disabled="true">
+            <span class="sidebar-settings-button__prefix">// STATS</span>
+          </button>
+        </div>
 
         <span id="config-status" class="config-status hidden"></span>
-
-        <section id="worktree-section" aria-label="Worktree pool"></section>
 
         <section id="ember-chat-panel" class="ember-chat-panel" aria-label="Ember">
           <div class="ember-chat-panel__header">
             <span class="ember-chat-panel__prefix">// EMBER</span>
-            <canvas id="ember-avatar" class="ember-chat-panel__avatar" width="72" height="72" aria-hidden="true"></canvas>
+            <canvas id="ember-avatar" class="ember-chat-panel__avatar" width="360" height="360" aria-hidden="true"></canvas>
           </div>
           <output id="ember-answer" class="ember-chat-panel__answer" aria-live="polite"></output>
           <div id="ember-status" class="ember-chat-panel__status" role="status" aria-live="polite"></div>
@@ -133,6 +133,8 @@
             />
           </form>
         </section>
+
+        <section id="worktree-section" aria-label="Worktree pool"></section>
       </aside>
 
       <main class="dashboard-main">
@@ -449,7 +451,7 @@
       renderHeaderCapacityBadgeHtml,
     } from './modules/headerCapacityBadge.js';
     import { connectEmberStream, shouldSendQuestion } from './modules/emberChat.js';
-    import { mountSetupWizardAvatar } from './modules/setupWizardAvatarRenderer.js';
+    import { mountEmberAvatar } from './modules/emberAvatarRenderer.js';
 
     const API_URL = window.location.origin;
     const WS_URL = `ws://${window.location.host}/ws`;
@@ -3868,9 +3870,10 @@
       const status = document.getElementById('ember-status');
       const retry = document.getElementById('ember-retry');
       const canvas = document.getElementById('ember-avatar');
+      const panel = document.getElementById('ember-chat-panel');
       if (!form || !input || !answer || !status || !canvas) return;
 
-      const avatar = mountSetupWizardAvatar({ canvas, initialState: 'idle' });
+      const avatar = mountEmberAvatar({ canvas, initialState: 'idle' });
 
       const ask = async () => {
         const question = input.value;
@@ -3878,6 +3881,7 @@
           input.focus();
           return;
         }
+        panel?.classList.add('ember-chat-panel--active');
         answer.textContent = '';
         status.textContent = '';
         retry.hidden = true;

--- a/src/dashboard/modules/emberAvatar.js
+++ b/src/dashboard/modules/emberAvatar.js
@@ -1,0 +1,192 @@
+/**
+ * Dashboard module — Ember flame wireframe avatar (SPEC-189).
+ * Humble object: pure functions, no DOM, no global state. Holds the flame-shaped
+ * wireframe geometry and every per-state visual decision, so the
+ * requestAnimationFrame loop in emberAvatarRenderer.js carries no branching.
+ *
+ * Ember is a warm wireframe BRAISE, not the setup wizard's abstract icosahedron:
+ * a teardrop flame mesh (pointed tip, rounded base) stroked in amber, that leans
+ * and flickers like a live coal — livelier and warmer when spoken to.
+ *
+ * Visual DNA: "Agentic OS" — dark warm near-black + amber. See
+ * project_agentic_os_design_dna.md.
+ */
+
+/**
+ * @typedef {'idle' | 'working' | 'error'} EmberState
+ */
+
+/** @type {EmberState[]} */
+export const EMBER_STATES = ['idle', 'working', 'error'];
+
+/** Top of the flame (the tip) in model space. */
+export const FLAME_TIP_Y = 1.5;
+/** Bottom of the flame (the rounded base) in model space. */
+export const FLAME_BASE_Y = -1.15;
+
+/**
+ * @typedef {Object} EmberVisual
+ * @property {string} color CSS custom-property name driving the warm stroke.
+ * @property {number} lineWidth Stroke width in device pixels.
+ * @property {number} rotationSpeed Radians per second of the slow Y rotation.
+ * @property {number} swaySpeed Radians per millisecond of the candle-lean sway.
+ * @property {number} swayAmount Horizontal lean amplitude at the flame tip.
+ * @property {number} flicker Amplitude of the scale shimmer (the coal breathing).
+ * @property {number} glow Stroke shadow-blur in pixels (the warm halo around lines).
+ */
+
+/** @type {Record<EmberState, EmberVisual>} */
+const EMBER_VISUALS = {
+  idle: { color: '--accent', lineWidth: 1.5, rotationSpeed: 0.3, swaySpeed: 0.0011, swayAmount: 0.08, flicker: 0.025, glow: 10 },
+  working: { color: '--accent', lineWidth: 1.8, rotationSpeed: 0.6, swaySpeed: 0.0026, swayAmount: 0.22, flicker: 0.16, glow: 16 },
+  error: { color: '--danger', lineWidth: 2, rotationSpeed: 0.18, swaySpeed: 0.0018, swayAmount: 0.14, flicker: 0.22, glow: 12 },
+};
+
+/**
+ * Maps an ember state to its stroke/animation parameters. Keeps the renderer
+ * humble: every per-state decision lives here, not in the canvas loop.
+ *
+ * @param {EmberState} state
+ * @returns {EmberVisual}
+ */
+export function emberStateToVisual(state) {
+  return EMBER_VISUALS[state];
+}
+
+/**
+ * @typedef {[number, number, number]} Vertex
+ */
+
+/**
+ * The flame radius at a normalised height ringT ∈ [0,1] (0 near the tip, 1 at the
+ * base). A teardrop profile: pointed at the top, bulging in the lower third, a
+ * small rounded base — the silhouette that reads as a coal/flame rather than a
+ * ball.
+ *
+ * @param {number} ringT
+ * @returns {number}
+ */
+function flameRadius(ringT) {
+  return Math.sin(Math.PI * ringT ** 1.3) * 0.9 + 0.06;
+}
+
+/**
+ * Builds the flame wireframe as a surface of revolution: a single tip vertex
+ * (index 0) plus `rings` × `meridians` body vertices, joined by tip spokes,
+ * vertical meridian lines and horizontal ring loops. Pure and deterministic.
+ *
+ * @param {{ rings: number; meridians: number }} options
+ * @returns {{ vertices: Vertex[]; edges: Array<[number, number]> }}
+ */
+export function buildFlameWireframe(options) {
+  const { rings, meridians } = options;
+  /** @type {Vertex[]} */
+  const vertices = [[0, FLAME_TIP_Y, 0]];
+  const indexAt = (ring, meridian) => 1 + ring * meridians + meridian;
+
+  for (let ring = 0; ring < rings; ring += 1) {
+    const ringT = (ring + 1) / rings;
+    const y = FLAME_TIP_Y + (FLAME_BASE_Y - FLAME_TIP_Y) * ringT;
+    const radius = flameRadius(ringT);
+    for (let meridian = 0; meridian < meridians; meridian += 1) {
+      const angle = (meridian / meridians) * Math.PI * 2;
+      vertices.push([Math.cos(angle) * radius, y, Math.sin(angle) * radius]);
+    }
+  }
+
+  /** @type {Array<[number, number]>} */
+  const edges = [];
+  for (let meridian = 0; meridian < meridians; meridian += 1) {
+    edges.push([0, indexAt(0, meridian)]);
+  }
+  for (let ring = 0; ring < rings - 1; ring += 1) {
+    for (let meridian = 0; meridian < meridians; meridian += 1) {
+      edges.push([indexAt(ring, meridian), indexAt(ring + 1, meridian)]);
+    }
+  }
+  for (let ring = 0; ring < rings; ring += 1) {
+    for (let meridian = 0; meridian < meridians; meridian += 1) {
+      edges.push([indexAt(ring, meridian), indexAt(ring, (meridian + 1) % meridians)]);
+    }
+  }
+
+  return { vertices, edges };
+}
+
+/**
+ * @typedef {Object} Projection
+ * @property {number} tilt Fixed X-axis tilt in radians.
+ * @property {number} distance Camera distance for the perspective divide.
+ * @property {number} scale Pixels per unit at the projection plane.
+ * @property {number} centerX Canvas-space x offset.
+ * @property {number} centerY Canvas-space y offset.
+ */
+
+/**
+ * Projects a flame vertex to a 2D canvas point: rotates around Y, leans the
+ * upper body sideways by `swayOffset` scaled by height (a candle flame bends at
+ * the tip, not the base), applies the fixed tilt, then a perspective divide.
+ * Pure and deterministic.
+ *
+ * @param {Vertex} vertex
+ * @param {number} rotationRadians
+ * @param {number} swayOffset
+ * @param {Projection} projection
+ * @returns {{ x: number; y: number }}
+ */
+export function projectFlameVertex(vertex, rotationRadians, swayOffset, projection) {
+  const [x, y, z] = vertex;
+
+  const cosY = Math.cos(rotationRadians);
+  const sinY = Math.sin(rotationRadians);
+  const rotatedX = x * cosY + z * sinY;
+  const rotatedZ = -x * sinY + z * cosY;
+
+  const heightFactor = (y - FLAME_BASE_Y) / (FLAME_TIP_Y - FLAME_BASE_Y);
+  const leanedX = rotatedX + swayOffset * heightFactor;
+
+  const cosTilt = Math.cos(projection.tilt);
+  const sinTilt = Math.sin(projection.tilt);
+  const tiltedY = y * cosTilt - rotatedZ * sinTilt;
+  const tiltedZ = y * sinTilt + rotatedZ * cosTilt;
+
+  const perspective = projection.scale / (tiltedZ + projection.distance);
+  return {
+    x: projection.centerX + leanedX * perspective,
+    y: projection.centerY - tiltedY * perspective,
+  };
+}
+
+/**
+ * The breathing multiplier applied to the flame scale at a given time: a slow
+ * pulse plus a faster two-tone shimmer that reads as flicker. Pure — 1 at time 0,
+ * always within 1 ± flicker.
+ *
+ * @param {EmberVisual} visual
+ * @param {number} time Milliseconds since the loop started.
+ * @returns {number}
+ */
+const SHIMMER_SLOW_FREQUENCY = 0.013;
+const SHIMMER_FAST_FREQUENCY = 0.031;
+const SHIMMER_SLOW_WEIGHT = 0.6;
+const SHIMMER_FAST_WEIGHT = 0.4;
+
+export function emberRadiusFactor(visual, time) {
+  const shimmer =
+    visual.flicker *
+    (SHIMMER_SLOW_WEIGHT * Math.sin(time * SHIMMER_SLOW_FREQUENCY) +
+      SHIMMER_FAST_WEIGHT * Math.sin(time * SHIMMER_FAST_FREQUENCY));
+  return 1 + shimmer;
+}
+
+/**
+ * The horizontal lean of the flame tip at a given time. Pure — 0 at time 0,
+ * always within ± swayAmount.
+ *
+ * @param {EmberVisual} visual
+ * @param {number} time Milliseconds since the loop started.
+ * @returns {number}
+ */
+export function emberSwayOffset(visual, time) {
+  return visual.swayAmount * Math.sin(time * visual.swaySpeed);
+}

--- a/src/dashboard/modules/emberAvatarRenderer.js
+++ b/src/dashboard/modules/emberAvatarRenderer.js
@@ -1,0 +1,119 @@
+/**
+ * Dashboard module — Ember flame wireframe renderer (SPEC-189).
+ * Humble glue: a thin requestAnimationFrame loop that strokes the flame
+ * wireframe with a warm amber glow (shadowBlur), a slow Y rotation, a candle
+ * lean and a flicker breathing. It owns the rAF handle and its teardown, and
+ * delegates EVERY decision (geometry, colour, line width, rotation, sway,
+ * flicker, glow) to the pure emberAvatar.js module. Lifecycle-tested only
+ * (browser-only drawing), mirroring setupWizardAvatarRenderer.
+ *
+ * Visual DNA: "Agentic OS" — dark warm near-black + amber.
+ */
+
+import {
+  emberStateToVisual,
+  buildFlameWireframe,
+  projectFlameVertex,
+  emberRadiusFactor,
+  emberSwayOffset,
+} from './emberAvatar.js';
+
+/**
+ * @param {CanvasRenderingContext2D} context
+ * @param {string} colorToken
+ * @returns {string}
+ */
+function resolveColor(context, colorToken) {
+  const value = getComputedStyle(context.canvas).getPropertyValue(colorToken).trim();
+  return value === '' ? '#F4A93D' : value;
+}
+
+/**
+ * The structural slice of a canvas the renderer depends on. A real
+ * HTMLCanvasElement satisfies it; tests pass a lightweight fake without casts.
+ *
+ * @typedef {Object} EmberCanvas
+ * @property {number} width
+ * @property {number} height
+ * @property {(contextId: '2d') => CanvasRenderingContext2D | null} getContext
+ */
+
+/**
+ * Mounts the animated flame wireframe avatar on a 2D canvas and returns its
+ * controls. The page calls setState() on each stream event and destroy() before
+ * any teardown so the rAF loop never leaks.
+ *
+ * @param {Object} options
+ * @param {EmberCanvas} options.canvas
+ * @param {import('./emberAvatar.js').EmberState} [options.initialState]
+ * @param {(callback: FrameRequestCallback) => number} [options.requestFrame]
+ * @param {(handle: number) => void} [options.cancelFrame]
+ * @param {() => number} [options.now]
+ * @returns {{ setState: (state: import('./emberAvatar.js').EmberState) => void; destroy: () => void }}
+ */
+export function mountEmberAvatar(options) {
+  const requestFrame = options.requestFrame ?? globalThis.requestAnimationFrame.bind(globalThis);
+  const cancelFrame = options.cancelFrame ?? globalThis.cancelAnimationFrame.bind(globalThis);
+  const now = options.now ?? (() => performance.now());
+  const context = options.canvas.getContext('2d');
+  const startTime = now();
+  const flame = buildFlameWireframe({ rings: 7, meridians: 10 });
+
+  let currentState = options.initialState ?? 'idle';
+  /** @type {number | null} */
+  let frameHandle = null;
+
+  const projection = {
+    tilt: 0.12,
+    distance: 4,
+    scale: Math.min(options.canvas.width, options.canvas.height) * 0.55,
+    centerX: options.canvas.width / 2,
+    centerY: options.canvas.height / 2,
+  };
+
+  /**
+   * @param {number} time
+   */
+  function draw(time) {
+    if (context === null) {
+      return;
+    }
+    const elapsed = time - startTime;
+    const visual = emberStateToVisual(currentState);
+    const rotation = (elapsed * visual.rotationSpeed) / 1000;
+    const sway = emberSwayOffset(visual, elapsed);
+    const framedProjection = { ...projection, scale: projection.scale * emberRadiusFactor(visual, elapsed) };
+
+    context.clearRect(0, 0, options.canvas.width, options.canvas.height);
+    const color = resolveColor(context, visual.color);
+    context.lineWidth = visual.lineWidth;
+    context.lineCap = 'round';
+    context.strokeStyle = color;
+    context.shadowColor = color;
+    context.shadowBlur = visual.glow;
+    context.beginPath();
+    for (const [from, to] of flame.edges) {
+      const start = projectFlameVertex(flame.vertices[from], rotation, sway, framedProjection);
+      const end = projectFlameVertex(flame.vertices[to], rotation, sway, framedProjection);
+      context.moveTo(start.x, start.y);
+      context.lineTo(end.x, end.y);
+    }
+    context.stroke();
+
+    frameHandle = requestFrame(draw);
+  }
+
+  frameHandle = requestFrame(draw);
+
+  return {
+    setState: (state) => {
+      currentState = state;
+    },
+    destroy: () => {
+      if (frameHandle !== null) {
+        cancelFrame(frameHandle);
+        frameHandle = null;
+      }
+    },
+  };
+}

--- a/src/dashboard/styles.css
+++ b/src/dashboard/styles.css
@@ -5442,6 +5442,20 @@ body.overview-tab-active .dashboard-main > *:not(#overview-section) {
 
 /* SPEC-179 — Settings modal + sidebar Settings button (Agentic OS DNA) */
 
+.sidebar-tool-buttons {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.sidebar-tool-buttons .sidebar-settings-button {
+  flex: 1 1 0;
+  min-width: 0;
+  margin-top: 0;
+  padding: 0.45rem 0.3rem;
+  justify-content: center;
+  font-size: 0.68rem;
+}
+
 .sidebar-settings-button {
   display: flex;
   align-items: center;
@@ -6388,20 +6402,47 @@ input:focus-visible,
 
 .ember-chat-panel__header {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: space-between;
-  margin-bottom: 8px;
+  gap: 10px;
+  margin-bottom: 12px;
 }
 
 .ember-chat-panel__prefix {
+  align-self: flex-start;
   color: var(--accent);
   font-size: 12px;
   letter-spacing: 0.04em;
 }
 
 .ember-chat-panel__avatar {
-  width: 48px;
-  height: 48px;
+  width: 260px;
+  height: 260px;
+  transition: width 0.45s ease, height 0.45s ease;
+}
+
+.ember-chat-panel--active .ember-chat-panel__header {
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.ember-chat-panel--active .ember-chat-panel__avatar {
+  width: 104px;
+  height: 104px;
+}
+
+.ember-chat-panel:not(.ember-chat-panel--active) .ember-chat-panel__answer,
+.ember-chat-panel:not(.ember-chat-panel--active) .ember-chat-panel__status,
+.ember-chat-panel:not(.ember-chat-panel--active) .ember-chat-panel__retry {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ember-chat-panel__avatar {
+    transition: none;
+    animation: none;
+  }
 }
 
 .ember-chat-panel__answer {

--- a/src/tests/units/dashboard/modules/emberAvatar.test.ts
+++ b/src/tests/units/dashboard/modules/emberAvatar.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import {
+  EMBER_STATES,
+  emberStateToVisual,
+  buildFlameWireframe,
+  projectFlameVertex,
+  emberRadiusFactor,
+  emberSwayOffset,
+  FLAME_TIP_Y,
+  FLAME_BASE_Y,
+} from '@/dashboard/modules/emberAvatar.js';
+
+describe('EMBER_STATES', () => {
+  it('exposes exactly the three chat-driven states in narrative order', () => {
+    expect(EMBER_STATES).toEqual(['idle', 'working', 'error']);
+  });
+});
+
+describe('emberStateToVisual', () => {
+  it('makes the working state lean, flicker and glow harder than idle', () => {
+    const idle = emberStateToVisual('idle');
+    const working = emberStateToVisual('working');
+    expect(working.swayAmount).toBeGreaterThan(idle.swayAmount);
+    expect(working.flicker).toBeGreaterThan(idle.flicker);
+    expect(working.glow).toBeGreaterThan(idle.glow);
+  });
+
+  it('paints the error state with a distinct colour token from idle', () => {
+    expect(emberStateToVisual('error').color).not.toBe(emberStateToVisual('idle').color);
+  });
+});
+
+describe('buildFlameWireframe', () => {
+  it('has one tip vertex plus a rings × meridians body', () => {
+    const { vertices } = buildFlameWireframe({ rings: 6, meridians: 8 });
+    expect(vertices).toHaveLength(1 + 6 * 8);
+    expect(vertices[0]).toEqual([0, FLAME_TIP_Y, 0]);
+    for (const vertex of vertices) {
+      expect(vertex).toHaveLength(3);
+    }
+  });
+
+  it('connects the tip, the meridians and the ring loops with edges', () => {
+    const { edges } = buildFlameWireframe({ rings: 6, meridians: 8 });
+    const tipSpokes = 8;
+    const verticalLines = (6 - 1) * 8;
+    const ringLoops = 6 * 8;
+    expect(edges).toHaveLength(tipSpokes + verticalLines + ringLoops);
+  });
+});
+
+describe('projectFlameVertex', () => {
+  const projection = { tilt: 0.12, distance: 4, scale: 50, centerX: 120, centerY: 120 };
+
+  it('is deterministic for the same inputs', () => {
+    const vertex: [number, number, number] = [0.5, 0.2, -0.3];
+    expect(projectFlameVertex(vertex, 1.1, 0.2, projection)).toEqual(
+      projectFlameVertex(vertex, 1.1, 0.2, projection),
+    );
+  });
+
+  it('leans the tip far more than the base for a positive sway', () => {
+    const tip: [number, number, number] = [0, FLAME_TIP_Y, 0];
+    const base: [number, number, number] = [0, FLAME_BASE_Y, 0];
+    const tipShift = projectFlameVertex(tip, 0, 0.4, projection).x - projectFlameVertex(tip, 0, 0, projection).x;
+    const baseShift = projectFlameVertex(base, 0, 0.4, projection).x - projectFlameVertex(base, 0, 0, projection).x;
+    expect(tipShift).toBeGreaterThan(baseShift);
+    expect(baseShift).toBeCloseTo(0, 6);
+  });
+});
+
+describe('emberRadiusFactor', () => {
+  it('returns the neutral factor of 1 at time 0', () => {
+    expect(emberRadiusFactor(emberStateToVisual('idle'), 0)).toBeCloseTo(1, 5);
+  });
+
+  it('stays within the flicker envelope', () => {
+    const visual = emberStateToVisual('working');
+    for (const time of [120, 900, 1750, 5000]) {
+      const factor = emberRadiusFactor(visual, time);
+      expect(factor).toBeGreaterThanOrEqual(1 - visual.flicker - 1e-6);
+      expect(factor).toBeLessThanOrEqual(1 + visual.flicker + 1e-6);
+    }
+  });
+});
+
+describe('emberSwayOffset', () => {
+  it('is zero at time 0 and bounded by the sway amplitude', () => {
+    const visual = emberStateToVisual('working');
+    expect(emberSwayOffset(visual, 0)).toBeCloseTo(0, 6);
+    for (const time of [200, 1234, 4321]) {
+      expect(Math.abs(emberSwayOffset(visual, time))).toBeLessThanOrEqual(visual.swayAmount + 1e-6);
+    }
+  });
+});

--- a/src/tests/units/dashboard/modules/emberAvatarRenderer.test.ts
+++ b/src/tests/units/dashboard/modules/emberAvatarRenderer.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { mountEmberAvatar } from '@/dashboard/modules/emberAvatarRenderer.js';
+
+interface FakeCanvas {
+  width: number;
+  height: number;
+  getContext: () => null;
+}
+
+function fakeCanvas(): FakeCanvas {
+  return { width: 240, height: 240, getContext: () => null };
+}
+
+describe('mountEmberAvatar (lifecycle glue)', () => {
+  it('schedules an animation frame on mount', () => {
+    const requested: Array<(time: number) => void> = [];
+
+    mountEmberAvatar({
+      canvas: fakeCanvas(),
+      requestFrame: (callback) => {
+        requested.push(callback);
+        return requested.length;
+      },
+      cancelFrame: () => undefined,
+      now: () => 0,
+    });
+
+    expect(requested).toHaveLength(1);
+  });
+
+  it('cancels the scheduled frame on destroy so the loop cannot leak', () => {
+    const cancelled: number[] = [];
+
+    const controls = mountEmberAvatar({
+      canvas: fakeCanvas(),
+      requestFrame: () => 42,
+      cancelFrame: (handle) => {
+        cancelled.push(handle);
+      },
+      now: () => 0,
+    });
+
+    controls.destroy();
+
+    expect(cancelled).toEqual([42]);
+  });
+
+  it('exposes setState and destroy controls', () => {
+    const controls = mountEmberAvatar({
+      canvas: fakeCanvas(),
+      requestFrame: () => 1,
+      cancelFrame: () => undefined,
+      now: () => 0,
+    });
+
+    expect(typeof controls.setState).toBe('function');
+    expect(typeof controls.destroy).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary
- Dedicated **warm flame wireframe** avatar for Ember (pure `emberAvatar.js` geometry/visuals + humble `emberAvatarRenderer.js` rAF loop) — replaces the shared setup-wizard icosahedron, which is left untouched.
- Idle: big, centered flame, `// EMBER` label kept **left**, gentle self-rotation, low flicker. When chatting: tucks into the **top-right corner** and grows livelier (faster rotation/sway, stronger glow).
- Sidebar `Settings` / `Economics` / `Stats` buttons regrouped into a **single row** to free vertical space.

## Scope
Frontend only. The Ember **backend transport** (`/api/ember/ask` returns UNAVAILABLE) is a separate, pre-existing issue flagged by SPEC-189 as unverified humble glue — candidate for an Ember Phase B spec (subscription-based live session via `claude --bg`, SPEC-172 supervisor).

## Test plan
- [x] `emberAvatar` pure module: 10 unit tests (states, visuals, flame geometry, projection + sway, flicker envelope)
- [x] `emberAvatarRenderer`: 3 lifecycle tests (mount schedules frame, destroy cancels, controls exposed)
- [x] `yarn typecheck` + `yarn lint` clean; commit passed `yarn test:ci` gate
- [x] Visual check in Chrome (idle big/centered, corner transition on chat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)