### PR TITLE
feat(platform): implement spec-196..201 webhook/executor platform hardening

### DIFF
--- a/docs/runbooks/webhook-transport-hardening.md
+++ b/docs/runbooks/webhook-transport-hardening.md
@@ -1,0 +1,117 @@
+# Webhook transport hardening runbook (SPEC-201)
+
+This runbook documents how to deploy the webhook ingress so that the only network
+path to the handler is: TLS terminated by a reverse proxy on loopback, forwarded
+over a single trusted hop, from an allowlisted platform IP range. It also documents
+the token rotation/revocation procedure (AC9) and the root trust assumption (AC10).
+
+## Configuration
+
+The app reads three environment values for the transport guard:
+
+| Variable | Meaning | Default |
+|---|---|---|
+| `WEBHOOK_TRUSTED_HOP` | The single hop (loopback proxy address) the app accepts connections from | `127.0.0.1` |
+| `WEBHOOK_ALLOWED_CIDR_RANGES` | Comma-separated IPv4 CIDR ranges of the platform | empty (rejects all until set) |
+| `GITLAB_WEBHOOK_TOKEN` | The shared webhook token, re-read on every verification | (required) |
+
+The app binds to loopback only; TLS is terminated at the proxy. `trust proxy`
+is scoped to `WEBHOOK_TRUSTED_HOP` (never `true`, never a broad subnet). The
+accept/reject decision is taken solely by the transport guard from the raw socket
+address and explicit `X-Forwarded-Proto` / `X-Forwarded-For` headers — never from
+framework-derived `req.protocol` / `req.ip`.
+
+## Reverse proxy: bind app to loopback
+
+Run the app with the listener reachable only from the proxy (loopback). The proxy
+must set `X-Forwarded-Proto` itself and must NOT pass a client-supplied value
+through.
+
+### nginx
+
+```nginx
+server {
+  listen 443 ssl;
+  server_name reviewflow.example.com;
+
+  ssl_certificate     /etc/letsencrypt/live/reviewflow.example.com/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/reviewflow.example.com/privkey.pem;
+
+  location /webhooks/ {
+    proxy_pass http://127.0.0.1:3000;
+    proxy_set_header Host              $host;
+    # Set by the proxy; never trust a client-supplied value.
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header X-Forwarded-For   $remote_addr;
+  }
+}
+```
+
+### Caddy
+
+```caddy
+reviewflow.example.com {
+  reverse_proxy /webhooks/* 127.0.0.1:3000 {
+    header_up X-Forwarded-Proto https
+    header_up X-Forwarded-For {remote_host}
+  }
+}
+```
+
+### Traefik (dynamic config)
+
+```yaml
+http:
+  routers:
+    reviewflow-webhooks:
+      rule: "Host(`reviewflow.example.com`) && PathPrefix(`/webhooks/`)"
+      entryPoints: [websecure]
+      tls: {}
+      service: reviewflow
+  services:
+    reviewflow:
+      loadBalancer:
+        servers:
+          - url: "http://127.0.0.1:3000"
+        # Traefik sets X-Forwarded-* from the connection; ensure the entrypoint
+        # forwardedHeaders.trustedIPs is the proxy hop only, never the client.
+```
+
+## Token rotation / revocation (AC9)
+
+`GITLAB_WEBHOOK_TOKEN` is re-read from the environment on every verification, so
+the secret can be rotated **without redeploying or restarting** the process.
+Comparison is uniformly constant-time (`timingSafeEqual` over fixed-length digests);
+there is no length-based short circuit that could leak token length.
+
+Rotation cadence: rotate on a fixed schedule (at least quarterly) and immediately
+on any suspected leak.
+
+Procedure to rotate (and to revoke a compromised token):
+
+1. Generate a new high-entropy token.
+2. Update `GITLAB_WEBHOOK_TOKEN` in the process environment and refresh it
+   (e.g. `systemctl set-environment` + reload, or update the secret store and
+   trigger an env refresh) — no redeploy required.
+3. Update the GitLab webhook secret token to the new value.
+4. The old token is immediately invalid: the next verification reads the new value.
+
+## Root trust assumption (AC10)
+
+GitLab does not sign the webhook body. Therefore **token confidentiality is the
+root trust assumption** of the entire webhook surface. Identity fields in the
+payload (e.g. `event.user.id`) are trusted **only transitively via token
+possession** — they are not independently verified. Any field that requires
+stronger assurance MUST be re-fetched from an authenticated GitLab API call
+(the `threadFetchGateway.fetchThreads` trusted-source pattern, cf. SPEC-196 AC9 /
+SPEC-198 AC-10), never read from the webhook body.
+
+Transport hardening is a necessary but not sufficient condition for trust:
+- The IP allowlist bounds probability, not impact, and is a secondary defense; on
+  shared SaaS ranges it proves nothing about which project sent the webhook.
+- Actor authenticity / confused-deputy control is SPEC-197.
+- Replay protection (`X-Gitlab-Event-UUID` de-duplication) is SPEC-200; a perfect
+  replay survives every transport guard.
+
+Because SPEC-197 is inoperative if the token leaks, the rotation/revocation
+procedure above (AC9) is load-bearing, not cosmetic.

--- a/docs/specs/196-least-privilege-platform-token.md
+++ b/docs/specs/196-least-privilege-platform-token.md
@@ -1,0 +1,126 @@
+---
+title: "SPEC-196: Least-privilege platform token for the CLI executor"
+status: draft
+labels: [executor, gitlab, least-privilege, token-scoping]
+visibility: PRIVATE-UNTIL-P0-SHIPPED
+depends_on: [SPEC-198]
+---
+
+# SPEC-196: Least-privilege platform token for the CLI executor
+
+## Context
+
+The CLI executor (`glab`-backed) currently runs with the ambient admin token wired at `routes.ts:58` (`defaultGitLabExecutor`). That token is broad: it can read, write, resolve threads, reply, post comments, and revoke approvals across every project the admin can see. The executor's input is a worktree diff read at `gitlab.controller.ts:849-1031` that is **non-sanitizable** by construction, and the model emits thread/comment verbs parsed at `threadActionsParser.ts:13-66`.
+
+This spec scopes the executor's GitLab credential to the **minimum privilege required by the actions that remain in the auto path**, builds its process environment by **allowlist** (not denylist), isolates `HOME`/`GLAB_CONFIG_DIR` so the token lives in an isolated `glab` config file rather than the process env, and **freezes the minimal role per action before merge**. The privilege boundary is enforced by construction, so the worst case of an auto-confirmed hostile diff (SPEC-174 chokepoint) is bounded to **read MR + postComment** — nothing else.
+
+This is a sibling of SPEC-197/198/199/201. It does **not** fix actor authentication, target validation of write verbs, or provenance signing — those remain with the sibling specs. It bounds **impact**, not **trust**.
+
+**Merge order (blocking):** SPEC-198 (`THREAD_RESOLVE` target-validation) MUST merge **before** SPEC-196. Closure of `THREAD_RESOLVE` is the **unwire in 196**, not the target-validation in 198 — if 196 lands first, the verb stays wired with only partial validation; if 198 lands without 196, the verb stays wired entirely. 198 hardens the verb while it still exists; 196 removes it. SPEC-196 therefore declares `depends_on: [SPEC-198]`.
+
+## Current behavior
+
+| Concern | Location | Behavior today |
+|---|---|---|
+| Executor token source | `routes.ts:58` | `defaultGitLabExecutor` uses the ambient admin token — full read/write/revoke. |
+| Executor wiring | `gitlab.controller.ts:938-978` | Executors wired with the same broad credential for every action. |
+| Job construction | `gitlab.controller.ts:716-766` | `ReviewJob` built 100% from the inbound payload. |
+| Diff ingestion | `gitlab.controller.ts:849-1031` | Diff read from the worktree, **non-sanitizable**, fed to the model. |
+| Thread/comment verbs | `threadActionsParser.ts:13-66` | Parses `[THREAD_RESOLVE:id]`, `[THREAD_REPLY]`, `[POST_COMMENT]`, `[FETCH_THREADS]`; `executeThreadActions` + `contextActionsExecutor` execute them. |
+| Revoke | `approvalRevocationGateway.revoke` | Revokes approvals with the ambient token. |
+| Post comment | `noteCommentPostGateway.postComment({projectPath, mrNumber, body})` | Posts with the ambient token. |
+| Process env | (executor spawn) | Inherits the full parent environment (denylist-shaped, leaks unrelated secrets). |
+| Config dir | (executor spawn) | Inherits the operator `HOME`/`GLAB_CONFIG_DIR`; token reachable from env. |
+
+## Acceptance criteria
+
+### AC1 — Dedicated service token, fail-closed
+The executor uses a **dedicated GitLab service account token** (`REVIEWFLOW_EXECUTOR_TOKEN`), never the ambient admin token. If the token is absent or empty at executor construction, construction **throws and the job is not started** (fail-closed). No silent fallback to the admin token.
+- **Test (deterministic):** construct the executor factory with the token env var unset → expect a thrown error and zero `glab`/gateway invocations. Construct with a non-empty token → expect a configured executor. Assert on the thrown error and the spawn-args, never on model output.
+
+### AC2 — Environment built by allowlist
+The executor process environment is assembled from an **explicit allowlist** of keys (`PATH`, `HOME`, `GLAB_CONFIG_DIR`, `LANG`, and any minimal runtime keys enumerated in code), not by copying `process.env` and deleting sensitive keys. Any key not in the allowlist is absent from the child env.
+- **Test (deterministic):** seed the parent process env with a canary secret key (e.g. `AMBIENT_ADMIN_TOKEN=canary`). Build the child env. Assert the canary key is **absent** from the resulting env map and that the env map's keyset is a subset of the declared allowlist. Pure map assertion, no spawn needed.
+
+### AC3 — Token never passed via environment
+The service token is **not** placed in the child process environment. It is written to an isolated `glab` config file (see AC4). The child env contains no key whose value equals the token.
+- **Test (deterministic):** build the child env from a known token value. Assert no env value equals the token string. Assert the token string does appear in the rendered config-file contents (AC4 fixture).
+
+### AC4 — Isolated HOME / GLAB_CONFIG_DIR
+The executor runs with `HOME` and `GLAB_CONFIG_DIR` pointed at a **per-invocation isolated directory**, and the token lives in `${GLAB_CONFIG_DIR}/glab-cli/config.yml` inside that directory. The operator's real `~/.config/glab-cli/config.yml` is never read or written.
+- **Test (deterministic):** run the env/config builder against a temp dir. Assert `GLAB_CONFIG_DIR` and `HOME` in the child env both resolve under the temp dir, and that the config file is created there containing the token. Assert no read/write touches a path outside the temp dir (use a stub fs that records paths, assert all paths are under the temp root).
+
+### AC5 — Minimal role frozen PER ACTION, verified before merge
+Each action that can run in the auto path declares the **minimal GitLab role/scope it requires**, frozen in a single source-of-truth table in code:
+
+| Action | Min role/scope | Auto path? |
+|---|---|---|
+| read MR (diff, metadata, threads/`FETCH_THREADS`) | Reporter / `read_api` | yes |
+| `postComment` (`POST_COMMENT`, `THREAD_REPLY` body) | Reporter + note-create / `api` note scope | yes |
+| `THREAD_RESOLVE` | Developer | **no** (see AC6) |
+| `revoke` (`approvalRevocationGateway`) | Developer | **no** (see AC6) |
+
+The executor is constructed with **only** the read + postComment capability set. Any action whose declared min role exceeds that set is **not wired** into the auto executor.
+- **Test (deterministic):** assert the capability table is the single exported constant. Construct the auto executor and assert its wired action set equals exactly `{readMr, postComment}`. Assert that `THREAD_RESOLVE` and `revoke` are **not** present in the wired set. Table-driven assertion on the exported map, no model involved.
+
+### AC6 — No write-capable executor on any auto path
+After this spec, ReviewFlow has **no** write-capable executor on any auto path. `approvalRevocationGateway.revoke` and `THREAD_RESOLVE` execution are **removed from the auto executor's wiring** (`gitlab.controller.ts:938-978`) and are **explicitly out of automated scope**. They are not reachable with the read+postComment token. Any future write capability requires its own numbered spec with dedicated ACs and its own CI gate (mirroring AC8) — it MUST NOT be enabled via an ambient or "retained" token (no dormant `REVIEWFLOW_WRITE_TOKEN` escape hatch).
+- **Test (deterministic):** drive the auto executor with parsed verbs including `[THREAD_RESOLVE:42]` and a revoke intent. Assert the resolve gateway and the revoke gateway receive **zero** calls (use real recording stubs, assert call count == 0). Assert `postComment` still fires for `[POST_COMMENT]`. Never assert on whether the model "obeyed" — assert on gateway call counts.
+
+### AC7 — Unwired write verbs are inert, not errors-into-admin
+When the model emits a removed verb (`THREAD_RESOLVE`, revoke), the auto executor treats it as a **no-op** (logged, dropped) — it does **not** fall back to a broader token, retry, or escalate. The job continues to completion with only read + postComment effects.
+- **Test (deterministic):** feed a verb stream mixing `[POST_COMMENT]`, `[THREAD_RESOLVE:7]`, `[FETCH_THREADS]`. Assert: postComment stub called once with the expected `{projectPath, mrNumber, body}`; resolve stub called zero times; FETCH_THREADS read stub called (read is allowed); no error thrown; no admin-token gateway constructed. Assert on observable call records.
+
+### AC8 — Privilege contract verified at build/CI (pre-merge gate)
+The per-action capability table (AC5) and the auto executor's wired set are asserted by a **test that runs in CI and blocks merge**. A change that re-wires `revoke`/`THREAD_RESOLVE` into the auto executor, or that widens the token's capability set, fails this gate.
+- **Test (deterministic):** a regression test imports the production wiring used by `defaultGitLabExecutor` and asserts the wired capability set is exactly `{readMr, postComment}`. Adding any write capability to the auto path turns this test red. This is a structural assertion on the production wiring object, not a runtime spawn.
+
+### AC9 — Action-target identity pinned to trusted provenance (fail-closed)
+The `(projectPath, mrNumber)` pair used to drive any executor action — including the `threadFetchGateway.fetchThreads(projectPath, mrNumber)` inventory that SPEC-198 AC-10 validates against — MUST be pinned to a **trusted, server-validated source**, never used as-is from the forgeable webhook payload (`gitlab.controller.ts:716-766`) to widen scope. Specifically:
+
+- `projectPath` MUST resolve to a configured repository via `findRepositoryByProjectPath`; an unrecognized `projectPath` fails closed (job not started, no fetch).
+- `mrNumber` MUST be the merge-request identifier that passed the upstream trusted-actor gate (SPEC-197) for that same validated `projectPath`. A `mrNumber` that does not correspond to the gated, validated MR MUST NOT be used to retarget `fetchThreads` at a different MR.
+- If the trusted `(projectPath, mrNumber)` cannot be established, the action surface resolves to **empty** (fail-closed): no fetch, no thread action.
+
+This closes the residual flagged in SPEC-198 AC-10: a forged `mrNumber` could otherwise point `fetchThreads` at a *different* MR whose authenticated inventory would then become actionable. SPEC-198 AC-10 validates targets *against* this inventory; SPEC-196 AC9 anchors *which* MR's inventory is fetched in the first place. Both are required.
+- **Test (deterministic):** (1) feed a payload whose `projectPath` is not in the repository registry → assert `findRepositoryByProjectPath` returns none, no executor constructed, `fetchThreads` recorded zero calls. (2) feed a payload whose `mrNumber` differs from the gated MR for the validated project → assert `fetchThreads` is never called with the forged `mrNumber` (real recording stub, call count == 0 for the foreign MR). Assert on observable gateway call records, never on model output.
+
+## Out of scope
+
+- Actor authentication / `event.user.id` trust (`eventFilter.ts:122-219`) — SPEC-197/201.
+- Target validation of write verbs and `FETCH_THREADS` restriction to `trusted` — SPEC-198.
+- Scanning `THREAD_REPLY` bodies — SPEC-199.
+- Webhook token confidentiality, rotation, and event-UUID dedup (`verifier.ts:14-85`) — SPEC-200 / SPEC-201.
+- A separate, more-scoped write executor for revoke/resolve — requires its own numbered spec with an AC8-mirror CI gate; not retained as a dormant token here (AC6).
+- The human chokepoint UX of SPEC-174 — this spec only bounds what the post-confirmation token can do.
+
+## Test strategy
+
+Detroit-style with real recording stubs (no `vi.fn`). All assertions are on **observable state**: thrown errors, env maps, rendered config-file contents, recorded filesystem paths, and gateway call counts/arguments. **No test asserts on model obedience or LLM output.** Boundaries under test:
+
+- Token-presence fail-closed (AC1).
+- Env keyset ⊆ allowlist, canary absent (AC2/AC3).
+- Config-dir isolation under temp root (AC4).
+- Capability table is the single source of truth; auto wired set == `{readMr, postComment}` (AC5/AC8).
+- Removed verbs produce zero write-gateway calls and no escalation (AC6/AC7).
+- `(projectPath, mrNumber)` provenance pin: unrecognized project / foreign MR → zero fetch, fail-closed (AC9).
+
+Fixtures: a real recording fs stub (records every read/write path), a real recording `glab`/gateway stub (records call count + args), and a fixed token string. The CI gate (AC8) is a structural test over the production wiring object.
+
+## Implementation order
+
+1. AC5 capability table — frozen exported constant, single source of truth.
+2. AC1 dedicated token + fail-closed construction.
+3. AC2/AC3 allowlist env builder + token-never-in-env.
+4. AC4 isolated `HOME`/`GLAB_CONFIG_DIR` + config-file writer.
+5. AC6/AC7 unwire `revoke`/`THREAD_RESOLVE` from the auto executor at `gitlab.controller.ts:938-978`; make removed verbs inert.
+6. AC9 pin `(projectPath, mrNumber)` to the validated repository + gated MR; fail-closed.
+7. AC8 CI gate test over the production wiring object.
+
+## Threat-check notes
+
+- **Closes its part of #3 (HIGH).** The auto-confirmed hostile diff (SPEC-174 × 190) is now bounded **by construction**: the executor token carries only read-MR + postComment. Even a fully confirmed hostile diff cannot resolve threads, reply destructively as a side-effect of resolve, or revoke approvals — those gateways are unwired (AC6) and inert (AC7), and the capability set is locked by a merge-blocking CI gate (AC8). The token is unreachable from the child env (AC3) and isolated from the operator config (AC4), so a diff that exfiltrates env contents gains nothing.
+- **Closes the provenance root of SPEC-198 AC-10 (#1).** AC9 anchors `(projectPath, mrNumber)` to a server-validated source. Without it, validating action targets against an authenticated inventory would be moot — a forged `mrNumber` could point `fetchThreads` at another MR whose authenticated inventory becomes actionable, displacing rather than closing the confused-deputy. AC9 anchors the trust root so the displacement does not occur.
+- **Hardens the #1 (CRITICAL) blast radius without fixing its root.** Removing `revoke`/`THREAD_RESOLVE` from the auto path entirely means even a successful `trusted` unlock cannot drive them through the auto executor. Target validation of the remaining write verb body and `FETCH_THREADS` restriction stay with **SPEC-198**; `THREAD_REPLY` content scanning stays with **SPEC-199**.
+- **Does NOT close #2 (CRITICAL).** `event.user.id` forgeability in GitLab.com SaaS depends on `gitlabWebhookToken` confidentiality + rotation (SPEC-201). This spec makes that an **explicit trust assumption**: if the webhook token leaks, provenance (191) is inoperative — but even then, this token's bounded capability set caps the damage at read + postComment in the auto path. Closing forgeability itself remains with the sibling spec.
+- **YAGNI guardrail.** No probabilistic diff sanitization, no content heuristics, no allow/deny scoring. The bound is a static capability set + a structural CI gate — deterministic, auditable, and merge-blocking.

--- a/docs/specs/197-trusted-actor-provenance-gate.md
+++ b/docs/specs/197-trusted-actor-provenance-gate.md
@@ -1,0 +1,171 @@
+---
+title: "SPEC-197: Trusted-actor trigger provenance gate"
+status: draft
+labels: [gitlab, webhook, provenance, trigger-gate]
+visibility: PRIVATE-UNTIL-P0-SHIPPED
+depends_on: [SPEC-201]
+sibling_specs: [SPEC-196, SPEC-198, SPEC-199, SPEC-174]
+---
+
+# SPEC-197: Trusted-actor trigger provenance gate
+
+## Context
+
+ReviewFlow auto-runs a Claude review when an inbound GitLab webhook is classified
+as a trigger (reviewer-added, MR update / followup, or an incoming note/comment).
+The originally shipped behaviour ran the review off the payload alone, without ever
+asking *who* triggered it. Any actor who can reach the webhook endpoint with a
+well-formed payload (and the shared token) can make ReviewFlow burn an
+admin-token review run against an arbitrary MR.
+
+This spec borns the **probability** of an illegitimate auto-run by gating Claude
+invocation on the trigger actor (`event.user`) being a Developer+ member of the
+target project. Non-trusted actors do not auto-run: the job is parked at the
+existing `gateClaudeInvocation` pending chokepoint (SPEC-174 `triggerMode`).
+
+This spec does **not** born the *impact* of a trusted run (what verbs a confirmed
+diff may execute) — that is owned by sibling specs 196 / 198 / 199. See
+Threat-check notes.
+
+### Trust assumption (hard dependency — write it down)
+
+`event.user.id` arrives in the webhook body and is **not signed** by GitLab.com
+SaaS. There is no body signature (GitLab signs nothing), and SaaS gives no usable
+source-IP allowlist. The **only** thing standing between an attacker and a forged
+`event.user.id = <some Developer>` is the secrecy of `gitlabWebhookToken`
+(`verifier.ts:14-37`, static `X-Gitlab-Token` compared with `timingSafeEqual`).
+
+Therefore:
+
+> **If `gitlabWebhookToken` leaks, SPEC-197 is inoperative.** A leaked token lets
+> an attacker forge `event.user` to any Developer+ identity and pass this gate.
+> The confidentiality **and rotation** of `gitlabWebhookToken` is a load-bearing
+> trust assumption of this spec. Transport/token hardening lives in SPEC-201;
+> 191 depends on it and does not attempt to re-validate provenance below the
+> token boundary.
+
+## Current behavior
+
+| Concern | Location | Current state |
+|---|---|---|
+| Reviewer-added classification | `eventFilter.ts:122-185` `checkGitLabReviewerAdded` | Never inspects `event.user` |
+| MR update / followup classification | `eventFilter.ts:191-219` `filterGitLabMrUpdate` | No actor check |
+| Note / comment classification | `eventFilter.ts` `filterGitLabNoteEvent` → `gitlab.controller.ts handleGitLabNoteHook` | No actor check (NEW in scope) |
+| Token verification | `verifier.ts:14-37` | Static `X-Gitlab-Token`, `timingSafeEqual`, fail-closed |
+| GitHub HMAC (for contrast) | `verifier.ts:43-77` | GitLab body is **not** signed |
+| Event de-duplication | `verifier.ts:82-85` | `X-Gitlab-Event-UUID` never deduplicated |
+| Job construction | `gitlab.controller.ts:716-766` | `ReviewJob` built 100% from payload |
+| Invocation chokepoint | `routes.ts` `gateClaudeInvocation` + `triggerMode` (SPEC-174) | Pending park exists; not actor-aware |
+| Membership lookup | (this spec) | Membership API, cached, fail-closed |
+
+## Acceptance criteria
+
+> Membership resolution: `event.user.id` (or namespace path) is resolved against
+> the target project's membership via the GitLab membership API, cached with TTL,
+> **fail-closed** (lookup error / timeout / ambiguous → treated as non-trusted →
+> park, never auto-run). `Developer+` = access level ≥ Developer.
+
+**AC1 — Reviewer-added gate.**
+When `checkGitLabReviewerAdded` classifies a trigger and `event.user` resolves to
+Developer+, the job proceeds to invocation. Otherwise it is parked pending at
+`gateClaudeInvocation`.
+*Test (deterministic):* stub membership gateway returning a fixed access level per
+`userId`; feed a reviewer-added payload with a Reporter `event.user.id`; assert the
+job lands in the pending queue and `defaultGitLabExecutor` was never constructed.
+Assertion is on observable job state, never on model output.
+
+**AC2 — Followup / MR-update gate.**
+Same gate applies to `filterGitLabMrUpdate`. A non-trusted actor's followup update
+parks; a Developer+ actor's update proceeds.
+*Test:* two MR-update payloads differing only by `event.user.id`; assert trusted →
+invocation path reached, non-trusted → pending. State-based.
+
+**AC3 — Note / comment gate (amendment).**
+`filterGitLabNoteEvent` / `handleGitLabNoteHook` now applies the identical actor
+gate before any auto-run. An incoming note from a non-trusted actor parks pending;
+a Developer+ note proceeds.
+*Test:* feed a note-event payload with a non-member `event.user.id`; assert the job
+is parked and no executor is wired (`gitlab.controller.ts:938-978` not reached).
+Then flip `event.user.id` to a Developer member and assert invocation path reached.
+Deterministic on job state — does not assert on whether Claude would have obeyed any
+comment body.
+
+**AC4 — Fail-closed membership resolution.**
+When the membership lookup errors, times out, or returns an indeterminate result,
+the actor is treated as non-trusted and the job parks.
+*Test:* membership stub set to throw / return undefined; assert park for every
+trigger type (reviewer-add, followup, note). No path reaches invocation.
+
+**AC5 — Cache does not widen trust.**
+A cached Developer+ result for actor A must never be applied to actor B.
+*Test:* prime the cache with `userId=A → Developer`; query `userId=B` (not primed);
+assert B resolves fail-closed (park), proving cache keying is per-actor.
+
+**AC6 — Token-boundary assumption is enforced, not assumed away.**
+The gate runs strictly *after* `verifier.ts` token validation has passed. A request
+failing token validation never reaches the actor gate (it is already rejected).
+*Test:* send a trigger payload with an invalid `X-Gitlab-Token`; assert rejection at
+the verifier layer, membership gateway never called. This makes explicit that 191
+sits *behind* the token boundary and inherits its trust from SPEC-201.
+
+## Out of scope
+
+- **Signing / authenticating `event.user.id`.** GitLab.com SaaS does not sign the
+  body; closing forgery is transport/token hardening — owned by **SPEC-201**.
+- **`X-Gitlab-Event-UUID` de-duplication / replay** (`verifier.ts:82-85`) — owned by
+  **SPEC-200**, not this gate.
+- **Impact bornage of a *trusted* run**: target validation of write verbs
+  (`THREAD_RESOLVE`, `THREAD_REPLY`, `revoke`), scoping `FETCH_THREADS` to trusted,
+  scanning `THREAD_REPLY` content — owned by **SPEC-198 / SPEC-199**.
+- **Scoping the ambient executor token** (`routes.ts:58 defaultGitLabExecutor`,
+  admin) down to read + `postComment`, and removing `revoke`/`resolve` from the
+  auto path — owned by **SPEC-196 / SPEC-174**.
+
+## Test strategy
+
+Detroit style: real stubs, no `vi.fn`. A stub membership gateway returns a fixed
+access level keyed by `userId`, with a `setShouldFail(true)` switch for AC4. All
+assertions observe **job state** (parked-pending vs invocation-path-reached) and
+**gateway call records** — never the LLM's compliance with any payload content.
+Each trigger type (reviewer-add / followup / note) gets its own payload fixture so a
+failure names the exact entry point.
+
+## Implementation order
+
+1. Membership gateway port + cached, fail-closed adapter (TTL, per-`userId` key).
+2. Shared `isTrustedActor(event, projectPath)` resolver consuming the gateway.
+3. Wire the resolver into `checkGitLabReviewerAdded` (AC1), `filterGitLabMrUpdate`
+   (AC2), and `filterGitLabNoteEvent` / `handleGitLabNoteHook` (AC3).
+4. Route non-trusted outcomes through the existing `gateClaudeInvocation` pending
+   park (SPEC-174 `triggerMode`); never construct `defaultGitLabExecutor` for them.
+5. AC4/AC5/AC6 tests harden fail-closed, cache keying, and the token-boundary
+   ordering.
+
+## Threat-check notes
+
+- **Trou #2 (CRITICAL — `event.user.id` spoofing): this spec closes its share.**
+  191 makes provenance a *required* condition for auto-run across all three trigger
+  entry points (reviewer-add, followup, note). What 191 **cannot** close is forgery
+  *below the token boundary*: in GitLab.com SaaS there is no body signature and no
+  usable IP allowlist, so a leaked `gitlabWebhookToken` defeats the gate entirely.
+  That residual is **explicitly accepted** here as the load-bearing trust assumption
+  (see Context → Trust assumption) and the *closing* of it is delegated to
+  **SPEC-201** (token confidentiality + rotation). 191 is inoperative if 195 fails.
+
+- **Trou #1 (CRITICAL — `trusted` is an under-borned blank cheque): NOT closed here,
+  delegated.** 191 only borns the *probability* that a run starts; it does not born
+  what a trusted (or token-forged-trusted) actor can then do via write verbs. A
+  Developer+ unlocking `THREAD_RESOLVE` / `THREAD_REPLY` / `revoke` against arbitrary
+  targets — including `THREAD_REPLY` unscanned by 193 — is **owned by SPEC-198**
+  (validate the target of write verbs, restrict `FETCH_THREADS` to trusted) and
+  **SPEC-199** (scan `THREAD_REPLY`). This spec deliberately does not add a
+  probabilistic impact layer (YAGNI); impact bornage is deterministic target/verb
+  scoping in the sibling specs.
+
+- **Trou #3 (HIGH — human chokepoint confirms a hostile diff with a possibly-Developer
+  token): NOT closed here, delegated.** The non-sanitizable worktree diff
+  (`gitlab.controller.ts:849-1031`) confirmed at the SPEC-174 chokepoint with the
+  ambient admin token is **owned by SPEC-196 / SPEC-174** (scope the token to
+  read + `postComment`, pull `revoke`/`resolve` off the auto path, or document the
+  residual). 191 only governs whether the run *starts*, not what the confirmed diff
+  may execute.

--- a/docs/specs/197-trusted-actor-provenance-gate.md
+++ b/docs/specs/197-trusted-actor-provenance-gate.md
@@ -60,33 +60,42 @@ Therefore:
 
 ## Acceptance criteria
 
-> Membership resolution: `event.user.id` (or namespace path) is resolved against
-> the target project's membership via the GitLab membership API, cached with TTL,
-> **fail-closed** (lookup error / timeout / ambiguous → treated as non-trusted →
-> park, never auto-run). `Developer+` = access level ≥ Developer.
+> **Codebase note (amendment):** the parsed GitLab webhook event guards expose
+> `event.user.username` (`gitlabMergeRequestEvent.guard.ts`, `gitlabNoteEvent.guard.ts`),
+> **not** `event.user.id`. Membership resolution therefore keys on `event.user.username`.
+> Where the GitLab Members API requires a numeric user id, resolve it first via the
+> Users API (`/users?username=<username>`) and then query membership
+> (`/projects/:id/members/all/:user_id`); both calls go through the authenticated
+> service token. The cache and all ACs below key on `username`.
+
+> Membership resolution: `event.user.username` is resolved against the target
+> project's membership via the GitLab membership API (Users API → user id → Members
+> API), cached with TTL, **fail-closed** (lookup error / timeout / ambiguous / unknown
+> username → treated as non-trusted → park, never auto-run). `Developer+` = access
+> level ≥ Developer.
 
 **AC1 — Reviewer-added gate.**
 When `checkGitLabReviewerAdded` classifies a trigger and `event.user` resolves to
 Developer+, the job proceeds to invocation. Otherwise it is parked pending at
 `gateClaudeInvocation`.
 *Test (deterministic):* stub membership gateway returning a fixed access level per
-`userId`; feed a reviewer-added payload with a Reporter `event.user.id`; assert the
+`username`; feed a reviewer-added payload with a Reporter `event.user.username`; assert the
 job lands in the pending queue and `defaultGitLabExecutor` was never constructed.
 Assertion is on observable job state, never on model output.
 
 **AC2 — Followup / MR-update gate.**
 Same gate applies to `filterGitLabMrUpdate`. A non-trusted actor's followup update
 parks; a Developer+ actor's update proceeds.
-*Test:* two MR-update payloads differing only by `event.user.id`; assert trusted →
+*Test:* two MR-update payloads differing only by `event.user.username`; assert trusted →
 invocation path reached, non-trusted → pending. State-based.
 
 **AC3 — Note / comment gate (amendment).**
 `filterGitLabNoteEvent` / `handleGitLabNoteHook` now applies the identical actor
 gate before any auto-run. An incoming note from a non-trusted actor parks pending;
 a Developer+ note proceeds.
-*Test:* feed a note-event payload with a non-member `event.user.id`; assert the job
+*Test:* feed a note-event payload with a non-member `event.user.username`; assert the job
 is parked and no executor is wired (`gitlab.controller.ts:938-978` not reached).
-Then flip `event.user.id` to a Developer member and assert invocation path reached.
+Then flip `event.user.username` to a Developer member and assert invocation path reached.
 Deterministic on job state — does not assert on whether Claude would have obeyed any
 comment body.
 
@@ -98,8 +107,8 @@ trigger type (reviewer-add, followup, note). No path reaches invocation.
 
 **AC5 — Cache does not widen trust.**
 A cached Developer+ result for actor A must never be applied to actor B.
-*Test:* prime the cache with `userId=A → Developer`; query `userId=B` (not primed);
-assert B resolves fail-closed (park), proving cache keying is per-actor.
+*Test:* prime the cache with `username=A → Developer`; query `username=B` (not primed);
+assert B resolves fail-closed (park), proving cache keying is per-username.
 
 **AC6 — Token-boundary assumption is enforced, not assumed away.**
 The gate runs strictly *after* `verifier.ts` token validation has passed. A request
@@ -124,7 +133,7 @@ sits *behind* the token boundary and inherits its trust from SPEC-201.
 ## Test strategy
 
 Detroit style: real stubs, no `vi.fn`. A stub membership gateway returns a fixed
-access level keyed by `userId`, with a `setShouldFail(true)` switch for AC4. All
+access level keyed by `username`, with a `setShouldFail(true)` switch for AC4. All
 assertions observe **job state** (parked-pending vs invocation-path-reached) and
 **gateway call records** — never the LLM's compliance with any payload content.
 Each trigger type (reviewer-add / followup / note) gets its own payload fixture so a
@@ -132,7 +141,7 @@ failure names the exact entry point.
 
 ## Implementation order
 
-1. Membership gateway port + cached, fail-closed adapter (TTL, per-`userId` key).
+1. Membership gateway port + cached, fail-closed adapter (TTL, per-`username` key).
 2. Shared `isTrustedActor(event, projectPath)` resolver consuming the gateway.
 3. Wire the resolver into `checkGitLabReviewerAdded` (AC1), `filterGitLabMrUpdate`
    (AC2), and `filterGitLabNoteEvent` / `handleGitLabNoteHook` (AC3).

--- a/docs/specs/198-constrained-action-surface.md
+++ b/docs/specs/198-constrained-action-surface.md
@@ -1,0 +1,246 @@
+---
+title: "SPEC-198: Constrained action surface for untrusted-origin merge requests"
+status: draft
+labels: [gitlab, llm-output, action-surface, provenance]
+visibility: PRIVATE-UNTIL-P0-SHIPPED
+depends_on: [SPEC-174, SPEC-196]
+blocks: [SPEC-196]
+---
+
+# SPEC-198: Constrained action surface for untrusted-origin merge requests
+
+## Context
+
+ReviewFlow drives a Claude review over GitLab merge requests. The LLM emits action
+tokens (`threadActionsParser.ts:13-66`) that are parsed and dispatched to write
+gateways (`executeThreadActions`, `contextActionsExecutor`). When a merge request
+originates from an untrusted actor, every parsed write verb is an attack primitive:
+the MR author controls diff content (`gitlab.controller.ts:849-1031`, read from the
+worktree, non-sanitizable) and can attempt prompt injection to coerce the model into
+emitting destructive verbs (`revoke`, `THREAD_RESOLVE`, `THREAD_REPLY`).
+
+The original scope reduced the write surface to `postComment` only for untrusted
+origins, and gated `THREAD_RESOLVE` / `THREAD_REPLY` / `revoke` behind a `trusted`
+provenance flag. An adversarial pentest demonstrated that gating on the **verb alone**
+is insufficient: once `trusted` is granted (legitimately, or via a forged unsigned
+`event.user.id` — out of this spec's scope, see Threat-check), the actor can resolve or
+reply to **arbitrary thread ids** not belonging to the current MR, and can use
+`FETCH_THREADS` to read sensitive thread contents that are then exfiltrated through
+`postComment` (read-amplification).
+
+This amendment bounds the **impact** of each write verb deterministically — target
+validation and a read-amplification gate — without adding any probabilistic layer.
+
+**Merge order (blocking):** this spec MUST merge **before** SPEC-196. SPEC-198 hardens
+the `THREAD_RESOLVE` verb (target-validation) while it still exists on the auto path;
+SPEC-196 then removes the verb from the auto path entirely. If 196 lands first the verb
+is gone before its validation matters; if 196 never lands the validation here keeps the
+verb safe for the `trusted` / future-write-executor case. Hence `blocks: [SPEC-196]`.
+
+## Current behavior
+
+| Concern | Location | Behavior |
+|---|---|---|
+| Reviewer-added filter | `eventFilter.ts:122-185` | `checkGitLabReviewerAdded` never inspects `event.user` |
+| MR-update follow-up filter | `eventFilter.ts:191-219` | `filterGitLabMrUpdate` performs no actor check |
+| Note/comment inbound filter | `eventFilter.ts` `filterGitLabNoteEvent` | feeds `gitlab.controller handleGitLabNoteHook`, no actor gate |
+| Static webhook token check | `verifier.ts:14-37` | `X-Gitlab-Token` compared with `timingSafeEqual` |
+| HMAC body signature | `verifier.ts:43-77` | GitHub-only; GitLab does **not** sign the body |
+| Event UUID dedup | `verifier.ts:82-85` | `X-Gitlab-Event-UUID` never deduplicated |
+| ReviewJob construction | `gitlab.controller.ts:716-766` | built 100% from payload |
+| Diff source | `gitlab.controller.ts:849-1031` | read from worktree, non-sanitizable |
+| Executor wiring | `gitlab.controller.ts:938-978` | wires thread/context executors |
+| Action token parser | `threadActionsParser.ts:13-66` | parses `[THREAD_RESOLVE:id]`, `[THREAD_REPLY]`, `[POST_COMMENT]`, `[FETCH_THREADS]` |
+| Resolve gateway | `approvalRevocationGateway.revoke` | revokes approval |
+| Comment gateway | `noteCommentPostGateway.postComment({projectPath, mrNumber, body})` | posts a note |
+| Ambient executor | `routes.ts:58` `defaultGitLabExecutor` | runs with ambient admin token |
+| Invocation chokepoint | `gateClaudeInvocation` + `triggerMode` (SPEC-174) | pending |
+
+## Acceptance criteria
+
+Provenance model (unchanged, restated for grounding):
+
+- **AC-1 (fail-closed provenance).** Any provenance value `!== 'trusted'` resolves to
+  `untrusted`. `trusted` is NEVER derived from a payload field (e.g. `event.user.id`,
+  author role). *Test:* feed provenance inputs `undefined`, `''`, `'TRUSTED'`,
+  `'trusted '`, `{}`; assert the resolver returns `untrusted` for all; assert it returns
+  `trusted` only for the exact canonical token set by the upstream gate.
+
+- **AC-2 (untrusted write surface = postComment only).** For an untrusted-origin MR, the
+  set of executable write verbs derived from LLM output is exactly `{ postComment }`.
+  *Test:* run the executor with an `untrusted` job and a parsed action list containing
+  one of each verb; assert only `noteCommentPostGateway.postComment` was invoked
+  (observe call records on real stub gateways), and `revoke` / resolve / reply / fetch
+  stubs recorded zero calls.
+
+- **AC-3 (parser ignores non-allowlisted types).** Tokens whose type is not in the
+  allowlist are dropped at parse time and never reach an executor. *Test:* parse a
+  string containing `[UNKNOWN:1]`, `[DROP_DB]`, and a valid `[POST_COMMENT]`; assert the
+  result contains only the `postComment` action.
+
+- **AC-4 (stdout / context-file parity).** The constrained surface is identical whether
+  actions arrive via stdout or via the context file. *Test:* feed the same action list
+  through both ingestion paths into an untrusted job; assert byte-identical executed
+  action sets.
+
+### Amended / new criteria (pentest)
+
+- **AC-5 (FETCH_THREADS restricted to trusted — read-amplification gate).**
+  `FETCH_THREADS` is a **read** verb that amplifies exfiltration via `postComment`.
+  For an untrusted-origin job it is dropped before execution; it executes only when
+  provenance is exactly `trusted`. *Test (deterministic, non-LLM boundary):* build two
+  jobs — one `untrusted`, one `trusted` — each with a parsed `[FETCH_THREADS]` action;
+  dispatch through `executeThreadActions` with real stub gateways; assert the
+  thread-fetch stub recorded **0** calls for the untrusted job and **exactly 1** for the
+  trusted job. No assertion touches model output.
+
+- **AC-6 (THREAD_RESOLVE target validation).** For a `[THREAD_RESOLVE:id]` action, the
+  executor resolves a thread **only if `id` belongs to the set of thread ids of the
+  current MR**. An `id` outside that set is dropped (no gateway call), regardless of
+  provenance. *Test:* seed the stub thread provider with current-MR thread ids
+  `{ "10", "11" }`; dispatch `[THREAD_RESOLVE:10]` (in-set), `[THREAD_RESOLVE:999]`
+  (out-of-set), and `[THREAD_RESOLVE:11 ]` (whitespace/format variant) on a `trusted`
+  job; assert the resolve stub recorded calls for `10` (and `11` after trim) only, and
+  zero call for `999`. Membership is computed from the MR thread inventory, never from
+  the token payload alone.
+
+- **AC-7 (THREAD_REPLY target validation).** For a `[THREAD_REPLY:id]` action, the
+  executor replies **only if `id` belongs to the current MR's thread id set**. An
+  out-of-set `id` is dropped (no gateway call), regardless of provenance. *Test:* same
+  seeding as AC-6; dispatch `[THREAD_REPLY:10]` and `[THREAD_REPLY:999]` on a `trusted`
+  job; assert the reply stub recorded exactly one call targeting `10` and zero call for
+  `999`.
+
+- **AC-8 (target validation precedes provenance, both required for resolve/reply).** The
+  resolve/reply path requires **both** `trusted` provenance **and** in-set target
+  membership; failing either drops the action with no gateway call. *Test:* matrix over
+  `{trusted, untrusted} × {in-set id, out-of-set id}` for both `THREAD_RESOLVE` and
+  `THREAD_REPLY`; assert a gateway call is recorded for exactly the
+  `(trusted, in-set)` cell and for no other cell.
+
+- **AC-9 (target inventory is authoritative, single source).** The current-MR thread id
+  set used for AC-6/AC-7 is derived from one explicit MR-scoped inventory passed into the
+  executor, not re-read from token text or LLM output. *Test:* construct an executor with
+  an MR thread inventory `{ "42" }`; dispatch `[THREAD_RESOLVE:42]` while the action token
+  also carries a spoofed look-alike payload claiming membership of `"7"`; assert only `42`
+  is acted on and `7` records zero calls.
+
+- **AC-10 — Action targets validated against an authenticated, complete thread inventory (fail-closed).**
+  The thread inventory consumed by AC-9 to validate every `[THREAD_RESOLVE:id]` and
+  `[THREAD_REPLY:id]` action MUST be resolved exclusively from the authenticated GitLab
+  Threads API via `threadFetchGateway.fetchThreads(projectPath, mrNumber)`. The inventory
+  MUST NOT be derived, in whole or in part, from the inbound webhook payload
+  (`gitlab.controller.ts:716-766`); any thread id, count, or membership taken from it is
+  untrusted and MUST be ignored when building the inventory.
+
+  Resolution semantics (fail-closed):
+
+  - The `projectPath` and `mrNumber` passed to `fetchThreads` MUST themselves be the
+    trusted, server-validated pair pinned by **SPEC-196 AC9** (validated repository +
+    gated MR). They are never taken as-is from forgeable payload fields to widen scope.
+    A forged `mrNumber` MUST NOT retarget `fetchThreads` at a different MR. (Anchored in
+    SPEC-196 AC9; restated here as the precondition AC-10 relies on.)
+  - **Pagination completeness (hardening).** `fetchThreads` MUST follow **all** GitLab
+    pagination pages and assemble the **complete** thread inventory. A partial `2xx`
+    response (an un-followed `next` page link, a truncated body, a page-count mismatch)
+    MUST NOT pass silently: the inventory either reflects every page or resolves to the
+    **empty set** (fail-closed). A silently partial inventory is forbidden — it must be
+    provably complete or provably empty, never "as many threads as the first page held".
+  - If `fetchThreads` fails for any reason (network error, auth failure, non-2xx,
+    timeout, malformed response, or incomplete pagination per the clause above), the
+    inventory MUST resolve to the **empty set**. It MUST NOT fall back to the payload, to
+    a cached prior inventory, or to a partially-built list.
+  - An empty inventory means **every** `THREAD_RESOLVE` / `THREAD_REPLY` action is
+    dropped: zero side effects are executed and the failure is logged. The system never
+    resolves or replies to a thread it could not authenticate.
+  - A `THREAD_RESOLVE:id` / `THREAD_REPLY:id` whose `id` is absent from the authenticated
+    inventory MUST be dropped (consistent with AC-9), regardless of whether that id
+    appeared in the payload.
+
+  This closes the AC-9 escalation: validating against an inventory that is itself
+  forgeable (or silently truncated) is equivalent to no validation. AC-10 anchors the
+  inventory to authenticated, complete state.
+
+  *Tests (deterministic, side-effect-asserting — count executed resolves/replies, not internal calls):*
+  1. **Forged-inventory rejection** — webhook payload embeds a fabricated thread inventory
+     (forged ids matching the parsed actions). Stub `threadFetchGateway.fetchThreads` to
+     return a disjoint authenticated inventory (none of the forged ids present). Assert
+     **0** resolve and **0** reply side effects — the payload-supplied ids are never honored.
+  2. **Fail-closed on fetch failure** — stub `fetchThreads` to fail (reject / non-2xx).
+     Provide parsed actions valid against any non-empty inventory. Assert inventory resolves
+     to empty, **0** resolve and **0** reply side effects, failure logged, no payload fallback.
+  3. **Fail-closed on incomplete pagination** — stub `fetchThreads` to return a first page
+     that advertises a `next` page which the stub does not deliver (truncated). Assert the
+     inventory resolves to **empty** (not the partial first page), and an in-set id from the
+     undelivered page records **0** resolve/reply side effects.
+
+## Out of scope
+
+- Forgery of `event.user.id` and the upstream provenance decision that grants `trusted`
+  (depends on SPEC-197 × SPEC-201; the unsigned-identity problem in GitLab.com SaaS).
+- Webhook token confidentiality / rotation mechanics (SPEC-201 trust assumption).
+- Event-UUID deduplication / replay protection (`verifier.ts:82-85`) — SPEC-200.
+- Scope-reduction of the ambient admin token / human-confirmed-diff token surface
+  (SPEC-196 × SPEC-174).
+- `THREAD_REPLY` content scanning for injected payloads (SPEC-199).
+- Sanitizing worktree diff content (`gitlab.controller.ts:849-1031`).
+
+## Test strategy
+
+- Detroit-school, real stub gateways (`noteCommentPostGateway`, `approvalRevocationGateway`,
+  `threadFetchGateway`, thread-resolve, thread-reply); no `vi.fn`.
+- Assertions on **observable state**: call records on stubs, executed action sets — never
+  on the model's obedience to a prompt.
+- Every gate (provenance, target membership, read-amplification, authenticated inventory)
+  tested at its deterministic boundary with explicit in-set / out-of-set,
+  trusted / untrusted, and forged / authenticated / partial-pagination inputs.
+- Format variants (whitespace, casing, empty, look-alike payload) included as negative
+  cases for the parser and target validator.
+- Stdout vs context-file parity asserted on identical inputs (AC-4).
+
+## Implementation order
+
+1. Provenance resolver fail-closed (AC-1) — confirm existing behavior with tests.
+2. Untrusted write-surface reduction to `postComment` (AC-2, AC-3, AC-4) — existing scope.
+3. Add `FETCH_THREADS` to the trusted-gated set (AC-5).
+4. Authenticated thread inventory: resolve via `threadFetchGateway.fetchThreads` on the
+   SPEC-196-pinned `(projectPath, mrNumber)`; full pagination or fail-closed-empty (AC-10).
+5. Thread inventory plumbing: pass the MR-scoped thread id set into the executor (AC-9).
+6. Target-membership validator for `THREAD_RESOLVE` / `THREAD_REPLY` (AC-6, AC-7).
+7. Compose provenance × target gate; both required for resolve/reply (AC-8).
+
+## Threat-check notes
+
+This spec closes **its part of trou #1** (under-bounded `trusted` blank cheque): the
+write verbs unlocked by `trusted` are now bounded in **impact**, not just availability.
+`THREAD_RESOLVE` / `THREAD_REPLY` validate their **target** against the current MR's
+thread inventory (AC-6, AC-7, AC-8, AC-9) — a manipulated `trusted` actor can no longer
+resolve/reply on arbitrary threads. `FETCH_THREADS` is restricted to `trusted` (AC-5),
+removing the read-amplification path by which an untrusted actor could exfiltrate
+sensitive thread content through `postComment`.
+
+**Hole #1 (target-validation bypass) — CLOSED AT THE ROOT.** Prior state: AC-9 validated
+targets against an "MR-scoped inventory". The re-pentest demonstrated that when this
+inventory was sourced from the inbound webhook payload (`gitlab.controller.ts:716-766`),
+it was forgeable on the same footing as `event.user.id` and the rest of the `ReviewJob`.
+An attacker could forge an inventory listing the very thread ids they wished to act on,
+collapsing AC-9 into a no-op. AC-10 removes the payload as a valid inventory source
+entirely (authenticated GitLab Threads API only, fail-closed, complete-or-empty), and
+SPEC-196 AC9 anchors the `(projectPath, mrNumber)` pinned into `fetchThreads` — so the
+inventory is neither attacker-controlled nor retargetable. Hole #1 is closed at the root.
+
+Renvoyé aux specs sœurs (explicitement hors de la garantie de 192):
+
+- **#1 remaining (THREAD_REPLY content):** scanning the reply body for injected payloads
+  is SPEC-199. 192 guarantees the reply *target* is in-set; it does not scan reply
+  *content*.
+- **#2 (event.user.id forgery / unsigned identity):** the decision that produces
+  `trusted` is upstream (SPEC-197 × SPEC-201). 192 is fail-closed on the flag but cannot
+  detect a forged identity.
+- **#3 (human-confirmed hostile diff with a possibly-Developer token):** bounding what
+  the non-sanitizable diff can do once confirmed, and scoping the ambient/confirmation
+  token to read + `postComment` (removing `revoke`/`resolve` from the auto path), is
+  SPEC-196 × SPEC-174. 192 only constrains the LLM-emitted verb surface, not the token's
+  ambient capability.
+- **Replay (`X-Gitlab-Event-UUID`)** — not addressed by AC-10; AC-10 addresses forgery of
+  the action inventory, not replay of a legitimate event. Replay/idempotency is SPEC-200.

--- a/docs/specs/199-review-output-egress-scan.md
+++ b/docs/specs/199-review-output-egress-scan.md
@@ -1,0 +1,111 @@
+---
+title: "SPEC-199: Review output egress scan before posting"
+status: draft
+labels: [egress, defense-in-depth, reviewflow]
+visibility: PRIVATE-UNTIL-P0-SHIPPED
+depends_on: [SPEC-196]
+---
+
+# SPEC-199: Review output egress scan before posting
+
+## Context
+
+ReviewFlow posts LLM-generated text to public GitLab surfaces (MR comments, discussion thread replies, and accompanying comments on quality-gate actions). The LLM output is non-deterministic and can be steered by a hostile diff or by injected instructions in the review context. Even with upstream authorization and provenance gates, the *content* that reaches a public surface must be bounded deterministically.
+
+This spec installs a deterministic decorator between any LLM-derived text and the public post operation. It is a defense-in-depth layer: it does not decide *who* may post or *whether* an action is authorized (those belong to sibling specs 197/198), it bounds *what leaves the system* on every public output channel — secret-shape egress, output volume, and out-of-scope cross-references.
+
+The pre-pentest version applied the scan only to `postComment`. The pentest showed `THREAD_REPLY` (same public channel, different verb) and the quality-gate `revoke` accompanying comment bypass the scan entirely. This amendment moves the enforcement point to the single shared post gateway so that **every** public-output path is covered, and adds a channel-exhaustiveness guarantee.
+
+## Current behavior
+
+| Concern | Location | Observed behavior |
+|---|---|---|
+| Comment post sink | `noteCommentPostGateway.postComment({projectPath, mrNumber, body})` | Posts `body` verbatim, no content scan. |
+| Thread reply verb | `threadActionsParser.ts:13-66` parses `[THREAD_REPLY]`; `executeThreadActions` + `contextActionsExecutor` execute it | Reply body is LLM-derived, posted via the public note channel, **not** scanned today. |
+| Quality-gate revoke comment | `approvalRevocationGateway.revoke` + accompanying note | The explanatory comment posted alongside a revoke is LLM-derived and **not** scanned today. |
+| Post comment verb | `threadActionsParser.ts` `[POST_COMMENT]` | LLM-derived body, posted via the public note channel. |
+| Ambient executor | `routes.ts:58 defaultGitLabExecutor` | Posts with ambient admin token; no content boundary on egress. |
+
+All public-output bodies converge on the note/comment posting primitive, but today only one caller (`postComment` direct) is wrapped. The other verbs reach the public surface through the same primitive without passing the scan.
+
+## Acceptance criteria
+
+> All criteria are enforced at a deterministic boundary **outside the LLM**. No criterion depends on the model "choosing" to comply. Tests assert observable state of the post gateway (called / not called, body transformed, error thrown), never the model's obedience.
+
+### AC1 — Single enforcement point on the post sink
+The egress scan is applied inside the post gateway decorator wrapping `noteCommentPostGateway.postComment`, not in individual callers. Any code path that posts public text MUST route through this decorated gateway.
+
+*Test (deterministic):* construct the decorated gateway with a real stub sink; call the decorated `postComment` with a body containing a secret shape; assert the stub sink received a redacted/blocked body (per mode), never the raw secret.
+
+### AC2 — Secret-shape scan (allow / redact / block)
+The decorator scans the outgoing body for secret shapes (token/key patterns) and applies the configured mode: `allow` (pass), `redact` (replace match with a fixed marker), `block` (do not post, signal failure).
+
+*Test (deterministic):* feed bodies with and without known secret shapes; assert: clean body passes unchanged; secret body in `redact` mode reaches the sink with the marker substituted; secret body in `block` mode never reaches the sink and raises the block signal.
+
+### AC3 — Deterministic length cap
+The decorator enforces a maximum body length. Bodies over the cap are truncated (with a fixed truncation marker) or blocked per configuration, deterministically, before reaching the sink.
+
+*Test (deterministic):* post a body exceeding the cap; assert the sink receives a body whose length ≤ cap and ends with the truncation marker (or that the post is blocked in block mode).
+
+### AC4 — Out-of-scope reference scan
+The decorator detects references outside the current review scope (e.g., cross-project paths / IRIs that do not match the active MR's `projectPath`) and applies the configured mode.
+
+*Test (deterministic):* post a body referencing a foreign `projectPath`; assert the reference is redacted/blocked per mode while in-scope references pass.
+
+### AC5 — Fail-closed on scanner error
+If the scanner throws or returns an indeterminate result, the decorator MUST NOT post. It fails closed and raises an error.
+
+*Test (deterministic):* inject a scanner stub that throws; call the decorated `postComment`; assert the sink was never called and an error was raised.
+
+### AC6 — Trace without secret
+On redact/block, the decorator emits a trace record that captures the decision (mode applied, channel, match category count) **without** including the matched secret value.
+
+*Test (deterministic):* trigger a redact on a known secret; assert the emitted trace contains the decision metadata and does **not** contain the raw secret substring.
+
+### AC7 — `THREAD_REPLY` egress is scanned (pentest amendment)
+The body produced for a `[THREAD_REPLY]` action MUST pass through the same decorated post sink before reaching the public thread. `executeThreadActions` / `contextActionsExecutor` MUST post replies via the decorated gateway, not a raw sink.
+
+*Test (deterministic):* drive `executeThreadActions` with a parsed `[THREAD_REPLY]` whose body contains a secret shape, using a real stub sink; assert the reply that reaches the sink is redacted/blocked per mode, identically to AC2 — proving the reply verb shares the same enforcement point.
+
+### AC8 — Revoke accompanying-comment egress (closed out-of-scope-by-design for the auto path)
+Per **SPEC-196 AC6**, `revoke` is **not** part of any automated ReviewFlow path. The accompanying-comment egress guarantee therefore has **no auto-path obligation** to fulfil once SPEC-196 merges: there is no auto revoke whose comment could leave the system. The guarantee that a revoke accompanying-comment is egress-scanned MUST be (re)stated in any future explicit write-executor spec that reintroduces `revoke`; it is **not** an obligation of the auto path. This AC closes as **out-of-scope-by-design** for the auto path.
+
+*Cross-ref: SPEC-196 AC6.* No deterministic auto-path test is required for AC8; if a future write-executor spec reintroduces `revoke`, that spec MUST carry the AC2-equivalent scan test for its accompanying comment, routed through the same decorated sink (AC1/AC9).
+
+### AC9 — Channel exhaustiveness (no unscanned public-output verb)
+No public-output verb may reach the note/comment primitive without passing the decorator. The set of public-output channels on the auto path {`postComment`, `THREAD_REPLY`, `POST_COMMENT`} all resolve to the single decorated sink.
+
+*Test (deterministic):* for each public-output verb in the auto-path set, exercise it through its executor with a secret-shape body against a shared real stub sink; assert every verb's body was processed by the decorator (e.g., the stub sink only ever receives scanned bodies, and a guard counter on the raw sink reads zero). This is a table-driven test over the verb set so adding an unscanned verb fails the suite.
+
+## Out of scope
+
+- **Authorization / target validation** of write verbs (`THREAD_RESOLVE`, `THREAD_REPLY`, `POST_COMMENT`, `revoke`) and restricting `FETCH_THREADS` to trusted actors → **SPEC-198**.
+- **Provenance / actor identity** (`event.user.id` forgery, webhook token confidentiality) → **SPEC-197 / SPEC-201**.
+- **Diff sanitization** of the worktree (`gitlab.controller.ts:849-1031`) and scoping the ambient executor token → **SPEC-196 / SPEC-174**.
+- **The `revoke` action and its accompanying comment** on any future write-executor path — re-stated there, not here (AC8).
+- Deciding *whether* a revoke is allowed.
+- Semantic / probabilistic content classification (toxicity, intent). This spec bounds shapes and volume deterministically only — YAGNI on any ML layer.
+
+## Test strategy
+
+- Detroit-style: real stub sink (`noteCommentPostGateway` stub recording received bodies), real stub scanner with deterministic match rules, no `vi.fn`.
+- Assertions on observable post-gateway state only: was the sink called, with what body, was an error raised, what trace was emitted.
+- A scanner stub exposing `setShouldFail(true)` drives AC5 fail-closed.
+- AC7/AC9 reuse the **same** decorated gateway and stub sink as AC1–AC6 to prove the enforcement point is genuinely shared (a verb routed around the decorator makes AC9's raw-sink counter non-zero and fails).
+- No test asserts model obedience; the LLM body is fixed test input.
+
+## Implementation order
+
+1. Extract the post sink into a single injectable `noteCommentPostGateway` interface consumed everywhere (no direct sink calls in executors).
+2. Implement the deterministic scanner (secret-shape, length cap, out-of-scope reference) as a pure module with `allow/redact/block` modes.
+3. Wrap the sink in the egress decorator (AC1–AC6), fail-closed and trace-without-secret.
+4. Route `THREAD_REPLY` (AC7) and `POST_COMMENT` executors through the decorated gateway.
+5. Add the channel-exhaustiveness table test (AC9) covering the full auto-path verb set.
+
+## Threat-check notes
+
+- **Closes ReviewFlow's part of trou #1 (CRITICAL — `trusted` blank cheque).** The pre-pentest scope left `THREAD_REPLY` as an unscanned public-output channel; this amendment (AC7) brings it under the same egress decorator as `postComment`, and AC9 guarantees no auto-path public-output verb escapes the scan. This bounds the *content impact* of an over-broad `trusted` state on the egress side, deterministically.
+- **Does NOT close the core of trou #1.** *Who* may invoke write verbs and *which target* they may write to (target validation of `THREAD_RESOLVE`/`THREAD_REPLY`, restricting `FETCH_THREADS` to trusted) remains with **SPEC-198**. This spec scans content; it does not authorize the action.
+- **Renders no judgement on trou #2 (CRITICAL — `event.user.id` forgery).** Provenance/identity is out of scope here and renvoyé to **SPEC-197 / SPEC-201**. Egress scanning is independent of who triggered the post — it bounds the body regardless of actor authenticity, so it remains effective even if provenance is forged. It does not, however, fix the forgery.
+- **Partially mitigates trou #3 (HIGH — confirmed hostile diff with a Developer-scoped token).** Once a hostile diff is human-confirmed, any LLM-derived public comment it produces is still secret-shape/length/scope-bounded on egress (AC2–AC4). This caps data exfiltration via the comment channel but does NOT scope the token or remove revoke/resolve from the auto path — that is **SPEC-196 / SPEC-174** (and after SPEC-196, `revoke` is off the auto path entirely, so AC8 closes out-of-scope-by-design).
+- The amendment is purely a *coverage extension* of an existing deterministic boundary (one enforcement point, more callers routed through it). No new probabilistic layer is introduced (YAGNI respected).

--- a/docs/specs/200-webhook-event-idempotency.md
+++ b/docs/specs/200-webhook-event-idempotency.md
@@ -1,0 +1,89 @@
+---
+title: "SPEC-200: Webhook event idempotency and replay protection"
+status: draft
+labels: [webhook, gitlab, reliability, controller]
+visibility: PRIVATE-UNTIL-P0-SHIPPED
+---
+
+# SPEC-200: Webhook event idempotency and replay protection
+
+## Context
+
+Incoming GitLab webhook deliveries carry a per-event identifier (`X-Gitlab-Event-UUID`) that is currently read nowhere, so the same event redelivered by the platform — or captured and replayed — is processed again end-to-end, including LLM invocation and platform-mutating actions. This spec adds an injectable idempotency store applied at controller entry, immediately after authentication and before any side effect, so that a given event is acted upon **at most once** within a TTL window.
+
+Guiding principle: this control **bounds the impact of replaying a single event**, it does not bound the probability that an event is malicious. It is not an authenticity control (GitLab does not sign the body; the static token remains the only authenticity check) and it does not reduce the capability blast radius (the executor still runs with the ambient token). The real impact boundary remains the `gateClaudeInvocation` chokepoint (SPEC-174). SPEC-200 only shrinks the **replay surface**: it stops a captured or redelivered event from being re-acted upon.
+
+## Current behavior
+
+| Location | Behavior |
+|---|---|
+| `verifier.ts:14-37` `verifyGitLabSignature` | Validates static `X-Gitlab-Token` via `timingSafeEqual` (timing-safe). |
+| `verifier.ts:43-77` `verifyGitHubSignature` | HMAC-SHA256 over raw body. GitLab does not sign the body (platform limit). |
+| `verifier.ts:82-85` `getGitLabEventType` | Reads `X-Gitlab-Event`. `X-Gitlab-Event-UUID` is also provided by GitLab but **never read or deduplicated**. |
+| `gitlab.controller.ts:164+` `handleGitLabWebhook` | `verify` → eventType → guard parse → filters → `filterGitLabEvent` → `findRepositoryByProjectPath` → `trackAssignment` → build `ReviewJob` → `gateClaudeInvocation.execute(...)` / enqueue. No event-level deduplication anywhere in this path. |
+| `routes.ts:388-444` | No in-app HTTPS enforcement nor IP allowlist. |
+
+Consequence: a redelivered or replayed event with the same `X-Gitlab-Event-UUID` runs the full pipeline again — replay is possible.
+
+## Acceptance criteria
+
+1. **AC1 — UUID extraction.** A pure helper `getGitLabEventUuid(headers): string | undefined` is added in `verifier.ts`, symmetric to `getGitLabEventType`, reading `X-Gitlab-Event-UUID`.
+   *Deterministic test:* given headers with the UUID present → returns the exact value; absent → returns `undefined`. No I/O, pure function.
+
+2. **AC2 — Injectable idempotency store (port).** A new gateway port `IdempotencyStore` is defined and injected through the composition root alongside existing gateways (`noteCommentPostGateway`, `approvalRevocationGateway`, `gateClaudeInvocation`). Use cases/controllers depend on the interface only.
+   *Deterministic test:* controller receives the store via deps; a stub implementation is swappable without touching controller code.
+
+3. **AC3 — Atomic check-and-record.** The port exposes a single atomic operation `recordIfAbsent(eventKey): Promise<boolean>` returning `true` when the key was newly recorded, `false` when it was already present. There is **no** separate `has`/`record` pair (TOCTOU avoidance).
+   *Deterministic test:* first call for a key → `true`; immediate second call for the same key → `false`. On the in-memory impl the check-and-set is synchronous (single event-loop tick), so two interleaved awaits cannot both observe absence.
+
+4. **AC4 — Guard placement: after auth, before any side effect.** In `handleGitLabWebhook`, the deduplication runs **immediately after a successful `verify`** and **before** `getGitLabEventType`, guard parse, `filterGitLabEvent`, `trackAssignment`, `findRepositoryByProjectPath`, `ReviewJob` construction, and `gateClaudeInvocation`. A duplicate UUID returns **HTTP 200 no-op** with zero downstream effect.
+   *Deterministic test:* two requests with the same UUID → `StubGateClaudeInvocation.invocationCount === 1`; output stubs (`noteCommentPost`, `approvalRevocation`, `trackAssignment`) remain pristine on the second; second response is 200.
+
+5. **AC5 — Distinct events are independent.** Two requests carrying different UUIDs each proceed past the guard.
+   *Deterministic test:* two distinct UUIDs → `invocationCount === 2`.
+
+6. **AC6 — Missing UUID degrades to gated, never hard-rejects.** When `verify` succeeds but `X-Gitlab-Event-UUID` is absent, the request is **not** deduplicated and is **not** rejected; it proceeds through the normal pipeline into `gateClaudeInvocation`, which under `triggerMode: pending` (SPEC-174) requires confirmation. The absence is recorded via the existing logging/telemetry path. No dedicated rejection branch is introduced (avoids a length/existence oracle and keeps the chokepoint as the single impact boundary).
+   *Deterministic test:* request without UUID → reaches `gateClaudeInvocation.execute` once (status `pending` under pending mode); no dedup entry is created; no 4xx branch is exercised.
+
+7. **AC7 — TTL re-acceptance and lower bound.** After the configured TTL elapses, the same UUID is accepted again (a legitimately re-delivered event after the window is reprocessed). The TTL is configurable and **must be ≥ the platform's maximum retry window**; it is not guessed in code.
+   *Deterministic test:* with an injected clock, `recordIfAbsent(key)` → `true`; advance clock beyond TTL; `recordIfAbsent(key)` → `true` again. Within TTL → `false`.
+
+8. **AC8 — TTL is internal to the store.** The TTL value and the clock are constructor concerns of the in-memory implementation, not part of the `IdempotencyStore` port surface. The port stays `recordIfAbsent(eventKey): Promise<boolean>`.
+   *Deterministic test:* port type exposes exactly one method; swapping TTL/clock is an impl-construction concern, invisible to consumers.
+
+## Out of scope
+
+- **Actor / provenance verification on the trigger** (the `eventFilter.ts:169-185` confused-deputy gap where `event.user` is never checked). Separate spec — SPEC-197. SPEC-200 deduplicates events, it does not authorize the actor who emitted them.
+- **Capability confinement of the executor** (`routes.ts:58` ambient admin token). SPEC-196; the impact boundary remains `gateClaudeInvocation` (SPEC-174).
+- **Body authenticity for GitLab** (platform does not sign the body). Out of reach in-app; the static token stays the sole authenticity check (SPEC-201 documents this as the root trust assumption).
+- **Distributed / multi-process store.** v1 is in-memory single-process. The port is designed so a Redis-backed impl is a drop-in later.
+- **GitHub `X-GitHub-Delivery` deduplication.** The port is platform-agnostic and reusable for free, but wiring it into the GitHub controller path is a distinct scope.
+- **HTTPS enforcement / IP allowlist** (`routes.ts:388-444`). Transport concern — SPEC-201.
+
+## Test strategy
+
+Detroit school, Vitest, real stubs (no `vi.fn` on gateways), assertions on observable state at deterministic boundaries only — never on LLM content.
+
+- **In-memory `IdempotencyStore` (inside-out, pure technical domain).** Real `Map` + injected clock. Observable state: the boolean return of `recordIfAbsent` and the presence/expiry of an entry. Covers AC3 (atomic first-true/second-false), AC7 (re-acceptance after clock advance beyond TTL), AC8 (TTL/clock internal).
+- **`getGitLabEventUuid` (pure extraction).** Header in → value out; absent → `undefined`. Covers AC1.
+- **Controller integration (`handleGitLabWebhook` with stubbed deps).** Stubs: `StubIdempotencyStore` (real Map + controlled clock), `StubGateClaudeInvocation` (counts invocations), pristine output stubs for `noteCommentPostGateway` / `approvalRevocationGateway` / `trackAssignment`. Every assertion targets a measurable non-LLM effect: `invocationCount`, output stubs untouched, HTTP status, idempotency-store contents. Covers AC4 (200 no-op, single invocation, pristine outputs), AC5 (two UUIDs → two invocations), AC6 (no UUID → one invocation into the gated chokepoint, no dedup entry, no 4xx).
+
+Proven boundaries: at most one invocation per UUID within TTL; zero side effects on a duplicate; two distinct UUIDs → two invocations; re-acceptance after TTL; missing-UUID degrades to gated rather than rejected.
+
+## Implementation order
+
+1. **In-memory `IdempotencyStore` impl** — `recordIfAbsent` with synchronous check-and-set on a `Map`, expiry via injected clock, lazy purge on write. Simplest boundary, zero controller dependency. (AC2, AC3, AC7, AC8)
+2. **`getGitLabEventUuid` in `verifier.ts`** — pure header extraction, symmetric to `getGitLabEventType`. (AC1)
+3. **Controller wiring in `handleGitLabWebhook`** — insert the guard right after `verify`, before `getGitLabEventType` and every downstream side effect: extract UUID → if present, `recordIfAbsent`; `false` → return 200 no-op; `true` → continue. If absent, skip dedup and continue into the existing pipeline (degrade-to-gated). (AC4, AC5, AC6)
+
+## Threat-check notes
+
+Residual bypasses identified and how this spec positions them:
+
+- **Forged fresh UUID per request.** An attacker holding the static token (`verifier.ts:14-37`) can mint a new UUID on every forged delivery, fully bypassing deduplication. **Not covered, by design** — idempotency is not an authenticity control. Covered conceptually by Context; the static token and the `gateClaudeInvocation` chokepoint remain the only barriers. Token authenticity hardening is SPEC-201.
+- **Confused deputy on the trigger** (`eventFilter.ts:169-185` never checks `event.user`). A *first*, non-replayed event emitted by an unauthorized actor passes untouched — dedup only stops the *second* occurrence. **Out of scope**, routed to SPEC-197.
+- **Capability blast radius** (`routes.ts:58` ambient admin token). A deduplicated, authenticated event still drives the executor at admin scope. **Out of scope**, routed to SPEC-196; named here so the impact boundary is not overstated.
+- **TOCTOU double-fire.** Closed by AC3: `recordIfAbsent` is a single atomic check-and-set, not a `has`+`record` pair, so two concurrent same-UUID deliveries cannot both pass the guard.
+- **Missing-UUID oracle / rejection branch.** Closed by AC6: absence degrades to "non-deduplicated but still gated" rather than a hard 4xx, so no rejection branch becomes an existence/length oracle and the chokepoint stays the single funnel.
+- **TTL window reopening.** Bounded by AC7: TTL must be ≥ the platform's maximum retry window; too-short a TTL would let a late legitimate redelivery be reprocessed. Configured, not guessed.
+- **Memory growth (in-memory store).** Lazy purge on write is acceptable for v1 single-process; documented as a known bound, superseded by a distributed store when that scope is opened.

--- a/docs/specs/201-transport-provenance-hardening.md
+++ b/docs/specs/201-transport-provenance-hardening.md
@@ -1,0 +1,102 @@
+---
+title: "SPEC-201: Transport and source provenance hardening"
+status: draft
+labels: [transport, infrastructure, ingress, deployment]
+visibility: PRIVATE-UNTIL-P0-SHIPPED
+related: [SPEC-197, SPEC-200]
+---
+
+# SPEC-201: Transport and source provenance hardening
+
+## Context
+
+The webhook ingress currently accepts requests on any transport and from any network origin, relying solely on a static GitLab token for trust. This spec hardens the **transport layer** so that the only path to the webhook handler is: TLS terminated by a reverse proxy on loopback, forwarded over a single trusted hop, from an allowlisted platform IP range. The guiding principle is to **bound impact deterministically, not bet on probability**: we make the set of network paths that can reach the handler small and verifiable, instead of trusting spoofable request attributes. Transport hardening is a **necessary but not sufficient** condition for trust — actor authenticity (SPEC-197), replay protection (SPEC-200), and the confused-deputy trigger are out of scope and handled by sibling specs. The IP allowlist in particular is a secondary defense (see Threat-check notes), never a proof of origin.
+
+This spec also pins down the **root trust assumption** of the whole webhook surface (AC10) and the **token rotation/revocation** procedure (AC9) that SPEC-197 depends on — because GitLab does not sign the webhook body, token confidentiality is the single load-bearing secret for provenance.
+
+## Current behavior
+
+| Concern | Location | Behavior |
+|---|---|---|
+| Webhook route mount | `routes.ts:388-444` | Endpoint mounted with no transport guard; no HTTPS enforcement, no IP allowlist in-app |
+| Protocol trust | `routes.ts:388-444` | Any naive `req.protocol` check here is spoofable when no proxy fronts the app |
+| Token verification | `verifier.ts:14-37` | `verifyGitLabSignature` — static token via `X-Gitlab-Token`, `timingSafeEqual` (already timing-safe) |
+| Token rotation | (none) | No documented rotation/revocation procedure; token effectively static for the deployment lifetime |
+| GitLab executor | `routes.ts:58` | `defaultGitLabExecutor` runs the CLI with the ambient env token — out of scope here (SPEC-196) |
+| Handler entry | `gitlab.controller.ts:164` | `handleGitLabWebhook` is reachable directly; no upstream transport gate |
+
+## Acceptance criteria
+
+1. **AC1 — Untrusted socket rejected.** When the direct socket address (`req.socket.remoteAddress`, never a header-derived value) is not the configured trusted hop, the request is rejected with `403` and `X-Forwarded-Proto` / `X-Forwarded-For` are ignored.
+   *Deterministic test:* `evaluateTransport` with a non-hop `directSocketAddress` returns `{kind:'reject', status:403}` regardless of header values. Pure function, assert discriminant + status.
+
+2. **AC2 — Non-HTTPS rejected.** When the socket passed AC1 but the resolved protocol (from the trusted hop's `X-Forwarded-Proto`) is not `https`, reject with `403`.
+   *Deterministic test:* hop-trusted context with `forwardedProto:'http'` returns `{kind:'reject', status:403}`.
+
+3. **AC3 — Allowlisted, HTTPS, hop-trusted accepted.** When socket ∈ trusted hop, protocol = https, and resolved client IP ∈ platform allowlist, return `{kind:'accept'}`.
+   *Deterministic test:* fully valid `TransportContext` returns `{kind:'accept'}`.
+
+4. **AC4 — Off-allowlist rejected.** When socket and protocol pass but the resolved client IP is outside every configured CIDR range, reject with `403`.
+   *Deterministic test:* context with resolved IP outside ranges returns `{kind:'reject', status:403}`.
+
+5. **AC5 — Handler unreachable on reject.** The webhook handler (`gitlab.controller.ts:164`) is reached **only** when the middleware calls `next()`. On any reject, `next` is never called.
+   *Deterministic test:* middleware over `FakeRequest`/`FakeResponse` — on accept `nextCalled === true`; on reject `nextCalled === false` and `res.statusCode === 403`.
+
+6. **AC6 — No spoofable protocol guard.** No `req.protocol` (nor `req.ip`, which Express derives from headers under `trust proxy`) is used as a trust decision anywhere in the ingress path. The transport middleware is the single authority; its decision reads only the raw socket address and explicit headers.
+   *Deterministic test:* static assertion / grep-equivalent over `routes.ts:388-444` and the middleware — no `req.protocol` / `req.ip` used as a guard. Decision inputs are `req.socket.remoteAddress` + named headers only.
+
+7. **AC7 — Deployment runbook shipped.** The spec ships a versioned runbook for nginx, Caddy, and Traefik: TLS terminated at the proxy, app bound to loopback only, single forwarded hop, `X-Forwarded-Proto` set by the proxy (never passed through from the client).
+   *Deterministic test:* none (documentation artifact); reviewed as part of the commit.
+
+8. **AC8 — `trust proxy` scoped to the single hop.** App bootstrap sets `app.set('trust proxy', <loopbackHop>)`, never `true`, never a broad subnet. The value is the loopback hop only, and the accept/reject decision does **not** depend on Express's derived `req.ip`.
+   *Deterministic test:* static assertion on the value passed to `app.set('trust proxy', …)` — equals the configured hop, never `true` / arbitrary IP.
+
+### Provenance / trust-root criteria (re-pentest contract)
+
+9. **AC9 — Webhook token rotation + revocation procedure.** `gitlabWebhookToken` MUST be rotatable **without redeploy**, and a documented revocation procedure MUST exist (rotate → update GitLab webhook secret → invalidate old). Token comparison MUST remain constant-time (`timingSafeEqual`, `verifier.ts:14-37`). The spec defines the rotation cadence and the operator runbook for a compromise.
+   *Deterministic test:* the token source is read from configuration that can be reloaded without restarting the process (assert the verifier reads the current configured value, not a value captured at bootstrap); the length-check-before-`timingSafeEqual` length oracle in `verifyGitLabSignature` is removed so comparison is uniformly constant-time. Runbook reviewed as part of the commit.
+
+10. **AC10 — Root trust assumption stated explicitly.** GitLab provides no webhook body-signing; therefore **token confidentiality is the root trust assumption** and MUST be stated as such in the spec. Identity fields in the payload (`event.user.id`) are trusted **only** transitively via token possession. Any field requiring stronger assurance MUST be re-fetched from an authenticated GitLab API call (the `threadFetchGateway.fetchThreads` trusted-source pattern, cf. SPEC-196 AC9 / SPEC-198 AC-10), never read from the webhook body.
+   *Deterministic test:* none for the assumption itself (operational constraint, not code-verifiable); it is documented in this spec and cross-referenced by SPEC-197 (which is inoperative if the token leaks). Where a field is re-fetched from the authenticated API instead of trusting the body, that re-fetch is covered by the owning spec's tests (SPEC-198 AC-10).
+
+> **Replay / idempotency** (`X-Gitlab-Event-UUID` de-duplication, `verifier.ts:82-85`) is owned by **SPEC-200**, not restated here. Transport hardening does not stop a perfect replay; SPEC-200 does.
+
+## Out of scope
+
+- **Actor / confused-deputy trigger.** `checkGitLabReviewerAdded` (`eventFilter.ts:169-185`) never checks `event.user`; `filterGitLabMrUpdate` (`191-219`) has no actor control. Membership check (`projects/:id/members/all/:user_id`, Developer+) is **SPEC-197**.
+- **Replay protection.** `X-Gitlab-Event-UUID` dedup/idempotency is **SPEC-200**.
+- **Blast radius of the executor.** `defaultGitLabExecutor` ambient admin token (`routes.ts:58`) → **SPEC-196**.
+- **LLM output → actions.** Diff content (`buildGitLabReviewProcessor`) and `threadActionsParser` execution are unaffected by this spec; transport bounds *who reaches* the handler, not *what the content does* (SPEC-198 / SPEC-199).
+- **GitHub `meta` API dynamic allowlist.** Best-effort; static CIDR config only here.
+
+## Test strategy
+
+Detroit school, Vitest, real stubs (no `vi.fn` on gateways). All boundaries are deterministic and LLM-free — no test depends on model output or worktree diff content.
+
+- **`evaluateTransport` (pure use case)** — the three sequential guards (socket trust → protocol → IP allowlist) as a pure function. Build `TransportContext` exclusively via `TransportContextFactory` (no naked literals). Assert on the `{kind, status}` discriminant. Covers AC1–AC4.
+- **`ClientIpResolver` + `StubClientIpResolver`** — `setResolved(ip)` returns a fixed IP; verifies the resolver consumes `forwardedFor` **only after** the socket is trusted, never to decide trust itself. Real stub, no socket.
+- **`transportGuardMiddleware` (Interface Adapter)** — `FakeRequest` (carries `socket.remoteAddress` + headers) / `FakeResponse` (captures `statusCode`) + a captured `nextCalled` flag. On accept → `next()` called and handler reachable; on reject → exact `statusCode` + `next` not called. Covers AC5.
+- **`trust proxy` bootstrap** — static assertion that the value passed to `app.set('trust proxy', …)` equals the configured hop and is never `true` / arbitrary. Covers AC8.
+- **No-spoofable-guard assertion** — static/grep-equivalent check that `req.protocol` / `req.ip` are absent as trust guards in `routes.ts:388-444` and the middleware. Covers AC6.
+- **Token rotation** — assert the verifier reads the current configured token (reloadable without restart) and that the length-oracle pre-check is removed so `timingSafeEqual` is the sole, constant-time comparison. Covers AC9.
+
+## Implementation order
+
+1. **`evaluateTransport` pure use case** — the three guards (socket trust, https, IP allowlist). Core value, zero I/O. RED → GREEN → REFACTOR per guard.
+2. **`ClientIpResolver` port + impl + stub** — IP resolution via the trusted hop; `forwardedFor` consumed only post-trust.
+3. **`transportGuardMiddleware` Interface Adapter** — wire Express → `TransportContext` → `evaluateTransport` → status / `next`. Inserted at the **head** of the chain in `routes.ts:388-444`, before `verifyGitLabSignature` (`verifier.ts:14`).
+4. **`trust proxy` bootstrap + cleanup** — `app.set('trust proxy', <loopbackHop>)`; remove every naive `req.protocol` check from `routes.ts:388-444`. Decision never reads `req.ip`.
+5. **Token rotation (AC9)** — read `gitlabWebhookToken` from reloadable config; remove the length-oracle pre-check in `verifyGitLabSignature`; ship the rotation/revocation runbook.
+6. **Deployment runbook** (nginx / Caddy / Traefik) in this spec — non-code, shipped with the commit (AC7).
+
+## Threat-check notes
+
+Residual bypasses identified during design review, and how this spec handles each:
+
+- **IP allowlist bounds probability, not impact.** If the platform ranges are GitLab.com SaaS, they are shared across all tenants — any hostile GitLab.com project emits from the same ranges. Guard (c) is therefore a **secondary** defense and proves nothing about *which* project sent the webhook. Authenticity weight stays on the signed token (`verifier.ts`) and SPEC-196/197. The spec never presents the allowlist as proof of origin.
+- **Trust decision must read the raw socket only.** Guard (a) evaluates `req.socket.remoteAddress`, never `X-Forwarded-For` / `req.ip`. Trusting a header to decide whether to trust the header is circular; the contract enforces that `forwardedFor` / `forwardedProto` are consumed only **after** the socket clears guard (a). This is why AC6 forbids `req.ip` (Express derives it from headers under `trust proxy`) as a guard.
+- **Single authority.** `app.set('trust proxy', hop)` is set only so Express does not pollute `req.ip` elsewhere; the accept/reject decision lives entirely in the middleware and does not consult Express-derived values. Two sources of truth on the same decision is a divergence risk — avoided by design (AC8 + AC6).
+- **Reject status is uniform `403`.** `421 Misdirected Request` was considered and rejected: it signals a TLS/SNI authority mismatch and can trigger unexpected client retries. All rejects return a sober `403`; the `reason` discriminant stays internal and is never sent to the client, avoiding a length/state oracle.
+- **Root trust = token confidentiality (AC10).** GitLab does not sign the body, so token + transport are the only network-level levers. `event.user.id` is trusted only transitively via token possession; SPEC-197 is inoperative if the token leaks. Hence AC9 (rotation/revocation without redeploy) is load-bearing, not cosmetic.
+- **Confused deputy is NOT closed by transport.** Once socket + IP + signature pass, the payload is still fully actor-controlled (`eventFilter.ts:169-185` never checks `event.user`). Explicitly deferred to **SPEC-197** — this spec must not create a false impression that provenance is resolved.
+- **Replay survives transport.** A perfect replay (same allowlisted IP, same static token, same body) passes every transport guard; `X-Gitlab-Event-UUID` dedup is **SPEC-200**.

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/damien/Documents/Projets/claude-review-automation/node_modules

--- a/src/main/routes.ts
+++ b/src/main/routes.ts
@@ -60,6 +60,8 @@ import {
 import { RecomputeGlobalConcurrencyUseCase } from '@/modules/cli-configuration/usecases/projectConfig/recomputeGlobalConcurrency.usecase.js';
 import { RepositoriesListRuntimeConfigGateway } from '@/modules/cli-configuration/interface-adapters/gateways/repositoriesList.runtimeConfig.gateway.js';
 import { GitLabThreadFetchGateway, defaultGitLabExecutor } from '@/modules/platform-integration/interface-adapters/gateways/threadFetch.gitlab.gateway.js';
+import { GitLabMemberAccessCliGateway } from '@/modules/platform-integration/interface-adapters/gateways/memberAccess.gitlab.cli.gateway.js';
+import { IsTrustedActorUseCase } from '@/modules/platform-integration/usecases/isTrustedActor.usecase.js';
 import { GitLabDiffMetadataFetchGateway } from '@/modules/platform-integration/interface-adapters/gateways/diffMetadataFetch.gitlab.gateway.js';
 import { GitHubThreadFetchGateway, defaultGitHubExecutor } from '@/modules/platform-integration/interface-adapters/gateways/threadFetch.github.gateway.js';
 import { GitHubDiffMetadataFetchGateway } from '@/modules/platform-integration/interface-adapters/gateways/diffMetadataFetch.github.gateway.js';
@@ -296,6 +298,11 @@ export async function registerRoutes(
     logger: deps.logger,
   });
 
+  // SPEC-197: trigger-actor provenance gate. Membership is resolved through the
+  // scoped GitLab executor, cached per username, fail-closed.
+  const gitLabMemberAccessGateway = new GitLabMemberAccessCliGateway(defaultGitLabExecutor);
+  const isTrustedActor = new IsTrustedActorUseCase(gitLabMemberAccessGateway);
+
   await app.register(pendingReviewsRoutes, {
     listPendingReviews,
     confirmPendingReview,
@@ -438,6 +445,7 @@ export async function registerRoutes(
       getRepositories: () => deps.config.repositories,
       claudeInvokerDeps,
       gateClaudeInvocation,
+      isTrustedActor,
       removeWorktree: removeWorktreeAction,
       recordBypass: new RecordBypassUseCase(trackingGw),
       noteCommentPostGateway: new EgressScannedNoteCommentPostGateway(

--- a/src/main/routes.ts
+++ b/src/main/routes.ts
@@ -43,6 +43,9 @@ import { getConfigDir } from '@/shared/services/configDir.js';
 import { homedir } from 'node:os';
 import { handleGitLabWebhook } from '@/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.js';
 import { handleGitHubWebhook } from '@/modules/platform-integration/interface-adapters/controllers/webhook/github.controller.js';
+import { transportGuardMiddleware } from '@/modules/platform-integration/interface-adapters/controllers/webhook/transportGuard.middleware.js';
+import { ForwardedForClientIpResolver } from '@/modules/platform-integration/interface-adapters/gateways/transport/clientIpResolver.forwardedFor.gateway.js';
+import { resolveTransportGuardConfig } from '@/security/transportGuardConfig.js';
 import {
   cancelJob,
   getJobStatus,
@@ -385,7 +388,25 @@ export async function registerRoutes(
       sourceCheckoutPath: input.sourceCheckoutPath,
     });
 
+  const transportGuardConfig = resolveTransportGuardConfig();
+  const clientIpResolver = new ForwardedForClientIpResolver();
+
   app.post('/webhooks/gitlab', async (request, reply) => {
+    let proceed = false;
+    transportGuardMiddleware(
+      {
+        request: { socket: { remoteAddress: request.socket.remoteAddress }, headers: request.headers },
+        reply: { code: (status) => reply.code(status), send: () => reply.send() },
+        next: () => {
+          proceed = true;
+        },
+        resolver: clientIpResolver,
+      },
+      transportGuardConfig,
+    );
+    if (!proceed) {
+      return;
+    }
     await handleGitLabWebhook(request, reply, deps.logger, trackingGw, {
       reviewContextGateway: deps.reviewContextGateway,
       threadFetchGateway: threadFetchGw,
@@ -416,6 +437,21 @@ export async function registerRoutes(
   const gitHubThreadFetchGw = new GitHubThreadFetchGateway(defaultGitHubExecutor);
 
   app.post('/webhooks/github', async (request, reply) => {
+    let proceedGitHub = false;
+    transportGuardMiddleware(
+      {
+        request: { socket: { remoteAddress: request.socket.remoteAddress }, headers: request.headers },
+        reply: { code: (status) => reply.code(status), send: () => reply.send() },
+        next: () => {
+          proceedGitHub = true;
+        },
+        resolver: clientIpResolver,
+      },
+      transportGuardConfig,
+    );
+    if (!proceedGitHub) {
+      return;
+    }
     await handleGitHubWebhook(request, reply, deps.logger, trackingGw, {
       reviewContextGateway: deps.reviewContextGateway,
       threadFetchGateway: gitHubThreadFetchGw,

--- a/src/main/routes.ts
+++ b/src/main/routes.ts
@@ -43,6 +43,7 @@ import { getConfigDir } from '@/shared/services/configDir.js';
 import { homedir } from 'node:os';
 import { handleGitLabWebhook } from '@/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.js';
 import { handleGitHubWebhook } from '@/modules/platform-integration/interface-adapters/controllers/webhook/github.controller.js';
+import { InMemoryIdempotencyStore } from '@/modules/platform-integration/interface-adapters/gateways/inMemoryIdempotencyStore.gateway.js';
 import {
   cancelJob,
   getJobStatus,
@@ -376,6 +377,13 @@ export async function registerRoutes(
   const trackingGw = deps.reviewRequestTrackingGateway;
   const threadFetchGw = new GitLabThreadFetchGateway(defaultGitLabExecutor);
 
+  // TTL must be >= the platform's maximum webhook retry window so a
+  // legitimately re-delivered event past that window is reprocessed, while any
+  // redelivery/replay inside it is acted upon at most once. 24h is a safe upper
+  // bound for GitLab's redelivery window.
+  const WEBHOOK_IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
+  const idempotencyStore = new InMemoryIdempotencyStore({ ttlMs: WEBHOOK_IDEMPOTENCY_TTL_MS });
+
   const removeWorktreeAction = (input: {
     identity: WorktreeIdentity;
     sourceCheckoutPath: string;
@@ -407,6 +415,7 @@ export async function registerRoutes(
       noteCommentPostGateway: new GitLabNoteCommentPostCliGateway(defaultGitLabExecutor),
       handlePlatformApproval: new HandlePlatformApprovalUseCase(trackingGw),
       approvalRevocationGateway: new GitLabApprovalRevocationCliGateway(defaultGitLabExecutor),
+      idempotencyStore,
       getQualityThreshold: (projectPath: string) =>
         loadProjectConfig(projectPath)?.qualityThreshold ?? null,
       now: () => new Date().toISOString(),

--- a/src/main/routes.ts
+++ b/src/main/routes.ts
@@ -72,6 +72,10 @@ import { RecordBypassUseCase } from '@/modules/tracking/usecases/tracking/record
 import { HandlePlatformApprovalUseCase } from '@/modules/tracking/usecases/tracking/handlePlatformApproval.usecase.js';
 import { GitLabNoteCommentPostCliGateway } from '@/modules/platform-integration/interface-adapters/gateways/cli/noteCommentPost.gitlab.cli.gateway.js';
 import { GitHubNoteCommentPostCliGateway } from '@/modules/platform-integration/interface-adapters/gateways/cli/noteCommentPost.github.cli.gateway.js';
+import { EgressScannedNoteCommentPostGateway } from '@/modules/platform-integration/interface-adapters/gateways/egressScanned.noteCommentPost.gateway.js';
+import { LoggerEgressTraceGateway } from '@/modules/platform-integration/interface-adapters/gateways/loggerEgressTrace.gateway.js';
+import { createEgressScanner } from '@/modules/platform-integration/entities/egressScan/egressScan.scanner.js';
+import { defaultEgressScanConfig } from '@/modules/platform-integration/entities/egressScan/egressScan.defaults.js';
 import { GitLabApprovalRevocationCliGateway } from '@/modules/platform-integration/interface-adapters/gateways/cli/approvalRevocation.gitlab.cli.gateway.js';
 import { GitHubApprovalRevocationCliGateway } from '@/modules/platform-integration/interface-adapters/gateways/cli/approvalRevocation.github.cli.gateway.js';
 import { ReviewContextFileSystemGateway } from '@/modules/review-execution/interface-adapters/gateways/reviewContext.fileSystem.gateway.js';
@@ -377,6 +381,9 @@ export async function registerRoutes(
   const trackingGw = deps.reviewRequestTrackingGateway;
   const threadFetchGw = new GitLabThreadFetchGateway(defaultGitLabExecutor);
 
+  const egressScanner = createEgressScanner(defaultEgressScanConfig);
+  const egressTraceGateway = new LoggerEgressTraceGateway(deps.logger);
+
   // TTL must be >= the platform's maximum webhook retry window so a
   // legitimately re-delivered event past that window is reprocessed, while any
   // redelivery/replay inside it is acted upon at most once. 24h is a safe upper
@@ -412,7 +419,11 @@ export async function registerRoutes(
       gateClaudeInvocation,
       removeWorktree: removeWorktreeAction,
       recordBypass: new RecordBypassUseCase(trackingGw),
-      noteCommentPostGateway: new GitLabNoteCommentPostCliGateway(defaultGitLabExecutor),
+      noteCommentPostGateway: new EgressScannedNoteCommentPostGateway(
+        new GitLabNoteCommentPostCliGateway(defaultGitLabExecutor),
+        egressScanner,
+        egressTraceGateway,
+      ),
       handlePlatformApproval: new HandlePlatformApprovalUseCase(trackingGw),
       approvalRevocationGateway: new GitLabApprovalRevocationCliGateway(defaultGitLabExecutor),
       idempotencyStore,
@@ -443,7 +454,11 @@ export async function registerRoutes(
       gateClaudeInvocation,
       removeWorktree: removeWorktreeAction,
       recordBypass: new RecordBypassUseCase(trackingGw),
-      noteCommentPostGateway: new GitHubNoteCommentPostCliGateway(defaultGitHubExecutor),
+      noteCommentPostGateway: new EgressScannedNoteCommentPostGateway(
+        new GitHubNoteCommentPostCliGateway(defaultGitHubExecutor),
+        egressScanner,
+        egressTraceGateway,
+      ),
       handlePlatformApproval: new HandlePlatformApprovalUseCase(trackingGw),
       approvalRevocationGateway: new GitHubApprovalRevocationCliGateway(defaultGitHubExecutor),
       getQualityThreshold: (projectPath: string) =>

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -28,6 +28,7 @@ import { runReviewRecovery } from '@/modules/review-execution/services/reviewRec
 import { executeActionsFromContext } from '@/modules/review-execution/services/contextActionsExecutor.js';
 import { defaultCommandExecutor } from '@/modules/review-execution/services/threadActionsExecutor.js';
 import { configureSettingsLogger, configureSettingsPath, getDefaultSettingsPath, loadSettingsFromDisk } from '@/frameworks/settings/runtimeSettings.js';
+import { transportTrustProxyValue } from '@/security/transportGuardConfig.js';
 
 export interface ServerOptions {
   config?: Config;
@@ -87,7 +88,10 @@ function reviveJobStatusFromRecord(record: JobRecord): JobStatus {
 }
 
 async function buildServer(deps: Dependencies): Promise<FastifyInstance> {
-  const app = Fastify({ logger: false });
+  // trust proxy is scoped to the single loopback hop only (never true, never a
+  // broad subnet) so Fastify does not inflate request attributes from client
+  // headers; the accept/reject decision lives entirely in the transport guard.
+  const app = Fastify({ logger: false, trustProxy: transportTrustProxyValue() });
 
   addRawBodyParser(app);
   await app.register(fastifyWebsocket);

--- a/src/modules/platform-integration/entities/egressScan/egressScan.defaults.ts
+++ b/src/modules/platform-integration/entities/egressScan/egressScan.defaults.ts
@@ -1,0 +1,10 @@
+import type { EgressScanConfig } from '@/modules/platform-integration/entities/egressScan/egressScan.scanner.js';
+
+export const defaultEgressScanConfig: EgressScanConfig = {
+  secretShapeMode: 'redact',
+  lengthMode: 'redact',
+  outOfScopeMode: 'allow',
+  maxBodyLength: 65536,
+  redactionMarker: '[redacted]',
+  truncationMarker: '\n\n…[truncated]',
+};

--- a/src/modules/platform-integration/entities/egressScan/egressScan.gateway.ts
+++ b/src/modules/platform-integration/entities/egressScan/egressScan.gateway.ts
@@ -1,0 +1,26 @@
+export type EgressScanMode = 'allow' | 'redact' | 'block';
+
+export type EgressChannel = 'postComment' | 'THREAD_REPLY' | 'POST_COMMENT';
+
+export type EgressMatchCategory = 'secret-shape' | 'length-cap' | 'out-of-scope';
+
+export interface EgressScanInput {
+  body: string;
+  channel: EgressChannel;
+  projectPath: string;
+}
+
+export interface EgressScanTrace {
+  channel: EgressChannel;
+  mode: EgressScanMode;
+  matchCategoryCounts: Record<EgressMatchCategory, number>;
+}
+
+export type EgressScanResult =
+  | { decision: 'pass'; body: string }
+  | { decision: 'redact'; body: string; trace: EgressScanTrace }
+  | { decision: 'block'; trace: EgressScanTrace };
+
+export interface EgressScanGateway {
+  scan(input: EgressScanInput): EgressScanResult;
+}

--- a/src/modules/platform-integration/entities/egressScan/egressScan.scanner.ts
+++ b/src/modules/platform-integration/entities/egressScan/egressScan.scanner.ts
@@ -1,0 +1,97 @@
+import type {
+  EgressScanGateway,
+  EgressScanInput,
+  EgressScanMode,
+  EgressScanResult,
+  EgressMatchCategory,
+} from '@/modules/platform-integration/entities/egressScan/egressScan.gateway.js';
+
+export interface EgressScanConfig {
+  secretShapeMode: EgressScanMode;
+  lengthMode: EgressScanMode;
+  outOfScopeMode: EgressScanMode;
+  maxBodyLength: number;
+  redactionMarker: string;
+  truncationMarker: string;
+}
+
+const SECRET_SHAPE_PATTERN =
+  /\b(?:glpat-[A-Za-z0-9_-]{20,}|gh[pousr]_[A-Za-z0-9]{20,}|sk-[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})\b/g;
+
+const PROJECT_REFERENCE_PATTERN = /\b[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._/-]*\b/g;
+
+function emptyCounts(): Record<EgressMatchCategory, number> {
+  return { 'secret-shape': 0, 'length-cap': 0, 'out-of-scope': 0 };
+}
+
+function isOutOfScope(reference: string, projectPath: string): boolean {
+  return reference !== projectPath && !reference.startsWith(`${projectPath}/`);
+}
+
+export function createEgressScanner(config: EgressScanConfig): EgressScanGateway {
+  return {
+    scan(input: EgressScanInput): EgressScanResult {
+      const counts = emptyCounts();
+      let body = input.body;
+      let blocked = false;
+      let mutated = false;
+
+      const secretMatches = body.match(SECRET_SHAPE_PATTERN) ?? [];
+      if (secretMatches.length > 0) {
+        counts['secret-shape'] = secretMatches.length;
+        if (config.secretShapeMode === 'block') {
+          blocked = true;
+        } else if (config.secretShapeMode === 'redact') {
+          body = body.replace(SECRET_SHAPE_PATTERN, config.redactionMarker);
+          mutated = true;
+        }
+      }
+
+      const outOfScopeMatches = (body.match(PROJECT_REFERENCE_PATTERN) ?? []).filter((reference) =>
+        isOutOfScope(reference, input.projectPath),
+      );
+      if (outOfScopeMatches.length > 0) {
+        counts['out-of-scope'] = outOfScopeMatches.length;
+        if (config.outOfScopeMode === 'block') {
+          blocked = true;
+        } else if (config.outOfScopeMode === 'redact') {
+          for (const reference of outOfScopeMatches) {
+            body = body.split(reference).join(config.redactionMarker);
+          }
+          mutated = true;
+        }
+      }
+
+      if (body.length > config.maxBodyLength) {
+        counts['length-cap'] = 1;
+        if (config.lengthMode === 'block') {
+          blocked = true;
+        } else if (config.lengthMode === 'redact') {
+          const room = config.maxBodyLength - config.truncationMarker.length;
+          const head = room > 0 ? body.slice(0, room) : '';
+          body = `${head}${config.truncationMarker}`;
+          mutated = true;
+        }
+      }
+
+      const mode: EgressScanMode = blocked ? 'block' : mutated ? 'redact' : 'allow';
+
+      if (blocked) {
+        return {
+          decision: 'block',
+          trace: { channel: input.channel, mode, matchCategoryCounts: counts },
+        };
+      }
+
+      if (mutated) {
+        return {
+          decision: 'redact',
+          body,
+          trace: { channel: input.channel, mode, matchCategoryCounts: counts },
+        };
+      }
+
+      return { decision: 'pass', body };
+    },
+  };
+}

--- a/src/modules/platform-integration/entities/egressScan/egressTrace.gateway.ts
+++ b/src/modules/platform-integration/entities/egressScan/egressTrace.gateway.ts
@@ -1,0 +1,5 @@
+import type { EgressScanTrace } from '@/modules/platform-integration/entities/egressScan/egressScan.gateway.js';
+
+export interface EgressTraceGateway {
+  record(trace: EgressScanTrace): void;
+}

--- a/src/modules/platform-integration/entities/executorToken/executorCapability.ts
+++ b/src/modules/platform-integration/entities/executorToken/executorCapability.ts
@@ -1,0 +1,23 @@
+export type ExecutorCapability = 'readMr' | 'postComment' | 'threadResolve' | 'revoke'
+
+export type GitLabRole = 'reporter' | 'developer'
+
+export interface CapabilityDeclaration {
+  readonly minRole: GitLabRole
+  readonly autoPath: boolean
+}
+
+export const EXECUTOR_CAPABILITY_TABLE: Readonly<
+  Record<ExecutorCapability, CapabilityDeclaration>
+> = {
+  readMr: { minRole: 'reporter', autoPath: true },
+  postComment: { minRole: 'reporter', autoPath: true },
+  threadResolve: { minRole: 'developer', autoPath: false },
+  revoke: { minRole: 'developer', autoPath: false },
+}
+
+export const AUTO_EXECUTOR_CAPABILITIES: ReadonlySet<ExecutorCapability> = new Set(
+  (Object.entries(EXECUTOR_CAPABILITY_TABLE) as [ExecutorCapability, CapabilityDeclaration][])
+    .filter(([, declaration]) => declaration.autoPath)
+    .map(([capability]) => capability),
+)

--- a/src/modules/platform-integration/entities/idempotency/idempotencyStore.gateway.ts
+++ b/src/modules/platform-integration/entities/idempotency/idempotencyStore.gateway.ts
@@ -1,0 +1,3 @@
+export interface IdempotencyStore {
+  recordIfAbsent(eventKey: string): Promise<boolean>;
+}

--- a/src/modules/platform-integration/entities/memberAccess/memberAccess.gateway.ts
+++ b/src/modules/platform-integration/entities/memberAccess/memberAccess.gateway.ts
@@ -1,0 +1,13 @@
+import type { ResolvedAccessLevel } from '@/modules/platform-integration/entities/memberAccess/memberAccess.js';
+
+/**
+ * Resolves a GitLab actor's access level on a target project, keyed by username.
+ *
+ * Implementations MUST be fail-closed (SPEC-197 AC4): any lookup error, timeout,
+ * ambiguous result, or unknown username resolves to `null` (non-trusted). The
+ * resolution keys on `username` (the only identity exposed by the parsed webhook
+ * guards) and never widens trust across usernames (AC5).
+ */
+export interface MemberAccessGateway {
+  resolve(projectPath: string, username: string): Promise<ResolvedAccessLevel>;
+}

--- a/src/modules/platform-integration/entities/memberAccess/memberAccess.ts
+++ b/src/modules/platform-integration/entities/memberAccess/memberAccess.ts
@@ -1,0 +1,32 @@
+/**
+ * GitLab project membership access levels, mirroring the numeric scale returned by
+ * the GitLab Members API. Only the ordering matters for trust decisions: Developer
+ * and above is trusted, everything below is not.
+ *
+ * See SPEC-197: trust = access level >= Developer.
+ */
+export const MEMBER_ACCESS_LEVELS = {
+  noAccess: 0,
+  minimalAccess: 5,
+  guest: 10,
+  reporter: 20,
+  developer: 30,
+  maintainer: 40,
+  owner: 50,
+} as const;
+
+export type MemberAccessLevel = (typeof MEMBER_ACCESS_LEVELS)[keyof typeof MEMBER_ACCESS_LEVELS];
+
+export const DEVELOPER_ACCESS_LEVEL: MemberAccessLevel = MEMBER_ACCESS_LEVELS.developer;
+
+/**
+ * A resolved access level (the actor is a member at some level) or `null` when the
+ * actor could not be resolved as a trusted member. Per SPEC-197 the gateway is
+ * fail-closed: lookup error / timeout / ambiguous / unknown username all collapse
+ * to `null` (non-trusted).
+ */
+export type ResolvedAccessLevel = MemberAccessLevel | null;
+
+export function isDeveloperOrAbove(accessLevel: ResolvedAccessLevel): boolean {
+  return accessLevel !== null && accessLevel >= DEVELOPER_ACCESS_LEVEL;
+}

--- a/src/modules/platform-integration/entities/transport/cidr.ts
+++ b/src/modules/platform-integration/entities/transport/cidr.ts
@@ -1,0 +1,40 @@
+function ipv4ToInteger(ip: string): number | null {
+  const octets = ip.split('.');
+  if (octets.length !== 4) {
+    return null;
+  }
+
+  let value = 0;
+  for (const octet of octets) {
+    if (!/^\d{1,3}$/.test(octet)) {
+      return null;
+    }
+    const part = Number(octet);
+    if (part > 255) {
+      return null;
+    }
+    value = value * 256 + part;
+  }
+  return value >>> 0;
+}
+
+export function isIpInCidr(ip: string, cidr: string): boolean {
+  const [rangeIp, prefixText] = cidr.split('/');
+  const prefix = Number(prefixText);
+  if (!Number.isInteger(prefix) || prefix < 0 || prefix > 32) {
+    return false;
+  }
+
+  const ipValue = ipv4ToInteger(ip);
+  const rangeValue = ipv4ToInteger(rangeIp);
+  if (ipValue === null || rangeValue === null) {
+    return false;
+  }
+
+  if (prefix === 0) {
+    return true;
+  }
+
+  const mask = (0xffffffff << (32 - prefix)) >>> 0;
+  return (ipValue & mask) === (rangeValue & mask);
+}

--- a/src/modules/platform-integration/entities/transport/clientIpResolver.gateway.ts
+++ b/src/modules/platform-integration/entities/transport/clientIpResolver.gateway.ts
@@ -1,0 +1,8 @@
+export interface ClientIpResolutionInput {
+  socketTrusted: boolean;
+  forwardedFor: string | null;
+}
+
+export interface ClientIpResolver {
+  resolve(input: ClientIpResolutionInput): string | null;
+}

--- a/src/modules/platform-integration/entities/transport/transportContext.ts
+++ b/src/modules/platform-integration/entities/transport/transportContext.ts
@@ -1,0 +1,13 @@
+export interface TransportContext {
+  directSocketAddress: string;
+  trustedHopAddress: string;
+  forwardedProto: string | null;
+  resolvedClientIp: string | null;
+  allowedCidrRanges: string[];
+}
+
+export type TransportRejectReason = 'untrusted-socket' | 'non-https' | 'off-allowlist';
+
+export type TransportDecision =
+  | { kind: 'accept' }
+  | { kind: 'reject'; status: 403; reason: TransportRejectReason };

--- a/src/modules/platform-integration/interface-adapters/controllers/webhook/github.controller.ts
+++ b/src/modules/platform-integration/interface-adapters/controllers/webhook/github.controller.ts
@@ -570,6 +570,8 @@ export async function handleGitHubWebhook(
                   j.localPath,
                   logger,
                   defaultCommandExecutor,
+                  null,
+                  deps.noteCommentPostGateway,
                 );
                 logger.info(
                   { ...contextActionResult, threadResolveCount, prNumber: j.mrNumber },
@@ -593,7 +595,8 @@ export async function handleGitHubWebhook(
                       localPath: j.localPath,
                     },
                     logger,
-                    defaultCommandExecutor
+                    defaultCommandExecutor,
+                    deps.noteCommentPostGateway
                   );
                   logger.info(
                     { ...actionResult, threadResolveCount, prNumber: j.mrNumber },
@@ -874,7 +877,8 @@ export async function handleGitHubWebhook(
             localPath: j.localPath,
           },
           logger,
-          defaultCommandExecutor
+          defaultCommandExecutor,
+          deps.noteCommentPostGateway
         );
         logger.info(
           { ...actionResult, prNumber: j.mrNumber },
@@ -889,7 +893,9 @@ export async function handleGitHubWebhook(
           reviewContext,
           j.localPath,
           logger,
-          defaultCommandExecutor
+          defaultCommandExecutor,
+          null,
+          deps.noteCommentPostGateway
         );
         logger.info(
           { ...contextActionResult, prNumber: j.mrNumber },

--- a/src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts
+++ b/src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts
@@ -601,6 +601,7 @@ export async function handleGitLabWebhook(
                   logger,
                   defaultCommandExecutor,
                   followupBaseUrl,
+                  deps.noteCommentPostGateway,
                 );
                 logger.info(
                   { ...contextActionResult, threadResolveCount, mrNumber: j.mrNumber },
@@ -625,7 +626,8 @@ export async function handleGitLabWebhook(
                       localPath: j.localPath,
                     },
                     logger,
-                    defaultCommandExecutor
+                    defaultCommandExecutor,
+                    deps.noteCommentPostGateway
                   );
                   logger.info(
                     { ...actionResult, threadResolveCount, mrNumber: j.mrNumber },
@@ -863,6 +865,7 @@ type GitLabReviewProcessorDeps = Pick<GitLabWebhookDependencies,
   | 'diffStatsFetchGateway'
   | 'recordCompletion'
   | 'claudeInvokerDeps'
+  | 'noteCommentPostGateway'
 >;
 
 export function buildGitLabReviewProcessor(
@@ -964,6 +967,7 @@ export function buildGitLabReviewProcessor(
             logger,
             defaultCommandExecutor,
             reviewBaseUrl,
+            deps.noteCommentPostGateway,
           );
           logger.info(
             { ...contextActionResult, mrNumber: j.mrNumber },
@@ -987,7 +991,8 @@ export function buildGitLabReviewProcessor(
                 localPath: j.localPath,
               },
               logger,
-              defaultCommandExecutor
+              defaultCommandExecutor,
+              deps.noteCommentPostGateway
             );
             logger.info(
               { ...actionResult, mrNumber: j.mrNumber },

--- a/src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts
+++ b/src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts
@@ -5,6 +5,7 @@ import { gitLabMergeRequestEventGuard } from '@/modules/platform-integration/ent
 import { gitLabNoteEventGuard } from '@/modules/platform-integration/entities/gitlab/gitlabNoteEvent.guard.js';
 import { filterGitLabEvent, filterGitLabMrUpdate, filterGitLabMrClose, filterGitLabMrMerge, filterGitLabMrApprove, filterGitLabNoteEvent } from '@/modules/platform-integration/interface-adapters/controllers/webhook/eventFilter.js';
 import { findRepositoryByProjectPath, type RepositoryConfig } from '@/config/loader.js';
+import { resolvePinnedThreadFetchTarget } from '@/modules/platform-integration/services/pinnedThreadFetchTarget.js';
 import {
   enqueueReview,
   createJobId,
@@ -868,8 +869,26 @@ export function buildGitLabReviewProcessor(
       const threadFetchGw = deps.threadFetchGateway;
       const diffMetadataFetchGw = deps.diffMetadataFetchGateway;
 
+      const pinnedTarget = resolvePinnedThreadFetchTarget({
+        payloadProjectPath: j.projectPath,
+        payloadMrNumber: j.mrNumber,
+        findRepository: (projectPath) => {
+          const matched = findRepositoryByProjectPath(projectPath);
+          return matched ? { projectPath } : null;
+        },
+        gatedMrNumber: j.mrNumber,
+      });
+
       try {
-        const threads = threadFetchGw.fetchThreads(j.projectPath, j.mrNumber);
+        const threads = pinnedTarget
+          ? threadFetchGw.fetchThreads(pinnedTarget.projectPath, pinnedTarget.mrNumber)
+          : [];
+        if (!pinnedTarget) {
+          logger.warn(
+            { projectPath: j.projectPath, mrNumber: j.mrNumber },
+            'Thread-fetch target failed provenance pin; action surface is empty'
+          );
+        }
         let diffMetadata: import('@/modules/review-execution/entities/reviewContext/reviewContext.js').DiffMetadata | undefined;
         try {
           diffMetadata = diffMetadataFetchGw.fetchDiffMetadata(j.projectPath, j.mrNumber);

--- a/src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts
+++ b/src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts
@@ -16,6 +16,7 @@ import {
 import { invokeClaudeReview, sendNotification } from '@/claude/invoker.js';
 import type { ClaudeInvokerDependencies } from '@/frameworks/claude/claudeInvoker.js';
 import type { GateClaudeInvocationUseCase } from '@/modules/review-execution/usecases/gateClaudeInvocation.usecase.js';
+import type { IsTrustedActorUseCase } from '@/modules/platform-integration/usecases/isTrustedActor.usecase.js';
 import type { ProcessorBuilder } from '@/modules/review-execution/services/processorRegistry.js';
 import type { ReviewRequestTrackingGateway } from '@/modules/tracking/interface-adapters/gateways/reviewRequestTracking.gateway.js';
 import type { TrackAssignmentUseCase } from '@/modules/tracking/usecases/tracking/trackAssignment.usecase.js';
@@ -89,6 +90,7 @@ export interface GitLabWebhookDependencies {
   getRepositories: () => RepositoryConfig[];
   claudeInvokerDeps?: ClaudeInvokerDependencies;
   gateClaudeInvocation?: GateClaudeInvocationUseCase;
+  isTrustedActor?: IsTrustedActorUseCase;
   removeWorktree: RemoveWorktreeAction;
   recordBypass: RecordBypassUseCase;
   noteCommentPostGateway: NoteCommentPostGateway;
@@ -103,6 +105,23 @@ function listEnabledLocalPaths(getRepositories: () => RepositoryConfig[]): strin
   return getRepositories()
     .filter((repository) => repository.enabled)
     .map((repository) => repository.localPath);
+}
+
+/**
+ * Trigger-actor provenance gate (SPEC-197). Resolves whether the actor that
+ * triggered the webhook is a Developer+ member of the target project. When no
+ * resolver is wired the gate is a no-op (returns true) so existing behaviour is
+ * preserved; with a resolver present it is fail-closed (a thrown lookup -> false).
+ */
+async function resolveActorTrust(
+  deps: GitLabWebhookDependencies,
+  projectPath: string,
+  username: string,
+): Promise<boolean> {
+  if (!deps.isTrustedActor) {
+    return true;
+  }
+  return deps.isTrustedActor.execute({ username, projectPath });
 }
 
 async function handleGitLabNoteHook(
@@ -121,6 +140,22 @@ async function handleGitLabNoteHook(
   const filterResult = filterGitLabNoteEvent(parseResult.data);
   if (!filterResult.shouldProcess) {
     reply.status(200).send({ status: 'ignored', reason: filterResult.reason });
+    return;
+  }
+
+  // SPEC-197 AC3: gate the note trigger on actor provenance before any side effect.
+  // A non-trusted actor's note never reaches the bypass-processing path.
+  const noteActorTrusted = await resolveActorTrust(
+    deps,
+    filterResult.projectPath,
+    parseResult.data.user.username,
+  );
+  if (!noteActorTrusted) {
+    logger.info(
+      { projectPath: filterResult.projectPath, actor: parseResult.data.user.username },
+      'Note trigger from non-trusted actor parked (provenance gate)',
+    );
+    reply.status(202).send({ status: 'pending-confirmation', reason: 'untrusted-actor' });
     return;
   }
 
@@ -695,11 +730,19 @@ export async function handleGitLabWebhook(
             }
           };
 
+          // SPEC-197 AC2: gate the followup trigger on actor provenance.
+          const followupActorTrusted = await resolveActorTrust(
+            deps,
+            updateResult.projectPath,
+            event.user.username,
+          );
+
           if (deps.gateClaudeInvocation) {
             const gateResult = await deps.gateClaudeInvocation.execute({
               job: followupJob,
               triggerSource: 'webhook-followup',
               processor: followupProcessor,
+              actorTrusted: followupActorTrusted,
             });
             if (gateResult.status === 'pending') {
               reply.status(202).send({
@@ -709,8 +752,19 @@ export async function handleGitLabWebhook(
               });
               return;
             }
-          } else {
+          } else if (followupActorTrusted) {
             enqueueReview(followupJob, followupProcessor);
+          } else {
+            logger.info(
+              { mrNumber: updateResult.mergeRequestNumber, actor: event.user.username },
+              'Followup trigger from non-trusted actor parked (provenance gate)',
+            );
+            reply.status(202).send({
+              status: 'pending-confirmation',
+              reason: 'untrusted-actor',
+              mrNumber: updateResult.mergeRequestNumber,
+            });
+            return;
           }
 
           reply.status(202).send({
@@ -820,11 +874,19 @@ export async function handleGitLabWebhook(
 
   const reviewProcessor = buildGitLabReviewProcessor(deps, logger)(job);
 
+  // SPEC-197 AC1: gate the reviewer-added trigger on actor provenance.
+  const reviewerActorTrusted = await resolveActorTrust(
+    deps,
+    filterResult.projectPath,
+    event.user.username,
+  );
+
   if (deps.gateClaudeInvocation) {
     const gateResult = await deps.gateClaudeInvocation.execute({
       job,
       triggerSource: 'webhook-initial',
       processor: reviewProcessor,
+      actorTrusted: reviewerActorTrusted,
     });
     if (gateResult.status === 'pending') {
       reply.status(202).send({
@@ -846,6 +908,19 @@ export async function handleGitLabWebhook(
       status: 'deduplicated',
       jobId,
       reason: 'Review already in progress or recently completed',
+    });
+    return;
+  }
+
+  if (!reviewerActorTrusted) {
+    logger.info(
+      { mrNumber: filterResult.mergeRequestNumber, actor: event.user.username },
+      'Reviewer-added trigger from non-trusted actor parked (provenance gate)',
+    );
+    reply.status(202).send({
+      status: 'pending-confirmation',
+      reason: 'untrusted-actor',
+      mrNumber: filterResult.mergeRequestNumber,
     });
     return;
   }

--- a/src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts
+++ b/src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts
@@ -1,6 +1,6 @@
 import type { FastifyRequest, FastifyReply } from 'fastify';
 import type { Logger } from 'pino';
-import { verifyGitLabSignature, getGitLabEventType } from '@/security/verifier.js';
+import { verifyGitLabSignature, getGitLabEventType, getGitLabEventUuid } from '@/security/verifier.js';
 import { gitLabMergeRequestEventGuard } from '@/modules/platform-integration/entities/gitlab/gitlabMergeRequestEvent.guard.js';
 import { gitLabNoteEventGuard } from '@/modules/platform-integration/entities/gitlab/gitlabNoteEvent.guard.js';
 import { filterGitLabEvent, filterGitLabMrUpdate, filterGitLabMrClose, filterGitLabMrMerge, filterGitLabMrApprove, filterGitLabNoteEvent } from '@/modules/platform-integration/interface-adapters/controllers/webhook/eventFilter.js';
@@ -25,6 +25,7 @@ import type { CheckFollowupNeededUseCase } from '@/modules/tracking/usecases/tra
 import type { SyncThreadsUseCase } from '@/modules/tracking/usecases/tracking/syncThreads.usecase.js';
 import type { RecordBypassUseCase } from '@/modules/tracking/usecases/tracking/recordBypass.usecase.js';
 import type { HandlePlatformApprovalUseCase } from '@/modules/tracking/usecases/tracking/handlePlatformApproval.usecase.js';
+import type { IdempotencyStore } from '@/modules/platform-integration/entities/idempotency/idempotencyStore.gateway.js';
 import type { NoteCommentPostGateway } from '@/modules/platform-integration/entities/noteComment/noteCommentPost.gateway.js';
 import type { ApprovalRevocationGateway } from '@/modules/platform-integration/entities/approvalRevocation/approvalRevocation.gateway.js';
 import { evaluateQualityGate } from '@/modules/tracking/entities/qualityGate/qualityGate.js';
@@ -88,6 +89,7 @@ export interface GitLabWebhookDependencies {
   noteCommentPostGateway: NoteCommentPostGateway;
   handlePlatformApproval: HandlePlatformApprovalUseCase;
   approvalRevocationGateway: ApprovalRevocationGateway;
+  idempotencyStore?: IdempotencyStore;
   getQualityThreshold: (projectPath: string) => number | null;
   now: () => string;
 }
@@ -175,6 +177,23 @@ export async function handleGitLabWebhook(
     logger.warn({ error: verification.error }, 'GitLab signature verification failed');
     reply.status(401).send({ error: verification.error });
     return;
+  }
+
+  // 1a. Idempotency guard: at most once per event UUID within the TTL window.
+  // Runs right after auth and before any side effect. A missing UUID degrades
+  // to the normal (gated) pipeline rather than being rejected.
+  if (deps.idempotencyStore) {
+    const eventUuid = getGitLabEventUuid(request);
+    if (eventUuid !== undefined) {
+      const accepted = await deps.idempotencyStore.recordIfAbsent(eventUuid);
+      if (!accepted) {
+        logger.info({ eventUuid }, 'Duplicate GitLab event UUID, no-op');
+        reply.status(200).send({ status: 'ignored', reason: 'Duplicate event' });
+        return;
+      }
+    } else {
+      logger.debug('GitLab event without UUID, proceeding without deduplication');
+    }
   }
 
   // 2. Check event type

--- a/src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts
+++ b/src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts
@@ -33,7 +33,11 @@ import { DEFAULT_AGENTS, DEFAULT_FOLLOWUP_AGENTS } from '@/modules/review-execut
 import { parseReviewOutput } from '@/modules/statistics-insights/services/statsService.js';
 import { ReviewContextResultFactory } from '@/modules/review-execution/entities/reviewContext/reviewContextResult.factory.js';
 import { parseThreadActions } from '@/modules/review-execution/services/threadActionsParser.js';
-import { executeThreadActions, defaultCommandExecutor } from '@/modules/review-execution/services/threadActionsExecutor.js';
+import { defaultCommandExecutor } from '@/modules/review-execution/services/threadActionsExecutor.js';
+import { dispatchConstrainedActions } from '@/modules/review-execution/services/dispatchConstrainedActions.js';
+import { resolveProvenance } from '@/modules/review-execution/entities/actionProvenance/actionProvenance.js';
+import { GitLabThreadInventoryGateway } from '@/modules/review-execution/interface-adapters/gateways/threadInventory.gitlab.gateway.js';
+import { defaultGitLabExecutor } from '@/modules/platform-integration/interface-adapters/gateways/threadFetch.gitlab.gateway.js';
 import { executeActionsFromContext } from '@/modules/review-execution/services/contextActionsExecutor.js';
 import { startWatchingReviewContext, stopWatchingReviewContext } from '@/main/websocket.js';
 import type { ReviewContextGateway } from '@/modules/review-execution/entities/reviewContext/reviewContext.gateway.js';
@@ -597,16 +601,20 @@ export async function handleGitLabWebhook(
                 const threadActions = parseThreadActions(result.stdout);
                 if (threadActions.length > 0) {
                   threadResolveCount = threadActions.filter(a => a.type === 'THREAD_RESOLVE').length;
-                  const actionResult = await executeThreadActions(
+                  const actionResult = await dispatchConstrainedActions(
                     threadActions,
                     {
-                      platform: 'gitlab',
-                      projectPath: j.projectPath,
-                      mrNumber: j.mrNumber,
-                      localPath: j.localPath,
-                    },
-                    logger,
-                    defaultCommandExecutor
+                      context: {
+                        platform: 'gitlab',
+                        projectPath: j.projectPath,
+                        mrNumber: j.mrNumber,
+                        localPath: j.localPath,
+                      },
+                      provenance: resolveProvenance(null),
+                      inventoryGateway: new GitLabThreadInventoryGateway(defaultGitLabExecutor),
+                      logger,
+                      executor: defaultCommandExecutor,
+                    }
                   );
                   logger.info(
                     { ...actionResult, threadResolveCount, mrNumber: j.mrNumber },
@@ -959,16 +967,20 @@ export function buildGitLabReviewProcessor(
           // FALLBACK: Execute thread actions from stdout markers (backward compatibility)
           const threadActions = parseThreadActions(result.stdout);
           if (threadActions.length > 0) {
-            const actionResult = await executeThreadActions(
+            const actionResult = await dispatchConstrainedActions(
               threadActions,
               {
-                platform: 'gitlab',
-                projectPath: j.projectPath,
-                mrNumber: j.mrNumber,
-                localPath: j.localPath,
-              },
-              logger,
-              defaultCommandExecutor
+                context: {
+                  platform: 'gitlab',
+                  projectPath: j.projectPath,
+                  mrNumber: j.mrNumber,
+                  localPath: j.localPath,
+                },
+                provenance: resolveProvenance(null),
+                inventoryGateway: new GitLabThreadInventoryGateway(defaultGitLabExecutor),
+                logger,
+                executor: defaultCommandExecutor,
+              }
             );
             logger.info(
               { ...actionResult, mrNumber: j.mrNumber },

--- a/src/modules/platform-integration/interface-adapters/controllers/webhook/transportGuard.middleware.ts
+++ b/src/modules/platform-integration/interface-adapters/controllers/webhook/transportGuard.middleware.ts
@@ -1,0 +1,59 @@
+import { evaluateTransport } from '@/modules/platform-integration/usecases/transport/evaluateTransport.usecase.js';
+import type { ClientIpResolver } from '@/modules/platform-integration/entities/transport/clientIpResolver.gateway.js';
+
+export interface TransportGuardConfig {
+  trustedHopAddress: string;
+  allowedCidrRanges: string[];
+}
+
+type HeaderValue = string | string[] | undefined;
+
+interface GuardRequest {
+  socket: { remoteAddress: string | undefined };
+  headers: Record<string, HeaderValue>;
+}
+
+interface GuardReply {
+  code(status: number): unknown;
+  send(): unknown;
+}
+
+export interface TransportGuardInput {
+  request: GuardRequest;
+  reply: GuardReply;
+  next: () => void;
+  resolver: ClientIpResolver;
+}
+
+function singleHeaderValue(value: HeaderValue): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+export function transportGuardMiddleware(
+  input: TransportGuardInput,
+  config: TransportGuardConfig,
+): void {
+  const directSocketAddress = input.request.socket.remoteAddress ?? '';
+  const socketTrusted = directSocketAddress === config.trustedHopAddress;
+
+  const resolvedClientIp = input.resolver.resolve({
+    socketTrusted,
+    forwardedFor: singleHeaderValue(input.request.headers['x-forwarded-for']),
+  });
+
+  const decision = evaluateTransport({
+    directSocketAddress,
+    trustedHopAddress: config.trustedHopAddress,
+    forwardedProto: singleHeaderValue(input.request.headers['x-forwarded-proto']),
+    resolvedClientIp,
+    allowedCidrRanges: config.allowedCidrRanges,
+  });
+
+  if (decision.kind === 'reject') {
+    input.reply.code(decision.status);
+    input.reply.send();
+    return;
+  }
+
+  input.next();
+}

--- a/src/modules/platform-integration/interface-adapters/gateways/egressScanned.noteCommentPost.gateway.ts
+++ b/src/modules/platform-integration/interface-adapters/gateways/egressScanned.noteCommentPost.gateway.ts
@@ -1,0 +1,42 @@
+import type {
+  NoteCommentPostGateway,
+  NoteCommentPostInput,
+} from '@/modules/platform-integration/entities/noteComment/noteCommentPost.gateway.js';
+import type { EgressScanGateway } from '@/modules/platform-integration/entities/egressScan/egressScan.gateway.js';
+import type { EgressTraceGateway } from '@/modules/platform-integration/entities/egressScan/egressTrace.gateway.js';
+
+export class EgressBlockedError extends Error {
+  constructor(channel: string) {
+    super(`Egress scan blocked output on channel ${channel}`);
+    this.name = 'EgressBlockedError';
+  }
+}
+
+export class EgressScannedNoteCommentPostGateway implements NoteCommentPostGateway {
+  constructor(
+    private readonly sink: NoteCommentPostGateway,
+    private readonly scanner: EgressScanGateway,
+    private readonly trace: EgressTraceGateway,
+  ) {}
+
+  async postComment(input: NoteCommentPostInput): Promise<void> {
+    const result = this.scanner.scan({
+      body: input.body,
+      channel: 'postComment',
+      projectPath: input.projectPath,
+    });
+
+    if (result.decision === 'block') {
+      this.trace.record(result.trace);
+      throw new EgressBlockedError(result.trace.channel);
+    }
+
+    if (result.decision === 'redact') {
+      this.trace.record(result.trace);
+      await this.sink.postComment({ ...input, body: result.body });
+      return;
+    }
+
+    await this.sink.postComment({ ...input, body: result.body });
+  }
+}

--- a/src/modules/platform-integration/interface-adapters/gateways/inMemoryIdempotencyStore.gateway.ts
+++ b/src/modules/platform-integration/interface-adapters/gateways/inMemoryIdempotencyStore.gateway.ts
@@ -1,0 +1,38 @@
+import type { IdempotencyStore } from '@/modules/platform-integration/entities/idempotency/idempotencyStore.gateway.js';
+
+export interface InMemoryIdempotencyStoreOptions {
+  ttlMs: number;
+  clock?: () => number;
+}
+
+export class InMemoryIdempotencyStore implements IdempotencyStore {
+  private readonly entries = new Map<string, number>();
+  private readonly ttlMs: number;
+  private readonly clock: () => number;
+
+  constructor(options: InMemoryIdempotencyStoreOptions) {
+    this.ttlMs = options.ttlMs;
+    this.clock = options.clock ?? (() => Date.now());
+  }
+
+  async recordIfAbsent(eventKey: string): Promise<boolean> {
+    const now = this.clock();
+    this.purgeExpired(now);
+
+    const existingExpiry = this.entries.get(eventKey);
+    if (existingExpiry !== undefined && existingExpiry > now) {
+      return false;
+    }
+
+    this.entries.set(eventKey, now + this.ttlMs);
+    return true;
+  }
+
+  private purgeExpired(now: number): void {
+    for (const [key, expiry] of this.entries) {
+      if (expiry <= now) {
+        this.entries.delete(key);
+      }
+    }
+  }
+}

--- a/src/modules/platform-integration/interface-adapters/gateways/loggerEgressTrace.gateway.ts
+++ b/src/modules/platform-integration/interface-adapters/gateways/loggerEgressTrace.gateway.ts
@@ -1,0 +1,18 @@
+import type { Logger } from 'pino';
+import type { EgressTraceGateway } from '@/modules/platform-integration/entities/egressScan/egressTrace.gateway.js';
+import type { EgressScanTrace } from '@/modules/platform-integration/entities/egressScan/egressScan.gateway.js';
+
+export class LoggerEgressTraceGateway implements EgressTraceGateway {
+  constructor(private readonly logger: Logger) {}
+
+  record(trace: EgressScanTrace): void {
+    this.logger.warn(
+      {
+        channel: trace.channel,
+        mode: trace.mode,
+        matchCategoryCounts: trace.matchCategoryCounts,
+      },
+      'egress scan decision',
+    );
+  }
+}

--- a/src/modules/platform-integration/interface-adapters/gateways/memberAccess.gitlab.cli.gateway.ts
+++ b/src/modules/platform-integration/interface-adapters/gateways/memberAccess.gitlab.cli.gateway.ts
@@ -1,0 +1,111 @@
+import { z } from 'zod';
+import type { MemberAccessGateway } from '@/modules/platform-integration/entities/memberAccess/memberAccess.gateway.js';
+import {
+  MEMBER_ACCESS_LEVELS,
+  type MemberAccessLevel,
+  type ResolvedAccessLevel,
+} from '@/modules/platform-integration/entities/memberAccess/memberAccess.js';
+
+export type CommandExecutor = (command: string) => string;
+
+export interface GitLabMemberAccessOptions {
+  ttlMs: number;
+  clock: () => number;
+}
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+
+const gitLabUserSchema = z.object({ id: z.number().int() });
+const gitLabUserListSchema = z.array(gitLabUserSchema);
+const gitLabMemberSchema = z.object({ access_level: z.number().int() });
+
+const KNOWN_ACCESS_LEVELS = new Set<number>(Object.values(MEMBER_ACCESS_LEVELS));
+
+interface CacheEntry {
+  accessLevel: ResolvedAccessLevel;
+  expiresAt: number;
+}
+
+function toKnownAccessLevel(value: number): MemberAccessLevel | null {
+  if (!KNOWN_ACCESS_LEVELS.has(value)) {
+    return null;
+  }
+  const known = Object.values(MEMBER_ACCESS_LEVELS).find((level) => level === value);
+  return known ?? null;
+}
+
+/**
+ * Cached, fail-closed GitLab membership resolver (SPEC-197).
+ *
+ * Resolves the actor's numeric id via the Users API (`/users?username=`) then the
+ * project membership via the Members API (`/projects/:id/members/all/:user_id`),
+ * both through the injected authenticated glab executor. Results are cached per
+ * username with a TTL. Every failure mode — lookup error, timeout, ambiguous match
+ * (more than one user), unknown username (empty list), non-member, or an
+ * access_level outside the known scale — resolves to `null` (non-trusted). The
+ * cache keys strictly on username, so a trusted result for one actor never widens
+ * trust for another (AC5).
+ */
+export class GitLabMemberAccessCliGateway implements MemberAccessGateway {
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly ttlMs: number;
+  private readonly clock: () => number;
+
+  constructor(
+    private readonly executor: CommandExecutor,
+    options?: Partial<GitLabMemberAccessOptions>,
+  ) {
+    this.ttlMs = options?.ttlMs ?? DEFAULT_TTL_MS;
+    this.clock = options?.clock ?? (() => Date.now());
+  }
+
+  async resolve(projectPath: string, username: string): Promise<ResolvedAccessLevel> {
+    const cacheKey = `${projectPath} ${username}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached && cached.expiresAt > this.clock()) {
+      return cached.accessLevel;
+    }
+
+    const accessLevel = this.lookup(projectPath, username);
+    this.cache.set(cacheKey, { accessLevel, expiresAt: this.clock() + this.ttlMs });
+    return accessLevel;
+  }
+
+  private lookup(projectPath: string, username: string): ResolvedAccessLevel {
+    const userId = this.resolveUserId(username);
+    if (userId === null) {
+      return null;
+    }
+    return this.resolveMembership(projectPath, userId);
+  }
+
+  private resolveUserId(username: string): number | null {
+    try {
+      const encodedUsername = encodeURIComponent(username);
+      const response = this.executor(`glab api users?username=${encodedUsername}`);
+      const parsed = gitLabUserListSchema.safeParse(JSON.parse(response));
+      if (!parsed.success || parsed.data.length !== 1) {
+        return null;
+      }
+      return parsed.data[0].id;
+    } catch {
+      return null;
+    }
+  }
+
+  private resolveMembership(projectPath: string, userId: number): ResolvedAccessLevel {
+    try {
+      const encodedProject = projectPath.replace(/\//g, '%2F');
+      const response = this.executor(
+        `glab api projects/${encodedProject}/members/all/${userId}`,
+      );
+      const parsed = gitLabMemberSchema.safeParse(JSON.parse(response));
+      if (!parsed.success) {
+        return null;
+      }
+      return toKnownAccessLevel(parsed.data.access_level);
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/modules/platform-integration/interface-adapters/gateways/scopedGitLabExecutor.ts
+++ b/src/modules/platform-integration/interface-adapters/gateways/scopedGitLabExecutor.ts
@@ -1,0 +1,39 @@
+import {
+  buildScopedExecutorEnvironment,
+  type ExecutorFileWriter,
+  type ScopedExecutorEnv,
+} from '@/modules/platform-integration/services/scopedExecutorEnvironment.js'
+import type { CommandExecutor } from '@/modules/platform-integration/interface-adapters/gateways/threadFetch.gitlab.gateway.js'
+
+export type ScopedSpawn = (
+  command: string,
+  env: ScopedExecutorEnv,
+  cwd: string,
+) => string
+
+export interface CreateScopedGitLabExecutorInput {
+  parentEnv: Record<string, string | undefined>
+  isolatedDir: string
+  fileWriter: ExecutorFileWriter
+  spawn: ScopedSpawn
+}
+
+/**
+ * Builds a CommandExecutor whose GitLab credential is a dedicated service token (AC1,
+ * fail-closed at construction), whose process env is an allowlist with the token never
+ * present (AC2/AC3), and which runs against an isolated HOME/GLAB_CONFIG_DIR holding the
+ * token in its own glab config file (AC4). Never inherits the ambient admin token.
+ */
+export function createScopedGitLabExecutor(
+  input: CreateScopedGitLabExecutorInput,
+): CommandExecutor {
+  const { env } = buildScopedExecutorEnvironment({
+    parentEnv: input.parentEnv,
+    isolatedDir: input.isolatedDir,
+    fileWriter: input.fileWriter,
+  })
+
+  const cwd = env.HOME ?? input.isolatedDir
+
+  return (command: string): string => input.spawn(command, env, cwd)
+}

--- a/src/modules/platform-integration/interface-adapters/gateways/threadFetch.gitlab.gateway.ts
+++ b/src/modules/platform-integration/interface-adapters/gateways/threadFetch.gitlab.gateway.ts
@@ -1,11 +1,43 @@
 import { execSync } from 'node:child_process'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { tmpdir } from 'node:os'
 import type { ThreadFetchGateway } from '@/modules/platform-integration/entities/threadFetch/threadFetch.gateway.js'
 import type { ReviewContextThread } from '@/modules/review-execution/entities/reviewContext/reviewContext.js'
+import { createScopedGitLabExecutor } from '@/modules/platform-integration/interface-adapters/gateways/scopedGitLabExecutor.js'
+import type { ExecutorFileWriter, ScopedExecutorEnv } from '@/modules/platform-integration/services/scopedExecutorEnvironment.js'
 
 export type CommandExecutor = (command: string) => string
 
-export const defaultGitLabExecutor: CommandExecutor = (command: string) => {
-  return execSync(command, { encoding: 'utf-8', timeout: 30000 })
+const realFileWriter: ExecutorFileWriter = {
+  write(path: string, contents: string): void {
+    mkdirSync(dirname(path), { recursive: true })
+    writeFileSync(path, contents, { mode: 0o600 })
+  },
+}
+
+const scopedSpawn = (command: string, env: ScopedExecutorEnv, cwd: string): string =>
+  execSync(command, { encoding: 'utf-8', timeout: 30000, env, cwd })
+
+let scopedExecutor: CommandExecutor | null = null
+
+/**
+ * Fail-closed scoped GitLab executor (SPEC-196 AC1-AC4). Built lazily on first use so the
+ * dedicated service token is read at construction time; if absent it throws and no job is
+ * started. The token never enters the child env (AC3); it lives in an isolated glab config
+ * file under a per-process HOME/GLAB_CONFIG_DIR (AC4). Never inherits the ambient admin token.
+ */
+export const defaultGitLabExecutor: CommandExecutor = (command: string): string => {
+  if (scopedExecutor === null) {
+    const isolatedDir = `${tmpdir()}/reviewflow-executor-${process.pid}`
+    scopedExecutor = createScopedGitLabExecutor({
+      parentEnv: process.env,
+      isolatedDir,
+      fileWriter: realFileWriter,
+      spawn: scopedSpawn,
+    })
+  }
+  return scopedExecutor(command)
 }
 
 interface GitLabNotePosition {

--- a/src/modules/platform-integration/interface-adapters/gateways/transport/clientIpResolver.forwardedFor.gateway.ts
+++ b/src/modules/platform-integration/interface-adapters/gateways/transport/clientIpResolver.forwardedFor.gateway.ts
@@ -1,0 +1,23 @@
+import type {
+  ClientIpResolutionInput,
+  ClientIpResolver,
+} from '@/modules/platform-integration/entities/transport/clientIpResolver.gateway.js';
+
+export class ForwardedForClientIpResolver implements ClientIpResolver {
+  resolve(input: ClientIpResolutionInput): string | null {
+    if (!input.socketTrusted) {
+      return null;
+    }
+
+    if (input.forwardedFor === null) {
+      return null;
+    }
+
+    const leftmost = input.forwardedFor.split(',')[0]?.trim();
+    if (!leftmost) {
+      return null;
+    }
+
+    return leftmost;
+  }
+}

--- a/src/modules/platform-integration/services/autoExecutorActionFilter.ts
+++ b/src/modules/platform-integration/services/autoExecutorActionFilter.ts
@@ -1,0 +1,46 @@
+import type { ReviewAction } from '@/modules/review-execution/entities/reviewAction/reviewAction.js'
+import { AUTO_EXECUTOR_CAPABILITIES } from '@/modules/platform-integration/entities/executorToken/executorCapability.js'
+
+export type ActionCapability = 'readMr' | 'postComment' | 'threadResolve' | 'revoke' | 'addLabel'
+
+export function capabilityForAction(action: ReviewAction): ActionCapability {
+  switch (action.type) {
+    case 'FETCH_THREADS':
+      return 'readMr'
+    case 'POST_COMMENT':
+    case 'THREAD_REPLY':
+    case 'POST_INLINE_COMMENT':
+      return 'postComment'
+    case 'THREAD_RESOLVE':
+      return 'threadResolve'
+    case 'ADD_LABEL':
+      return 'addLabel'
+  }
+}
+
+export interface AutoExecutorActionFilterResult {
+  allowed: ReviewAction[]
+  dropped: ReviewAction[]
+}
+
+function isAutoCapability(capability: ActionCapability): boolean {
+  return (
+    (capability === 'readMr' || capability === 'postComment') &&
+    AUTO_EXECUTOR_CAPABILITIES.has(capability)
+  )
+}
+
+export function filterAutoExecutorActions(actions: ReviewAction[]): AutoExecutorActionFilterResult {
+  const allowed: ReviewAction[] = []
+  const dropped: ReviewAction[] = []
+
+  for (const action of actions) {
+    if (isAutoCapability(capabilityForAction(action))) {
+      allowed.push(action)
+    } else {
+      dropped.push(action)
+    }
+  }
+
+  return { allowed, dropped }
+}

--- a/src/modules/platform-integration/services/pinnedThreadFetchTarget.ts
+++ b/src/modules/platform-integration/services/pinnedThreadFetchTarget.ts
@@ -1,0 +1,40 @@
+export interface PinnedThreadFetchTarget {
+  projectPath: string
+  mrNumber: number
+}
+
+interface ResolvedRepository {
+  projectPath: string
+}
+
+export interface ResolvePinnedThreadFetchTargetInput {
+  payloadProjectPath: string
+  payloadMrNumber: number
+  findRepository: (projectPath: string) => ResolvedRepository | null | undefined
+  gatedMrNumber: number | null
+}
+
+/**
+ * Anchors the (projectPath, mrNumber) pair driving fetchThreads to a server-validated
+ * source (AC9). The forgeable webhook payload is never used as-is to widen scope:
+ * - projectPath MUST resolve to a configured repository.
+ * - mrNumber MUST equal the merge-request that passed the upstream trusted-actor gate.
+ * If either cannot be established, the action surface is empty (null, fail-closed).
+ */
+export function resolvePinnedThreadFetchTarget(
+  input: ResolvePinnedThreadFetchTargetInput,
+): PinnedThreadFetchTarget | null {
+  const repository = input.findRepository(input.payloadProjectPath)
+  if (!repository) {
+    return null
+  }
+
+  if (input.gatedMrNumber === null || input.payloadMrNumber !== input.gatedMrNumber) {
+    return null
+  }
+
+  return {
+    projectPath: repository.projectPath,
+    mrNumber: input.gatedMrNumber,
+  }
+}

--- a/src/modules/platform-integration/services/scopedExecutorEnvironment.ts
+++ b/src/modules/platform-integration/services/scopedExecutorEnvironment.ts
@@ -1,0 +1,69 @@
+export const EXECUTOR_TOKEN_ENV_KEY = 'REVIEWFLOW_EXECUTOR_TOKEN'
+
+export const ENV_ALLOWLIST = ['PATH', 'HOME', 'GLAB_CONFIG_DIR', 'LANG'] as const
+
+export type AllowlistedEnvKey = (typeof ENV_ALLOWLIST)[number]
+
+export type ScopedExecutorEnv = Partial<Record<AllowlistedEnvKey, string>>
+
+export class MissingExecutorTokenError extends Error {
+  constructor() {
+    super(
+      `Executor service token (${EXECUTOR_TOKEN_ENV_KEY}) is absent or empty; refusing to start with the ambient token.`,
+    )
+    this.name = 'MissingExecutorTokenError'
+  }
+}
+
+export interface ExecutorFileWriter {
+  write(path: string, contents: string): void
+}
+
+export interface BuildScopedExecutorEnvironmentInput {
+  parentEnv: Record<string, string | undefined>
+  isolatedDir: string
+  fileWriter: ExecutorFileWriter
+}
+
+export interface ScopedExecutorEnvironment {
+  env: ScopedExecutorEnv
+  configFilePath: string
+}
+
+function renderGlabConfig(token: string): string {
+  return [
+    'hosts:',
+    '  gitlab.com:',
+    `    token: ${token}`,
+    '    api_protocol: https',
+    '',
+  ].join('\n')
+}
+
+export function buildScopedExecutorEnvironment(
+  input: BuildScopedExecutorEnvironmentInput,
+): ScopedExecutorEnvironment {
+  const token = input.parentEnv[EXECUTOR_TOKEN_ENV_KEY]?.trim()
+  if (!token) {
+    throw new MissingExecutorTokenError()
+  }
+
+  const home = `${input.isolatedDir}/home`
+  const glabConfigDir = `${input.isolatedDir}/glab-config`
+
+  const env: ScopedExecutorEnv = {
+    HOME: home,
+    GLAB_CONFIG_DIR: glabConfigDir,
+  }
+
+  const path = input.parentEnv.PATH
+  if (path) env.PATH = path
+
+  const lang = input.parentEnv.LANG
+  if (lang) env.LANG = lang
+
+  const configFilePath = `${glabConfigDir}/glab-cli/config.yml`
+  input.fileWriter.write(configFilePath, renderGlabConfig(token))
+
+  return { env, configFilePath }
+}

--- a/src/modules/platform-integration/usecases/isTrustedActor.usecase.ts
+++ b/src/modules/platform-integration/usecases/isTrustedActor.usecase.ts
@@ -1,0 +1,26 @@
+import type { MemberAccessGateway } from '@/modules/platform-integration/entities/memberAccess/memberAccess.gateway.js';
+import { isDeveloperOrAbove } from '@/modules/platform-integration/entities/memberAccess/memberAccess.js';
+
+export interface IsTrustedActorInput {
+  username: string;
+  projectPath: string;
+}
+
+/**
+ * Decides whether the trigger actor is a trusted (Developer+) member of the target
+ * project (SPEC-197). Consumes the fail-closed MemberAccessGateway: any resolution
+ * failure or sub-Developer level collapses to non-trusted, so a thrown lookup never
+ * widens trust.
+ */
+export class IsTrustedActorUseCase {
+  constructor(private readonly memberAccessGateway: MemberAccessGateway) {}
+
+  async execute(input: IsTrustedActorInput): Promise<boolean> {
+    try {
+      const accessLevel = await this.memberAccessGateway.resolve(input.projectPath, input.username);
+      return isDeveloperOrAbove(accessLevel);
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/modules/platform-integration/usecases/transport/evaluateTransport.usecase.ts
+++ b/src/modules/platform-integration/usecases/transport/evaluateTransport.usecase.ts
@@ -1,0 +1,28 @@
+import type {
+  TransportContext,
+  TransportDecision,
+} from '@/modules/platform-integration/entities/transport/transportContext.js';
+import { isIpInCidr } from '@/modules/platform-integration/entities/transport/cidr.js';
+
+const REJECT_STATUS = 403;
+
+export function evaluateTransport(context: TransportContext): TransportDecision {
+  if (context.directSocketAddress !== context.trustedHopAddress) {
+    return { kind: 'reject', status: REJECT_STATUS, reason: 'untrusted-socket' };
+  }
+
+  if (context.forwardedProto !== 'https') {
+    return { kind: 'reject', status: REJECT_STATUS, reason: 'non-https' };
+  }
+
+  const clientIp = context.resolvedClientIp;
+  const allowed =
+    clientIp !== null &&
+    context.allowedCidrRanges.some((range) => isIpInCidr(clientIp, range));
+
+  if (!allowed) {
+    return { kind: 'reject', status: REJECT_STATUS, reason: 'off-allowlist' };
+  }
+
+  return { kind: 'accept' };
+}

--- a/src/modules/review-execution/entities/actionProvenance/actionProvenance.ts
+++ b/src/modules/review-execution/entities/actionProvenance/actionProvenance.ts
@@ -1,0 +1,13 @@
+export type Provenance = 'trusted' | 'untrusted'
+
+const CANONICAL_TRUSTED = 'trusted'
+
+/**
+ * Fail-closed provenance resolver.
+ * Only the exact canonical token resolves to `trusted`; every other value
+ * (including casing, padding, non-string types, null/undefined) is `untrusted`.
+ * `trusted` is NEVER derived from a payload field.
+ */
+export function resolveProvenance(value: unknown): Provenance {
+  return value === CANONICAL_TRUSTED ? 'trusted' : 'untrusted'
+}

--- a/src/modules/review-execution/entities/threadInventory/threadInventory.gateway.ts
+++ b/src/modules/review-execution/entities/threadInventory/threadInventory.gateway.ts
@@ -1,0 +1,13 @@
+export interface ThreadInventoryPage {
+  page: number
+  totalPages: number
+  threadIds: string[]
+}
+
+/**
+ * Authenticated, page-by-page access to the current MR's thread inventory.
+ * Each page carries its own `totalPages` so the resolver can prove completeness.
+ */
+export interface ThreadInventoryGateway {
+  fetchPage(projectPath: string, mergeRequestNumber: number, page: number): ThreadInventoryPage
+}

--- a/src/modules/review-execution/interface-adapters/gateways/threadInventory.gitlab.gateway.ts
+++ b/src/modules/review-execution/interface-adapters/gateways/threadInventory.gitlab.gateway.ts
@@ -1,0 +1,46 @@
+import type {
+  ThreadInventoryGateway,
+  ThreadInventoryPage,
+} from '@/modules/review-execution/entities/threadInventory/threadInventory.gateway.js'
+
+export type CommandExecutor = (command: string) => string
+
+interface GitLabDiscussion {
+  id: string
+}
+
+const HEADER_BODY_SEPARATOR = '\r\n\r\n'
+
+function parseTotalPages(headers: string): number {
+  const match = headers.match(/x-total-pages:\s*(\d+)/i)
+  return match ? Number.parseInt(match[1], 10) : 1
+}
+
+/**
+ * Authenticated GitLab Threads (discussions) inventory access.
+ *
+ * Issues `glab api -i` so the response carries the `X-Total-Pages` header used by the
+ * resolver to prove pagination completeness (complete-or-empty, fail-closed).
+ */
+export class GitLabThreadInventoryGateway implements ThreadInventoryGateway {
+  constructor(private readonly executor: CommandExecutor) {}
+
+  fetchPage(projectPath: string, mergeRequestNumber: number, page: number): ThreadInventoryPage {
+    const encodedProject = projectPath.replace(/\//g, '%2F')
+    const raw = this.executor(
+      `glab api -i "projects/${encodedProject}/merge_requests/${mergeRequestNumber}/discussions?page=${page}&per_page=100"`
+    )
+
+    const separatorIndex = raw.indexOf(HEADER_BODY_SEPARATOR)
+    const headers = separatorIndex === -1 ? '' : raw.slice(0, separatorIndex)
+    const body = separatorIndex === -1 ? raw : raw.slice(separatorIndex + HEADER_BODY_SEPARATOR.length)
+
+    const discussions: GitLabDiscussion[] = JSON.parse(body)
+
+    return {
+      page,
+      totalPages: parseTotalPages(headers),
+      threadIds: discussions.map(discussion => discussion.id),
+    }
+  }
+}

--- a/src/modules/review-execution/services/constrainActionSurface.ts
+++ b/src/modules/review-execution/services/constrainActionSurface.ts
@@ -1,0 +1,63 @@
+import type { ReviewAction } from '@/modules/review-execution/entities/reviewAction/reviewAction.js'
+import type { Provenance } from '@/modules/review-execution/entities/actionProvenance/actionProvenance.js'
+
+export interface ActionSurfaceConstraints {
+  provenance: Provenance
+  threadInventory: ReadonlySet<string>
+}
+
+/**
+ * Bounds the executable write surface derived from LLM output.
+ *
+ * - `POST_COMMENT` is always allowed (the only untrusted write verb).
+ * - `FETCH_THREADS` is allowed only for `trusted` provenance (read-amplification gate).
+ * - `THREAD_RESOLVE` / `THREAD_REPLY` require BOTH `trusted` provenance AND the (trimmed)
+ *   target id being a member of the authenticated MR thread inventory.
+ * - Any other verb is dropped.
+ *
+ * Membership is computed from the passed inventory only, never from token text.
+ */
+export function constrainActionSurface(
+  actions: ReviewAction[],
+  constraints: ActionSurfaceConstraints
+): ReviewAction[] {
+  const { provenance, threadInventory } = constraints
+  const isTrusted = provenance === 'trusted'
+
+  const constrained: ReviewAction[] = []
+
+  for (const action of actions) {
+    switch (action.type) {
+      case 'POST_COMMENT':
+        constrained.push(action)
+        break
+
+      case 'FETCH_THREADS':
+        if (isTrusted) constrained.push(action)
+        break
+
+      case 'THREAD_RESOLVE': {
+        if (!isTrusted) break
+        const target = action.threadId.trim()
+        if (threadInventory.has(target)) {
+          constrained.push({ ...action, threadId: target })
+        }
+        break
+      }
+
+      case 'THREAD_REPLY': {
+        if (!isTrusted) break
+        const target = action.threadId.trim()
+        if (threadInventory.has(target)) {
+          constrained.push({ ...action, threadId: target })
+        }
+        break
+      }
+
+      default:
+        break
+    }
+  }
+
+  return constrained
+}

--- a/src/modules/review-execution/services/contextActionsExecutor.ts
+++ b/src/modules/review-execution/services/contextActionsExecutor.ts
@@ -3,6 +3,8 @@ import type { ReviewAction } from '@/modules/review-execution/entities/reviewAct
 import { GitLabReviewActionCliGateway } from '@/modules/review-execution/interface-adapters/gateways/cli/reviewAction.gitlab.cli.gateway.js'
 import { GitHubReviewActionCliGateway } from '@/modules/review-execution/interface-adapters/gateways/cli/reviewAction.github.cli.gateway.js'
 import type { ExecutionResult, CommandExecutor } from '@/modules/review-execution/entities/reviewAction/reviewAction.gateway.js'
+import type { NoteCommentPostGateway } from '@/modules/platform-integration/entities/noteComment/noteCommentPost.gateway.js'
+import { executePublicOutput, isPublicOutputAction } from '@/modules/review-execution/services/publicOutputExecutor.js'
 
 /**
  * @deprecated Use ReviewContextAction from reviewAction entity instead
@@ -27,6 +29,7 @@ export async function executeActionsFromContext(
   _logger: Logger,
   executor: CommandExecutor,
   baseUrl: string | null = null,
+  postGateway: NoteCommentPostGateway | null = null,
 ): Promise<ExecutionResult> {
   const gatewayContext = {
     projectPath: context.projectPath,
@@ -41,5 +44,27 @@ export async function executeActionsFromContext(
       ? new GitLabReviewActionCliGateway(executor)
       : new GitHubReviewActionCliGateway(executor)
 
-  return gateway.execute(context.actions as ReviewAction[], gatewayContext)
+  const actions = context.actions as ReviewAction[]
+
+  if (postGateway === null) {
+    return gateway.execute(actions, gatewayContext)
+  }
+
+  const publicOutputActions = actions.filter(isPublicOutputAction)
+  const remainingActions = actions.filter(action => !isPublicOutputAction(action))
+
+  await executePublicOutput(
+    publicOutputActions,
+    { projectPath: context.projectPath, mrNumber: context.mergeRequestNumber },
+    postGateway,
+  )
+
+  const cliResult = await gateway.execute(remainingActions, gatewayContext)
+
+  return {
+    total: actions.length,
+    succeeded: cliResult.succeeded + publicOutputActions.length,
+    failed: cliResult.failed,
+    skipped: cliResult.skipped,
+  }
 }

--- a/src/modules/review-execution/services/contextActionsExecutor.ts
+++ b/src/modules/review-execution/services/contextActionsExecutor.ts
@@ -3,6 +3,7 @@ import type { ReviewAction } from '@/modules/review-execution/entities/reviewAct
 import { GitLabReviewActionCliGateway } from '@/modules/review-execution/interface-adapters/gateways/cli/reviewAction.gitlab.cli.gateway.js'
 import { GitHubReviewActionCliGateway } from '@/modules/review-execution/interface-adapters/gateways/cli/reviewAction.github.cli.gateway.js'
 import type { ExecutionResult, CommandExecutor } from '@/modules/review-execution/entities/reviewAction/reviewAction.gateway.js'
+import { filterAutoExecutorActions } from '@/modules/platform-integration/services/autoExecutorActionFilter.js'
 
 /**
  * @deprecated Use ReviewContextAction from reviewAction entity instead
@@ -24,7 +25,7 @@ interface Logger {
 export async function executeActionsFromContext(
   context: ReviewContext,
   localPath: string,
-  _logger: Logger,
+  logger: Logger,
   executor: CommandExecutor,
   baseUrl: string | null = null,
 ): Promise<ExecutionResult> {
@@ -36,10 +37,19 @@ export async function executeActionsFromContext(
     baseUrl,
   }
 
+  const { allowed, dropped } = filterAutoExecutorActions(context.actions as ReviewAction[])
+
+  if (dropped.length > 0) {
+    logger.warn(
+      { droppedTypes: dropped.map(action => action.type) },
+      'Auto executor dropped write-capable actions outside the read+postComment capability set',
+    )
+  }
+
   const gateway =
     context.platform === 'gitlab'
       ? new GitLabReviewActionCliGateway(executor)
       : new GitHubReviewActionCliGateway(executor)
 
-  return gateway.execute(context.actions as ReviewAction[], gatewayContext)
+  return gateway.execute(allowed, gatewayContext)
 }

--- a/src/modules/review-execution/services/dispatchConstrainedActions.ts
+++ b/src/modules/review-execution/services/dispatchConstrainedActions.ts
@@ -49,5 +49,7 @@ export async function dispatchConstrainedActions(
 
   const constrained = constrainActionSurface(actions, { provenance, threadInventory })
 
-  return executeThreadActions(constrained, context, logger, executor, postGateway)
+  return executeThreadActions(constrained, context, logger, executor, postGateway, {
+    skipAutoCapabilityFilter: true,
+  })
 }

--- a/src/modules/review-execution/services/dispatchConstrainedActions.ts
+++ b/src/modules/review-execution/services/dispatchConstrainedActions.ts
@@ -1,0 +1,50 @@
+import type { ReviewAction } from '@/modules/review-execution/entities/reviewAction/reviewAction.js'
+import type { Provenance } from '@/modules/review-execution/entities/actionProvenance/actionProvenance.js'
+import type { ThreadInventoryGateway } from '@/modules/review-execution/entities/threadInventory/threadInventory.gateway.js'
+import { constrainActionSurface } from '@/modules/review-execution/services/constrainActionSurface.js'
+import { resolveThreadInventory } from '@/modules/review-execution/services/resolveThreadInventory.js'
+import {
+  executeThreadActions,
+  type ExecutionContext,
+  type ExecutionResult,
+  type CommandExecutor,
+} from '@/modules/review-execution/services/threadActionsExecutor.js'
+
+interface DispatchLogger {
+  info: (obj: object, message: string) => void
+  warn: (obj: object, message: string) => void
+  error: (obj: object, message: string) => void
+  debug: (obj: object, message: string) => void
+}
+
+export interface DispatchOptions {
+  context: ExecutionContext
+  provenance: Provenance
+  inventoryGateway: ThreadInventoryGateway
+  logger: DispatchLogger
+  executor: CommandExecutor
+}
+
+/**
+ * Single chokepoint between parsed LLM actions and live write commands.
+ *
+ * Resolves the authenticated MR thread inventory (fail-closed), bounds the action
+ * surface against provenance + that inventory, then dispatches only the surviving
+ * actions to the executor. Forged or out-of-MR thread ids never reach a live write.
+ */
+export async function dispatchConstrainedActions(
+  actions: ReviewAction[],
+  options: DispatchOptions
+): Promise<ExecutionResult> {
+  const { context, provenance, inventoryGateway, logger, executor } = options
+
+  const threadInventory = resolveThreadInventory(
+    inventoryGateway,
+    { projectPath: context.projectPath, mrNumber: context.mrNumber },
+    logger
+  )
+
+  const constrained = constrainActionSurface(actions, { provenance, threadInventory })
+
+  return executeThreadActions(constrained, context, logger, executor)
+}

--- a/src/modules/review-execution/services/publicOutputExecutor.ts
+++ b/src/modules/review-execution/services/publicOutputExecutor.ts
@@ -19,6 +19,10 @@ function publicOutputBody(action: ReviewAction): string | null {
   }
 }
 
+export function isPublicOutputAction(action: ReviewAction): boolean {
+  return publicOutputBody(action) !== null;
+}
+
 export async function executePublicOutput(
   actions: PublicOutputAction[],
   context: PublicOutputContext,

--- a/src/modules/review-execution/services/publicOutputExecutor.ts
+++ b/src/modules/review-execution/services/publicOutputExecutor.ts
@@ -1,0 +1,38 @@
+import type { ReviewAction } from '@/modules/review-execution/entities/reviewAction/reviewAction.js';
+import type { NoteCommentPostGateway } from '@/modules/platform-integration/entities/noteComment/noteCommentPost.gateway.js';
+
+export type PublicOutputAction = ReviewAction;
+
+export interface PublicOutputContext {
+  projectPath: string;
+  mrNumber: number;
+}
+
+function publicOutputBody(action: ReviewAction): string | null {
+  switch (action.type) {
+    case 'POST_COMMENT':
+      return action.body;
+    case 'THREAD_REPLY':
+      return action.message;
+    default:
+      return null;
+  }
+}
+
+export async function executePublicOutput(
+  actions: PublicOutputAction[],
+  context: PublicOutputContext,
+  postGateway: NoteCommentPostGateway,
+): Promise<void> {
+  for (const action of actions) {
+    const body = publicOutputBody(action);
+    if (body === null) {
+      continue;
+    }
+    await postGateway.postComment({
+      projectPath: context.projectPath,
+      mrNumber: context.mrNumber,
+      body,
+    });
+  }
+}

--- a/src/modules/review-execution/services/resolveThreadInventory.ts
+++ b/src/modules/review-execution/services/resolveThreadInventory.ts
@@ -1,0 +1,64 @@
+import type { ThreadInventoryGateway } from '@/modules/review-execution/entities/threadInventory/threadInventory.gateway.js'
+
+export interface PinnedMergeRequest {
+  projectPath: string
+  mrNumber: number
+}
+
+interface InventoryLogger {
+  error: (obj: object, message: string) => void
+}
+
+const MAX_PAGES = 100
+
+/**
+ * Resolves the authenticated MR thread inventory, fail-closed.
+ *
+ * The inventory is built ONLY from the authenticated gateway, never from the
+ * inbound webhook payload. It is either provably complete (every advertised page
+ * followed) or provably empty. Any failure — fetch error, page-count mismatch,
+ * undelivered page — resolves to the empty set with no payload/partial fallback.
+ */
+export function resolveThreadInventory(
+  gateway: ThreadInventoryGateway,
+  pinned: PinnedMergeRequest,
+  logger: InventoryLogger
+): ReadonlySet<string> {
+  try {
+    const first = gateway.fetchPage(pinned.projectPath, pinned.mrNumber, 1)
+    const totalPages = first.totalPages
+    const ids = new Set<string>(first.threadIds)
+
+    if (totalPages < 1 || totalPages > MAX_PAGES) {
+      logger.error(
+        { projectPath: pinned.projectPath, mrNumber: pinned.mrNumber, totalPages },
+        'thread inventory: implausible page count, failing closed to empty inventory'
+      )
+      return new Set<string>()
+    }
+
+    for (let page = 2; page <= totalPages; page++) {
+      const next = gateway.fetchPage(pinned.projectPath, pinned.mrNumber, page)
+      if (next.totalPages !== totalPages) {
+        logger.error(
+          { projectPath: pinned.projectPath, mrNumber: pinned.mrNumber, page },
+          'thread inventory: page-count mismatch, failing closed to empty inventory'
+        )
+        return new Set<string>()
+      }
+      for (const id of next.threadIds) ids.add(id)
+    }
+
+    return ids
+  } catch (error) {
+    logger.error(
+      {
+        projectPath: pinned.projectPath,
+        mrNumber: pinned.mrNumber,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      'thread inventory: fetch failed, failing closed to empty inventory'
+    )
+    return new Set<string>()
+  }
+}

--- a/src/modules/review-execution/services/threadActionsExecutor.ts
+++ b/src/modules/review-execution/services/threadActionsExecutor.ts
@@ -24,6 +24,16 @@ export interface ExecutionContext {
 
 export type { ExecutionResult, CommandExecutor }
 
+export interface ExecuteThreadActionsOptions {
+  /**
+   * Skip the auto-path capability filter (SPEC-196). Set by the constrained
+   * dispatch chokepoint (SPEC-198), where provenance + authenticated-inventory
+   * validation has already bounded the surface and must NOT be re-narrowed by
+   * the auto-path read+postComment gate.
+   */
+  skipAutoCapabilityFilter?: boolean
+}
+
 interface Logger {
   info: (obj: object, msg: string) => void
   warn: (obj: object, msg: string) => void
@@ -39,7 +49,8 @@ export async function executeThreadActions(
   context: ExecutionContext,
   logger: Logger,
   executor: CommandExecutor,
-  postGateway: NoteCommentPostGateway | null = null
+  postGateway: NoteCommentPostGateway | null = null,
+  options: ExecuteThreadActionsOptions = {}
 ): Promise<ExecutionResult> {
   const gatewayContext: GatewayExecutionContext = {
     projectPath: context.projectPath,
@@ -49,13 +60,16 @@ export async function executeThreadActions(
     baseUrl: null,
   }
 
-  const { allowed, dropped } = filterAutoExecutorActions(actions)
-
-  if (dropped.length > 0) {
-    logger.warn(
-      { droppedTypes: dropped.map(action => action.type) },
-      'Auto executor dropped write-capable actions outside the read+postComment capability set',
-    )
+  let effectiveActions = actions
+  if (!options.skipAutoCapabilityFilter) {
+    const { allowed, dropped } = filterAutoExecutorActions(actions)
+    if (dropped.length > 0) {
+      logger.warn(
+        { droppedTypes: dropped.map(action => action.type) },
+        'Auto executor dropped write-capable actions outside the read+postComment capability set',
+      )
+    }
+    effectiveActions = allowed
   }
 
   const gateway =
@@ -64,11 +78,11 @@ export async function executeThreadActions(
       : new GitHubReviewActionCliGateway(executor)
 
   if (postGateway === null) {
-    return gateway.execute(allowed, gatewayContext)
+    return gateway.execute(effectiveActions, gatewayContext)
   }
 
-  const publicOutputActions = allowed.filter(isPublicOutputAction)
-  const remainingActions = allowed.filter(action => !isPublicOutputAction(action))
+  const publicOutputActions = effectiveActions.filter(isPublicOutputAction)
+  const remainingActions = effectiveActions.filter(action => !isPublicOutputAction(action))
 
   await executePublicOutput(
     publicOutputActions,
@@ -79,7 +93,7 @@ export async function executeThreadActions(
   const cliResult = await gateway.execute(remainingActions, gatewayContext)
 
   return {
-    total: allowed.length,
+    total: effectiveActions.length,
     succeeded: cliResult.succeeded + publicOutputActions.length,
     failed: cliResult.failed,
     skipped: cliResult.skipped,

--- a/src/modules/review-execution/services/threadActionsExecutor.ts
+++ b/src/modules/review-execution/services/threadActionsExecutor.ts
@@ -3,6 +3,7 @@ import type { ReviewAction } from '@/modules/review-execution/entities/reviewAct
 import { GitLabReviewActionCliGateway } from '@/modules/review-execution/interface-adapters/gateways/cli/reviewAction.gitlab.cli.gateway.js'
 import { GitHubReviewActionCliGateway } from '@/modules/review-execution/interface-adapters/gateways/cli/reviewAction.github.cli.gateway.js'
 import type { ExecutionResult, CommandExecutor, ExecutionContext as GatewayExecutionContext } from '@/modules/review-execution/entities/reviewAction/reviewAction.gateway.js'
+import { filterAutoExecutorActions } from '@/modules/platform-integration/services/autoExecutorActionFilter.js'
 
 const COMMAND_TIMEOUT_MS = 30000
 
@@ -34,7 +35,7 @@ interface Logger {
 export async function executeThreadActions(
   actions: ThreadAction[],
   context: ExecutionContext,
-  _logger: Logger,
+  logger: Logger,
   executor: CommandExecutor
 ): Promise<ExecutionResult> {
   const gatewayContext: GatewayExecutionContext = {
@@ -45,12 +46,21 @@ export async function executeThreadActions(
     baseUrl: null,
   }
 
+  const { allowed, dropped } = filterAutoExecutorActions(actions)
+
+  if (dropped.length > 0) {
+    logger.warn(
+      { droppedTypes: dropped.map(action => action.type) },
+      'Auto executor dropped write-capable actions outside the read+postComment capability set',
+    )
+  }
+
   const gateway =
     context.platform === 'gitlab'
       ? new GitLabReviewActionCliGateway(executor)
       : new GitHubReviewActionCliGateway(executor)
 
-  return gateway.execute(actions, gatewayContext)
+  return gateway.execute(allowed, gatewayContext)
 }
 
 export const defaultCommandExecutor: CommandExecutor = (

--- a/src/modules/review-execution/services/threadActionsExecutor.ts
+++ b/src/modules/review-execution/services/threadActionsExecutor.ts
@@ -3,6 +3,8 @@ import type { ReviewAction } from '@/modules/review-execution/entities/reviewAct
 import { GitLabReviewActionCliGateway } from '@/modules/review-execution/interface-adapters/gateways/cli/reviewAction.gitlab.cli.gateway.js'
 import { GitHubReviewActionCliGateway } from '@/modules/review-execution/interface-adapters/gateways/cli/reviewAction.github.cli.gateway.js'
 import type { ExecutionResult, CommandExecutor, ExecutionContext as GatewayExecutionContext } from '@/modules/review-execution/entities/reviewAction/reviewAction.gateway.js'
+import type { NoteCommentPostGateway } from '@/modules/platform-integration/entities/noteComment/noteCommentPost.gateway.js'
+import { executePublicOutput, isPublicOutputAction } from '@/modules/review-execution/services/publicOutputExecutor.js'
 
 const COMMAND_TIMEOUT_MS = 30000
 
@@ -35,7 +37,8 @@ export async function executeThreadActions(
   actions: ThreadAction[],
   context: ExecutionContext,
   _logger: Logger,
-  executor: CommandExecutor
+  executor: CommandExecutor,
+  postGateway: NoteCommentPostGateway | null = null
 ): Promise<ExecutionResult> {
   const gatewayContext: GatewayExecutionContext = {
     projectPath: context.projectPath,
@@ -50,7 +53,27 @@ export async function executeThreadActions(
       ? new GitLabReviewActionCliGateway(executor)
       : new GitHubReviewActionCliGateway(executor)
 
-  return gateway.execute(actions, gatewayContext)
+  if (postGateway === null) {
+    return gateway.execute(actions, gatewayContext)
+  }
+
+  const publicOutputActions = actions.filter(isPublicOutputAction)
+  const remainingActions = actions.filter(action => !isPublicOutputAction(action))
+
+  await executePublicOutput(
+    publicOutputActions,
+    { projectPath: context.projectPath, mrNumber: context.mrNumber },
+    postGateway
+  )
+
+  const cliResult = await gateway.execute(remainingActions, gatewayContext)
+
+  return {
+    total: actions.length,
+    succeeded: cliResult.succeeded + publicOutputActions.length,
+    failed: cliResult.failed,
+    skipped: cliResult.skipped,
+  }
 }
 
 export const defaultCommandExecutor: CommandExecutor = (

--- a/src/modules/review-execution/usecases/gateClaudeInvocation.usecase.ts
+++ b/src/modules/review-execution/usecases/gateClaudeInvocation.usecase.ts
@@ -32,6 +32,12 @@ export interface GateClaudeInvocationInput {
   job: ReviewJob;
   triggerSource: TriggerSource;
   processor: GateClaudeInvocationProcessor;
+  /**
+   * Trigger-actor provenance verdict (SPEC-197). When explicitly `false` the job
+   * is parked pending regardless of triggerMode: a non-trusted actor never
+   * auto-runs. `undefined`/`true` preserves the existing triggerMode behaviour.
+   */
+  actorTrusted?: boolean;
 }
 
 export type GateClaudeInvocationResult =
@@ -49,7 +55,9 @@ export class GateClaudeInvocationUseCase {
   async execute(input: GateClaudeInvocationInput): Promise<GateClaudeInvocationResult> {
     const { triggerMode, pendingReviewRequestGateway, enqueue, broadcastPendingChanged, logger } = this.deps;
 
-    if (triggerMode === 'full-auto') {
+    const actorParks = input.actorTrusted === false;
+
+    if (triggerMode === 'full-auto' && !actorParks) {
       const enqueued = await enqueue(input.job, input.processor);
       if (!enqueued) {
         logger.info({ jobId: input.job.id }, 'Job rejected by queue (deduplicated or already active)');

--- a/src/security/gitlabWebhookTokenSource.ts
+++ b/src/security/gitlabWebhookTokenSource.ts
@@ -1,0 +1,15 @@
+/**
+ * Reads the current GitLab webhook token from the process environment on every
+ * call so the secret can be rotated without redeploying or restarting the
+ * process: an operator updates GITLAB_WEBHOOK_TOKEN (and the GitLab webhook
+ * secret), and the next verification already uses the new value.
+ */
+export function currentGitlabWebhookToken(): string | null {
+  const token = process.env.GITLAB_WEBHOOK_TOKEN;
+  return typeof token === 'string' && token.length > 0 ? token : null;
+}
+
+export function __resetGitlabTokenCacheForTests(): void {
+  // No cache is kept; the token is read fresh on every call. This hook exists
+  // so rotation tests document the no-capture contract explicitly.
+}

--- a/src/security/transportGuardConfig.ts
+++ b/src/security/transportGuardConfig.ts
@@ -1,0 +1,44 @@
+import type { TransportGuardConfig } from '@/modules/platform-integration/interface-adapters/controllers/webhook/transportGuard.middleware.js';
+
+export const DEFAULT_LOOPBACK_HOP = '127.0.0.1';
+
+function parseCidrRanges(raw: string | undefined): string[] {
+  if (!raw) {
+    return [];
+  }
+  return raw
+    .split(',')
+    .map((range) => range.trim())
+    .filter((range) => range.length > 0);
+}
+
+/**
+ * The single trusted hop the app accepts connections from. Scoped to the
+ * loopback reverse proxy only; never a broad subnet, never `true`.
+ */
+export function resolveTrustedHopAddress(): string {
+  const configured = process.env.WEBHOOK_TRUSTED_HOP;
+  return typeof configured === 'string' && configured.length > 0
+    ? configured
+    : DEFAULT_LOOPBACK_HOP;
+}
+
+export function resolveAllowedCidrRanges(): string[] {
+  return parseCidrRanges(process.env.WEBHOOK_ALLOWED_CIDR_RANGES);
+}
+
+export function resolveTransportGuardConfig(): TransportGuardConfig {
+  return {
+    trustedHopAddress: resolveTrustedHopAddress(),
+    allowedCidrRanges: resolveAllowedCidrRanges(),
+  };
+}
+
+/**
+ * The value handed to Fastify's `trustProxy` option. It is always the single
+ * loopback hop, never `true` and never an arbitrary/broad value, so Express-style
+ * derived request attributes cannot be inflated from client-supplied headers.
+ */
+export function transportTrustProxyValue(): string {
+  return resolveTrustedHopAddress();
+}

--- a/src/security/verifier.ts
+++ b/src/security/verifier.ts
@@ -1,15 +1,30 @@
-import { createHmac, timingSafeEqual } from 'node:crypto';
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
 import type { FastifyRequest } from 'fastify';
 import { loadEnvSecrets } from '@/config/loader.js';
+import { currentGitlabWebhookToken } from '@/security/gitlabWebhookTokenSource.js';
 
 export interface VerificationResult {
   valid: boolean;
   error?: string;
 }
 
+// Per-process random key used only to fold both candidate and expected tokens
+// into fixed-length digests before comparison. It never leaves the process and
+// is not a secret in the trust model; its sole purpose is to make timingSafeEqual
+// operate on equal-length inputs so no length-based oracle precedes the compare.
+const comparisonKey = randomBytes(32);
+
+function constantTimeStringEqual(candidate: string, expected: string): boolean {
+  const candidateDigest = createHmac('sha256', comparisonKey).update(candidate).digest();
+  const expectedDigest = createHmac('sha256', comparisonKey).update(expected).digest();
+  return timingSafeEqual(candidateDigest, expectedDigest);
+}
+
 /**
- * Verify GitLab webhook signature
- * GitLab uses a simple secret token sent in the X-Gitlab-Token header
+ * Verify GitLab webhook signature.
+ * GitLab uses a simple secret token sent in the X-Gitlab-Token header.
+ * The expected token is read from the current configuration on every call so it
+ * can be rotated without restarting the process (see gitlabWebhookTokenSource).
  */
 export function verifyGitLabSignature(request: FastifyRequest): VerificationResult {
   const token = request.headers['x-gitlab-token'];
@@ -18,18 +33,12 @@ export function verifyGitLabSignature(request: FastifyRequest): VerificationResu
     return { valid: false, error: 'Header X-Gitlab-Token manquant' };
   }
 
-  const secrets = loadEnvSecrets();
-  const expectedToken = secrets.gitlabWebhookToken;
-
-  // Use timing-safe comparison to prevent timing attacks
-  const tokenBuffer = Buffer.from(token);
-  const expectedBuffer = Buffer.from(expectedToken);
-
-  if (tokenBuffer.length !== expectedBuffer.length) {
+  const expectedToken = currentGitlabWebhookToken();
+  if (expectedToken === null) {
     return { valid: false, error: 'Token invalide' };
   }
 
-  if (!timingSafeEqual(tokenBuffer, expectedBuffer)) {
+  if (!constantTimeStringEqual(token, expectedToken)) {
     return { valid: false, error: 'Token invalide' };
   }
 

--- a/src/security/verifier.ts
+++ b/src/security/verifier.ts
@@ -84,6 +84,15 @@ export function getGitLabEventType(request: FastifyRequest): string | undefined 
   return typeof eventHeader === 'string' ? eventHeader : undefined;
 }
 
+/**
+ * Extract the per-event delivery identifier from request headers.
+ * Symmetric to getGitLabEventType; reads X-Gitlab-Event-UUID.
+ */
+export function getGitLabEventUuid(request: FastifyRequest): string | undefined {
+  const uuidHeader = request.headers['x-gitlab-event-uuid'];
+  return typeof uuidHeader === 'string' ? uuidHeader : undefined;
+}
+
 export function getGitHubEventType(request: FastifyRequest): string | undefined {
   const eventHeader = request.headers['x-github-event'];
   return typeof eventHeader === 'string' ? eventHeader : undefined;

--- a/src/tests/factories/transportContext.factory.ts
+++ b/src/tests/factories/transportContext.factory.ts
@@ -1,0 +1,16 @@
+import type { TransportContext } from '@/modules/platform-integration/entities/transport/transportContext.js';
+
+const TRUSTED_HOP = '127.0.0.1';
+
+export class TransportContextFactory {
+  static valid(overrides: Partial<TransportContext> = {}): TransportContext {
+    return {
+      directSocketAddress: TRUSTED_HOP,
+      trustedHopAddress: TRUSTED_HOP,
+      forwardedProto: 'https',
+      resolvedClientIp: '10.20.30.40',
+      allowedCidrRanges: ['10.20.30.0/24'],
+      ...overrides,
+    };
+  }
+}

--- a/src/tests/stubs/egressScan.stub.ts
+++ b/src/tests/stubs/egressScan.stub.ts
@@ -1,0 +1,40 @@
+import type {
+  EgressScanGateway,
+  EgressScanInput,
+  EgressScanResult,
+} from '@/modules/platform-integration/entities/egressScan/egressScan.gateway.js';
+import type { EgressTraceGateway } from '@/modules/platform-integration/entities/egressScan/egressTrace.gateway.js';
+import type { EgressScanTrace } from '@/modules/platform-integration/entities/egressScan/egressScan.gateway.js';
+
+export class StubEgressScanGateway implements EgressScanGateway {
+  readonly calls: EgressScanInput[] = [];
+  private result: EgressScanResult | null = null;
+  private shouldFail = false;
+
+  setResult(result: EgressScanResult): void {
+    this.result = result;
+  }
+
+  setShouldFail(shouldFail: boolean): void {
+    this.shouldFail = shouldFail;
+  }
+
+  scan(input: EgressScanInput): EgressScanResult {
+    this.calls.push(input);
+    if (this.shouldFail) {
+      throw new Error('scanner failure');
+    }
+    if (this.result === null) {
+      return { decision: 'pass', body: input.body };
+    }
+    return this.result;
+  }
+}
+
+export class StubEgressTraceGateway implements EgressTraceGateway {
+  readonly traces: EgressScanTrace[] = [];
+
+  record(trace: EgressScanTrace): void {
+    this.traces.push(trace);
+  }
+}

--- a/src/tests/stubs/idempotencyStore.stub.ts
+++ b/src/tests/stubs/idempotencyStore.stub.ts
@@ -1,0 +1,23 @@
+import type { IdempotencyStore } from '@/modules/platform-integration/entities/idempotency/idempotencyStore.gateway.js';
+
+export class StubIdempotencyStore implements IdempotencyStore {
+  readonly recordedKeys: string[] = [];
+  private readonly present = new Set<string>();
+
+  async recordIfAbsent(eventKey: string): Promise<boolean> {
+    this.recordedKeys.push(eventKey);
+    if (this.present.has(eventKey)) {
+      return false;
+    }
+    this.present.add(eventKey);
+    return true;
+  }
+
+  get entryCount(): number {
+    return this.present.size;
+  }
+
+  has(eventKey: string): boolean {
+    return this.present.has(eventKey);
+  }
+}

--- a/src/tests/stubs/memberAccess.stub.ts
+++ b/src/tests/stubs/memberAccess.stub.ts
@@ -1,0 +1,38 @@
+import type { MemberAccessGateway } from '@/modules/platform-integration/entities/memberAccess/memberAccess.gateway.js';
+import type { ResolvedAccessLevel } from '@/modules/platform-integration/entities/memberAccess/memberAccess.js';
+
+export interface MemberAccessResolveCall {
+  projectPath: string;
+  username: string;
+}
+
+/**
+ * Recording stub for MemberAccessGateway (Detroit style — no vi.fn).
+ *
+ * Returns a fixed access level per username via `setAccess`. Unknown usernames
+ * resolve fail-closed to `null`. `setShouldFail(true)` makes every resolve throw,
+ * exercising the fail-closed boundary (SPEC-197 AC4). All calls are recorded so
+ * tests can assert call counts and args (AC6: gateway never called when the token
+ * verifier rejects).
+ */
+export class StubMemberAccessGateway implements MemberAccessGateway {
+  public readonly calls: MemberAccessResolveCall[] = [];
+  private accessByUsername = new Map<string, ResolvedAccessLevel>();
+  private shouldFail = false;
+
+  setAccess(username: string, accessLevel: ResolvedAccessLevel): void {
+    this.accessByUsername.set(username, accessLevel);
+  }
+
+  setShouldFail(shouldFail: boolean): void {
+    this.shouldFail = shouldFail;
+  }
+
+  async resolve(projectPath: string, username: string): Promise<ResolvedAccessLevel> {
+    this.calls.push({ projectPath, username });
+    if (this.shouldFail) {
+      throw new Error('Membership lookup failed (stub)');
+    }
+    return this.accessByUsername.get(username) ?? null;
+  }
+}

--- a/src/tests/units/entities/egressScan/egressScan.scanner.test.ts
+++ b/src/tests/units/entities/egressScan/egressScan.scanner.test.ts
@@ -1,0 +1,168 @@
+import { createEgressScanner } from '@/modules/platform-integration/entities/egressScan/egressScan.scanner.js';
+import type { EgressScanConfig } from '@/modules/platform-integration/entities/egressScan/egressScan.scanner.js';
+
+const baseConfig: EgressScanConfig = {
+  secretShapeMode: 'redact',
+  lengthMode: 'redact',
+  outOfScopeMode: 'redact',
+  maxBodyLength: 100,
+  redactionMarker: '[REDACTED]',
+  truncationMarker: '…[TRUNCATED]',
+};
+
+const SECRET = 'glpat-abcdefghij1234567890';
+
+describe('createEgressScanner', () => {
+  describe('secret-shape scan (AC2)', () => {
+    it('passes a clean body unchanged in any mode', () => {
+      const scanner = createEgressScanner(baseConfig);
+
+      const result = scanner.scan({
+        body: 'Looks good to me, nicely done.',
+        channel: 'postComment',
+        projectPath: 'group/project',
+      });
+
+      expect(result.decision).toBe('pass');
+      if (result.decision === 'pass') {
+        expect(result.body).toBe('Looks good to me, nicely done.');
+      }
+    });
+
+    it('redacts a secret shape with the fixed marker in redact mode', () => {
+      const scanner = createEgressScanner(baseConfig);
+
+      const result = scanner.scan({
+        body: `token is ${SECRET} here`,
+        channel: 'postComment',
+        projectPath: 'group/project',
+      });
+
+      expect(result.decision).toBe('redact');
+      if (result.decision === 'redact') {
+        expect(result.body).toBe('token is [REDACTED] here');
+        expect(result.body).not.toContain(SECRET);
+        expect(result.trace.matchCategoryCounts['secret-shape']).toBe(1);
+      }
+    });
+
+    it('blocks a secret shape in block mode and emits no body', () => {
+      const scanner = createEgressScanner({ ...baseConfig, secretShapeMode: 'block' });
+
+      const result = scanner.scan({
+        body: `token is ${SECRET} here`,
+        channel: 'postComment',
+        projectPath: 'group/project',
+      });
+
+      expect(result.decision).toBe('block');
+      if (result.decision === 'block') {
+        expect(result.trace.matchCategoryCounts['secret-shape']).toBe(1);
+      }
+    });
+
+    it('passes a secret shape untouched in allow mode', () => {
+      const scanner = createEgressScanner({ ...baseConfig, secretShapeMode: 'allow' });
+
+      const result = scanner.scan({
+        body: `token is ${SECRET} here`,
+        channel: 'postComment',
+        projectPath: 'group/project',
+      });
+
+      expect(result.decision).toBe('pass');
+    });
+  });
+
+  describe('length cap (AC3)', () => {
+    it('truncates a body over the cap with the truncation marker in redact mode', () => {
+      const scanner = createEgressScanner({ ...baseConfig, maxBodyLength: 20 });
+
+      const result = scanner.scan({
+        body: 'x'.repeat(100),
+        channel: 'postComment',
+        projectPath: 'group/project',
+      });
+
+      expect(result.decision).toBe('redact');
+      if (result.decision === 'redact') {
+        expect(result.body.length).toBeLessThanOrEqual(20);
+        expect(result.body.endsWith('…[TRUNCATED]')).toBe(true);
+        expect(result.trace.matchCategoryCounts['length-cap']).toBe(1);
+      }
+    });
+
+    it('blocks a body over the cap in block mode', () => {
+      const scanner = createEgressScanner({ ...baseConfig, lengthMode: 'block', maxBodyLength: 20 });
+
+      const result = scanner.scan({
+        body: 'x'.repeat(100),
+        channel: 'postComment',
+        projectPath: 'group/project',
+      });
+
+      expect(result.decision).toBe('block');
+    });
+  });
+
+  describe('out-of-scope reference scan (AC4)', () => {
+    it('passes an in-scope project reference', () => {
+      const scanner = createEgressScanner(baseConfig);
+
+      const result = scanner.scan({
+        body: 'See group/project/src/index.ts for details',
+        channel: 'postComment',
+        projectPath: 'group/project',
+      });
+
+      expect(result.decision).toBe('pass');
+    });
+
+    it('redacts a foreign project reference in redact mode', () => {
+      const scanner = createEgressScanner(baseConfig);
+
+      const result = scanner.scan({
+        body: 'Compare with foreign/secret-repo internals',
+        channel: 'postComment',
+        projectPath: 'group/project',
+      });
+
+      expect(result.decision).toBe('redact');
+      if (result.decision === 'redact') {
+        expect(result.body).not.toContain('foreign/secret-repo');
+        expect(result.trace.matchCategoryCounts['out-of-scope']).toBe(1);
+      }
+    });
+
+    it('blocks a foreign project reference in block mode', () => {
+      const scanner = createEgressScanner({ ...baseConfig, outOfScopeMode: 'block' });
+
+      const result = scanner.scan({
+        body: 'Compare with foreign/secret-repo internals',
+        channel: 'postComment',
+        projectPath: 'group/project',
+      });
+
+      expect(result.decision).toBe('block');
+    });
+  });
+
+  describe('trace metadata carries no secret (AC6)', () => {
+    it('never embeds the matched secret value in the trace', () => {
+      const scanner = createEgressScanner(baseConfig);
+
+      const result = scanner.scan({
+        body: `token ${SECRET}`,
+        channel: 'THREAD_REPLY',
+        projectPath: 'group/project',
+      });
+
+      expect(result.decision).toBe('redact');
+      if (result.decision === 'redact') {
+        expect(JSON.stringify(result.trace)).not.toContain(SECRET);
+        expect(result.trace.channel).toBe('THREAD_REPLY');
+        expect(result.trace.mode).toBe('redact');
+      }
+    });
+  });
+});

--- a/src/tests/units/interface-adapters/controllers/webhook/gitlab.controller.test.ts
+++ b/src/tests/units/interface-adapters/controllers/webhook/gitlab.controller.test.ts
@@ -96,6 +96,11 @@ import { RecordBypassUseCase } from '@/modules/tracking/usecases/tracking/record
 import { HandlePlatformApprovalUseCase } from '@/modules/tracking/usecases/tracking/handlePlatformApproval.usecase.js';
 import { StubNoteCommentPostGateway } from '@/tests/stubs/noteCommentPost.stub.js';
 import { StubApprovalRevocationGateway } from '@/tests/stubs/approvalRevocation.stub.js';
+import { StubMemberAccessGateway } from '@/tests/stubs/memberAccess.stub.js';
+import { StubPendingReviewRequestGateway } from '@/tests/stubs/pendingReviewRequest.stub.js';
+import { IsTrustedActorUseCase } from '@/modules/platform-integration/usecases/isTrustedActor.usecase.js';
+import { GateClaudeInvocationUseCase } from '@/modules/review-execution/usecases/gateClaudeInvocation.usecase.js';
+import { MEMBER_ACCESS_LEVELS } from '@/modules/platform-integration/entities/memberAccess/memberAccess.js';
 
 function createMockTrackingGateway() {
   const basicMr = TrackedMrFactory.create({
@@ -107,7 +112,7 @@ function createMockTrackingGateway() {
 
   return {
     getById: vi.fn((): TrackedMr | null => basicMr),
-    getByNumber: vi.fn(() => null),
+    getByNumber: vi.fn((): TrackedMr | null => null),
     create: vi.fn(),
     update: vi.fn(),
     getByState: vi.fn(() => []),
@@ -115,7 +120,7 @@ function createMockTrackingGateway() {
     remove: vi.fn(() => true),
     archive: vi.fn(() => true),
     recordReviewEvent: vi.fn(),
-    recordPush: vi.fn(() => null),
+    recordPush: vi.fn((): TrackedMr | null => null),
     loadTracking: vi.fn(() => null),
     saveTracking: vi.fn(),
   };
@@ -533,6 +538,140 @@ describe('handleGitLabWebhook', () => {
       expect(defaultDeps.enforceBudget.execute).toHaveBeenCalled();
       expect(enqueueReview).toHaveBeenCalled();
       expect(defaultDeps.broadcastBudgetExceeded).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('trusted-actor trigger provenance gate (SPEC-197)', () => {
+    function buildGatedDeps(
+      memberAccess: StubMemberAccessGateway,
+      pendingGateway: StubPendingReviewRequestGateway,
+    ) {
+      const gateClaudeInvocation = new GateClaudeInvocationUseCase({
+        triggerMode: 'full-auto',
+        pendingReviewRequestGateway: pendingGateway,
+        enqueue: enqueueReview,
+        broadcastPendingChanged: () => {},
+        logger,
+      });
+      return {
+        ...defaultDeps,
+        gateClaudeInvocation,
+        isTrustedActor: new IsTrustedActorUseCase(memberAccess),
+      };
+    }
+
+    describe('AC1 - reviewer-added gate', () => {
+      it('parks pending and never enqueues when the actor is a Reporter', async () => {
+        mockGateway.getById.mockReturnValue(null);
+        const memberAccess = new StubMemberAccessGateway();
+        memberAccess.setAccess('reporter-actor', MEMBER_ACCESS_LEVELS.reporter);
+        const pendingGateway = new StubPendingReviewRequestGateway();
+        const deps = buildGatedDeps(memberAccess, pendingGateway);
+
+        const event = GitLabEventFactory.createWithReviewerAdded('claude-bot');
+        event.user = { username: 'reporter-actor', name: 'Reporter Actor' };
+        const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+        await handleGitLabWebhook(request, mockReply, logger, mockGateway, deps);
+
+        expect(enqueueReview).not.toHaveBeenCalled();
+        expect(pendingGateway.saveCount).toBe(1);
+        expect(memberAccess.calls).toEqual([
+          { projectPath: 'test-org/test-project', username: 'reporter-actor' },
+        ]);
+      });
+
+      it('enqueues when the actor is a Developer', async () => {
+        mockGateway.getById.mockReturnValue(null);
+        const memberAccess = new StubMemberAccessGateway();
+        memberAccess.setAccess('dev-actor', MEMBER_ACCESS_LEVELS.developer);
+        const pendingGateway = new StubPendingReviewRequestGateway();
+        const deps = buildGatedDeps(memberAccess, pendingGateway);
+
+        const event = GitLabEventFactory.createWithReviewerAdded('claude-bot');
+        event.user = { username: 'dev-actor', name: 'Dev Actor' };
+        const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+        await handleGitLabWebhook(request, mockReply, logger, mockGateway, deps);
+
+        expect(enqueueReview).toHaveBeenCalled();
+        expect(pendingGateway.saveCount).toBe(0);
+      });
+    });
+
+    describe('AC2 - followup / MR-update gate', () => {
+      function buildFollowupMr(): TrackedMr {
+        return TrackedMrFactory.create({
+          id: 'gitlab-test-org/test-project-42',
+          mrNumber: 42,
+          platform: 'gitlab',
+          project: 'test-org/test-project',
+          state: 'pending-review',
+          openThreads: 3,
+          autoFollowup: true,
+          lastPushAt: '2026-05-26T12:00:00.000Z',
+          lastReviewAt: '2026-05-25T12:00:00.000Z',
+        });
+      }
+
+      it('parks pending and never enqueues a followup from a non-trusted actor', async () => {
+        const followupMr = buildFollowupMr();
+        mockGateway.getById.mockImplementation(() => followupMr);
+        mockGateway.getByNumber.mockImplementation(() => followupMr);
+        mockGateway.recordPush.mockImplementation(() => followupMr);
+        const memberAccess = new StubMemberAccessGateway();
+        memberAccess.setAccess('reporter-actor', MEMBER_ACCESS_LEVELS.reporter);
+        const pendingGateway = new StubPendingReviewRequestGateway();
+        const deps = buildGatedDeps(memberAccess, pendingGateway);
+
+        const event = GitLabEventFactory.createMrUpdate();
+        event.user = { username: 'reporter-actor', name: 'Reporter Actor' };
+        const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+        await handleGitLabWebhook(request, mockReply, logger, mockGateway, deps);
+
+        expect(enqueueReview).not.toHaveBeenCalled();
+        expect(pendingGateway.saveCount).toBe(1);
+      });
+
+      it('enqueues a followup from a Developer actor', async () => {
+        const followupMr = buildFollowupMr();
+        mockGateway.getById.mockImplementation(() => followupMr);
+        mockGateway.getByNumber.mockImplementation(() => followupMr);
+        mockGateway.recordPush.mockImplementation(() => followupMr);
+        const memberAccess = new StubMemberAccessGateway();
+        memberAccess.setAccess('dev-actor', MEMBER_ACCESS_LEVELS.developer);
+        const pendingGateway = new StubPendingReviewRequestGateway();
+        const deps = buildGatedDeps(memberAccess, pendingGateway);
+
+        const event = GitLabEventFactory.createMrUpdate();
+        event.user = { username: 'dev-actor', name: 'Dev Actor' };
+        const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+        await handleGitLabWebhook(request, mockReply, logger, mockGateway, deps);
+
+        expect(enqueueReview).toHaveBeenCalled();
+        expect(pendingGateway.saveCount).toBe(0);
+      });
+    });
+
+    describe('AC4 - fail-closed membership resolution', () => {
+      it('parks a reviewer-added trigger when membership resolution throws', async () => {
+        mockGateway.getById.mockReturnValue(null);
+        const memberAccess = new StubMemberAccessGateway();
+        memberAccess.setShouldFail(true);
+        const pendingGateway = new StubPendingReviewRequestGateway();
+        const deps = buildGatedDeps(memberAccess, pendingGateway);
+
+        const event = GitLabEventFactory.createWithReviewerAdded('claude-bot');
+        event.user = { username: 'dev-actor', name: 'Dev Actor' };
+        const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+        await handleGitLabWebhook(request, mockReply, logger, mockGateway, deps);
+
+        expect(enqueueReview).not.toHaveBeenCalled();
+        expect(pendingGateway.saveCount).toBe(1);
+      });
     });
   });
 });

--- a/src/tests/units/interface-adapters/gateways/egressScanned.noteCommentPost.gateway.test.ts
+++ b/src/tests/units/interface-adapters/gateways/egressScanned.noteCommentPost.gateway.test.ts
@@ -1,0 +1,141 @@
+import { EgressScannedNoteCommentPostGateway } from '@/modules/platform-integration/interface-adapters/gateways/egressScanned.noteCommentPost.gateway.js';
+import { EgressBlockedError } from '@/modules/platform-integration/interface-adapters/gateways/egressScanned.noteCommentPost.gateway.js';
+import { StubNoteCommentPostGateway } from '@/tests/stubs/noteCommentPost.stub.js';
+import { StubEgressScanGateway, StubEgressTraceGateway } from '@/tests/stubs/egressScan.stub.js';
+
+const SECRET = 'glpat-abcdefghij1234567890';
+
+describe('EgressScannedNoteCommentPostGateway', () => {
+  describe('AC1 — single enforcement point', () => {
+    it('passes a clean scanned body to the underlying sink', async () => {
+      const sink = new StubNoteCommentPostGateway();
+      const scanner = new StubEgressScanGateway();
+      const trace = new StubEgressTraceGateway();
+      scanner.setResult({ decision: 'pass', body: 'clean body' });
+      const gateway = new EgressScannedNoteCommentPostGateway(sink, scanner, trace);
+
+      await gateway.postComment({ projectPath: 'group/project', mrNumber: 1, body: 'clean body' });
+
+      expect(sink.calls).toHaveLength(1);
+      expect(sink.calls[0].body).toBe('clean body');
+      expect(scanner.calls).toHaveLength(1);
+      expect(scanner.calls[0].channel).toBe('postComment');
+    });
+
+    it('sends the redacted body, never the raw secret, to the sink', async () => {
+      const sink = new StubNoteCommentPostGateway();
+      const scanner = new StubEgressScanGateway();
+      const trace = new StubEgressTraceGateway();
+      scanner.setResult({
+        decision: 'redact',
+        body: 'token is [REDACTED] here',
+        trace: {
+          channel: 'postComment',
+          mode: 'redact',
+          matchCategoryCounts: { 'secret-shape': 1, 'length-cap': 0, 'out-of-scope': 0 },
+        },
+      });
+      const gateway = new EgressScannedNoteCommentPostGateway(sink, scanner, trace);
+
+      await gateway.postComment({ projectPath: 'group/project', mrNumber: 1, body: `token is ${SECRET} here` });
+
+      expect(sink.calls).toHaveLength(1);
+      expect(sink.calls[0].body).toBe('token is [REDACTED] here');
+      expect(sink.calls[0].body).not.toContain(SECRET);
+    });
+
+    it('never calls the sink when the scanner blocks, and raises EgressBlockedError', async () => {
+      const sink = new StubNoteCommentPostGateway();
+      const scanner = new StubEgressScanGateway();
+      const trace = new StubEgressTraceGateway();
+      scanner.setResult({
+        decision: 'block',
+        trace: {
+          channel: 'postComment',
+          mode: 'block',
+          matchCategoryCounts: { 'secret-shape': 1, 'length-cap': 0, 'out-of-scope': 0 },
+        },
+      });
+      const gateway = new EgressScannedNoteCommentPostGateway(sink, scanner, trace);
+
+      await expect(
+        gateway.postComment({ projectPath: 'group/project', mrNumber: 1, body: `token ${SECRET}` }),
+      ).rejects.toBeInstanceOf(EgressBlockedError);
+      expect(sink.calls).toHaveLength(0);
+    });
+  });
+
+  describe('AC5 — fail-closed on scanner error', () => {
+    it('never posts and raises when the scanner throws', async () => {
+      const sink = new StubNoteCommentPostGateway();
+      const scanner = new StubEgressScanGateway();
+      const trace = new StubEgressTraceGateway();
+      scanner.setShouldFail(true);
+      const gateway = new EgressScannedNoteCommentPostGateway(sink, scanner, trace);
+
+      await expect(
+        gateway.postComment({ projectPath: 'group/project', mrNumber: 1, body: 'anything' }),
+      ).rejects.toThrow();
+      expect(sink.calls).toHaveLength(0);
+    });
+  });
+
+  describe('AC6 — trace without secret', () => {
+    it('records a trace on redact without the raw secret', async () => {
+      const sink = new StubNoteCommentPostGateway();
+      const scanner = new StubEgressScanGateway();
+      const trace = new StubEgressTraceGateway();
+      scanner.setResult({
+        decision: 'redact',
+        body: 'token is [REDACTED]',
+        trace: {
+          channel: 'postComment',
+          mode: 'redact',
+          matchCategoryCounts: { 'secret-shape': 1, 'length-cap': 0, 'out-of-scope': 0 },
+        },
+      });
+      const gateway = new EgressScannedNoteCommentPostGateway(sink, scanner, trace);
+
+      await gateway.postComment({ projectPath: 'group/project', mrNumber: 1, body: `token is ${SECRET}` });
+
+      expect(trace.traces).toHaveLength(1);
+      expect(trace.traces[0].mode).toBe('redact');
+      expect(trace.traces[0].matchCategoryCounts['secret-shape']).toBe(1);
+      expect(JSON.stringify(trace.traces[0])).not.toContain(SECRET);
+    });
+
+    it('records a trace on block', async () => {
+      const sink = new StubNoteCommentPostGateway();
+      const scanner = new StubEgressScanGateway();
+      const trace = new StubEgressTraceGateway();
+      scanner.setResult({
+        decision: 'block',
+        trace: {
+          channel: 'postComment',
+          mode: 'block',
+          matchCategoryCounts: { 'secret-shape': 1, 'length-cap': 0, 'out-of-scope': 0 },
+        },
+      });
+      const gateway = new EgressScannedNoteCommentPostGateway(sink, scanner, trace);
+
+      await expect(
+        gateway.postComment({ projectPath: 'group/project', mrNumber: 1, body: `token ${SECRET}` }),
+      ).rejects.toBeInstanceOf(EgressBlockedError);
+
+      expect(trace.traces).toHaveLength(1);
+      expect(trace.traces[0].mode).toBe('block');
+    });
+
+    it('records no trace on a clean pass', async () => {
+      const sink = new StubNoteCommentPostGateway();
+      const scanner = new StubEgressScanGateway();
+      const trace = new StubEgressTraceGateway();
+      scanner.setResult({ decision: 'pass', body: 'clean' });
+      const gateway = new EgressScannedNoteCommentPostGateway(sink, scanner, trace);
+
+      await gateway.postComment({ projectPath: 'group/project', mrNumber: 1, body: 'clean' });
+
+      expect(trace.traces).toHaveLength(0);
+    });
+  });
+});

--- a/src/tests/units/modules/platform-integration/controllers/gitlabProcessorProvenance.test.ts
+++ b/src/tests/units/modules/platform-integration/controllers/gitlabProcessorProvenance.test.ts
@@ -1,0 +1,84 @@
+import { vi } from 'vitest'
+
+vi.mock('@/config/loader.js', () => ({
+  loadConfig: vi.fn(() => ({ repositories: [] })),
+  findRepositoryByProjectPath: vi.fn(() => undefined),
+}))
+
+vi.mock('@/claude/invoker.js', () => ({
+  invokeClaudeReview: vi.fn(() =>
+    Promise.resolve({ success: true, stdout: '', durationMs: 1, exitCode: 0, cancelled: false, stderr: '' }),
+  ),
+  sendNotification: vi.fn(),
+}))
+
+vi.mock('@/main/websocket.js', () => ({
+  startWatchingReviewContext: vi.fn(),
+  stopWatchingReviewContext: vi.fn(),
+}))
+
+vi.mock('@/config/projectConfig.js', () => ({
+  loadProjectConfig: vi.fn(() => null),
+  getProjectAgents: vi.fn(() => null),
+  getProjectAgentsOrFocusDefaults: vi.fn(() => null),
+  getFollowupAgents: vi.fn(() => null),
+  getProjectLanguage: vi.fn(() => 'en'),
+}))
+
+import { describe, it, expect } from 'vitest'
+import { buildGitLabReviewProcessor } from '@/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.js'
+import { createStubLogger } from '@/tests/stubs/logger.stub.js'
+import type { ReviewJob } from '@/frameworks/queue/pQueueAdapter.js'
+
+class RecordingThreadFetch {
+  public readonly calls: Array<{ projectPath: string; mrNumber: number }> = []
+  fetchThreads = (projectPath: string, mrNumber: number) => {
+    this.calls.push({ projectPath, mrNumber })
+    return []
+  }
+}
+
+function buildJob(): ReviewJob {
+  return {
+    id: 'gitlab-attacker/unknown-5',
+    platform: 'gitlab',
+    projectPath: 'attacker/unknown',
+    localPath: '/repo',
+    mrNumber: 5,
+    skill: 'review-front',
+    mrUrl: 'https://gitlab.com/attacker/unknown/-/merge_requests/5',
+    sourceBranch: 'feature',
+    targetBranch: 'main',
+    jobType: 'review',
+    language: 'en',
+  } as unknown as ReviewJob
+}
+
+describe('GitLab review processor provenance pin (AC9)', () => {
+  it('AC9(1): an unconfigured projectPath never reaches fetchThreads (fail-closed)', async () => {
+    const threadFetch = new RecordingThreadFetch()
+    const processor = buildGitLabReviewProcessor(
+      {
+        reviewContextGateway: {
+          create: () => undefined,
+          read: () => null,
+          updateProgress: () => undefined,
+          setResult: () => undefined,
+          delete: () => ({ deleted: true }),
+        },
+        threadFetchGateway: threadFetch,
+        diffMetadataFetchGateway: { fetchDiffMetadata: () => undefined },
+        diffStatsFetchGateway: { fetchDiffStats: () => null },
+        recordCompletion: { execute: () => undefined },
+        claudeInvokerDeps: undefined,
+      } as never,
+      createStubLogger(),
+    )
+
+    const job = buildJob()
+    const run = processor(job)
+
+    await expect(run(job, new AbortController().signal)).rejects.toThrow()
+    expect(threadFetch.calls).toHaveLength(0)
+  })
+})

--- a/src/tests/units/modules/platform-integration/entities/executorCapability.test.ts
+++ b/src/tests/units/modules/platform-integration/entities/executorCapability.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import {
+  EXECUTOR_CAPABILITY_TABLE,
+  AUTO_EXECUTOR_CAPABILITIES,
+  type ExecutorCapability,
+} from '@/modules/platform-integration/entities/executorToken/executorCapability.js'
+
+describe('executor capability table (AC5)', () => {
+  it('declares the minimal role per action in a single exported constant', () => {
+    expect(EXECUTOR_CAPABILITY_TABLE).toEqual({
+      readMr: { minRole: 'reporter', autoPath: true },
+      postComment: { minRole: 'reporter', autoPath: true },
+      threadResolve: { minRole: 'developer', autoPath: false },
+      revoke: { minRole: 'developer', autoPath: false },
+    })
+  })
+
+  it('exposes the auto-path capability set as exactly {readMr, postComment}', () => {
+    const sorted = [...AUTO_EXECUTOR_CAPABILITIES].sort()
+    expect(sorted).toEqual<ExecutorCapability[]>(['postComment', 'readMr'])
+  })
+
+  it('excludes every non-auto-path action from the auto capability set', () => {
+    expect(AUTO_EXECUTOR_CAPABILITIES.has('threadResolve')).toBe(false)
+    expect(AUTO_EXECUTOR_CAPABILITIES.has('revoke')).toBe(false)
+  })
+
+  it('derives the auto set strictly from the table autoPath flags', () => {
+    const derived = Object.entries(EXECUTOR_CAPABILITY_TABLE)
+      .filter(([, capability]) => capability.autoPath)
+      .map(([name]) => name)
+      .sort()
+    expect(derived).toEqual(['postComment', 'readMr'])
+  })
+})

--- a/src/tests/units/modules/platform-integration/entities/memberAccess/memberAccess.test.ts
+++ b/src/tests/units/modules/platform-integration/entities/memberAccess/memberAccess.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MEMBER_ACCESS_LEVELS,
+  isDeveloperOrAbove,
+} from '@/modules/platform-integration/entities/memberAccess/memberAccess.js';
+
+describe('isDeveloperOrAbove', () => {
+  it('treats Developer and above as trusted', () => {
+    expect(isDeveloperOrAbove(MEMBER_ACCESS_LEVELS.developer)).toBe(true);
+    expect(isDeveloperOrAbove(MEMBER_ACCESS_LEVELS.maintainer)).toBe(true);
+    expect(isDeveloperOrAbove(MEMBER_ACCESS_LEVELS.owner)).toBe(true);
+  });
+
+  it('treats below Developer as non-trusted', () => {
+    expect(isDeveloperOrAbove(MEMBER_ACCESS_LEVELS.reporter)).toBe(false);
+    expect(isDeveloperOrAbove(MEMBER_ACCESS_LEVELS.guest)).toBe(false);
+    expect(isDeveloperOrAbove(MEMBER_ACCESS_LEVELS.noAccess)).toBe(false);
+  });
+
+  it('treats an unresolved actor (null) as non-trusted', () => {
+    expect(isDeveloperOrAbove(null)).toBe(false);
+  });
+});

--- a/src/tests/units/modules/platform-integration/gateways/defaultGitLabExecutor.test.ts
+++ b/src/tests/units/modules/platform-integration/gateways/defaultGitLabExecutor.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { defaultGitLabExecutor } from '@/modules/platform-integration/interface-adapters/gateways/threadFetch.gitlab.gateway.js'
+import { MissingExecutorTokenError } from '@/modules/platform-integration/services/scopedExecutorEnvironment.js'
+
+describe('defaultGitLabExecutor fail-closed (AC1 production wiring)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('throws MissingExecutorTokenError when the service token is unset, never falling back to the ambient token', () => {
+    vi.stubEnv('REVIEWFLOW_EXECUTOR_TOKEN', '')
+    expect(() => defaultGitLabExecutor('glab api projects/x/merge_requests/1/discussions')).toThrow(
+      MissingExecutorTokenError,
+    )
+  })
+})

--- a/src/tests/units/modules/platform-integration/gateways/memberAccess.gitlab.cli.gateway.test.ts
+++ b/src/tests/units/modules/platform-integration/gateways/memberAccess.gitlab.cli.gateway.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GitLabMemberAccessCliGateway } from '@/modules/platform-integration/interface-adapters/gateways/memberAccess.gitlab.cli.gateway.js';
+import { MEMBER_ACCESS_LEVELS } from '@/modules/platform-integration/entities/memberAccess/memberAccess.js';
+
+interface RecordedCommand {
+  command: string;
+}
+
+class RecordingExecutor {
+  public readonly commands: RecordedCommand[] = [];
+  private responses = new Map<string, string>();
+  private failures = new Set<string>();
+
+  onMatch(fragment: string, response: string): void {
+    this.responses.set(fragment, response);
+  }
+
+  failOnMatch(fragment: string): void {
+    this.failures.add(fragment);
+  }
+
+  run = (command: string): string => {
+    this.commands.push({ command });
+    for (const fragment of this.failures) {
+      if (command.includes(fragment)) {
+        throw new Error(`glab failed for ${fragment}`);
+      }
+    }
+    for (const [fragment, response] of this.responses) {
+      if (command.includes(fragment)) {
+        return response;
+      }
+    }
+    throw new Error(`No stubbed response for command: ${command}`);
+  };
+}
+
+describe('GitLabMemberAccessCliGateway', () => {
+  let executor: RecordingExecutor;
+  let now: number;
+  const clock = (): number => now;
+
+  beforeEach(() => {
+    executor = new RecordingExecutor();
+    now = 1_000;
+  });
+
+  function buildGateway(ttlMs = 60_000): GitLabMemberAccessCliGateway {
+    return new GitLabMemberAccessCliGateway(executor.run, { ttlMs, clock });
+  }
+
+  it('resolves username to id then membership access level', async () => {
+    executor.onMatch('users?username=alice', JSON.stringify([{ id: 7, username: 'alice' }]));
+    executor.onMatch('members/all/7', JSON.stringify({ id: 7, access_level: 30 }));
+
+    const accessLevel = await buildGateway().resolve('org/project', 'alice');
+
+    expect(accessLevel).toBe(MEMBER_ACCESS_LEVELS.developer);
+  });
+
+  it('caches per username and does not re-query within the TTL', async () => {
+    executor.onMatch('users?username=alice', JSON.stringify([{ id: 7, username: 'alice' }]));
+    executor.onMatch('members/all/7', JSON.stringify({ id: 7, access_level: 40 }));
+
+    const gateway = buildGateway();
+    await gateway.resolve('org/project', 'alice');
+    const commandsAfterFirst = executor.commands.length;
+    await gateway.resolve('org/project', 'alice');
+
+    expect(executor.commands.length).toBe(commandsAfterFirst);
+  });
+
+  it('does not apply a cached result for one username to another (AC5)', async () => {
+    executor.onMatch('users?username=alice', JSON.stringify([{ id: 7, username: 'alice' }]));
+    executor.onMatch('members/all/7', JSON.stringify({ id: 7, access_level: 30 }));
+    executor.failOnMatch('users?username=mallory');
+
+    const gateway = buildGateway();
+    await gateway.resolve('org/project', 'alice');
+    const mallory = await gateway.resolve('org/project', 'mallory');
+
+    expect(mallory).toBeNull();
+  });
+
+  it('re-queries after the TTL expires', async () => {
+    executor.onMatch('users?username=alice', JSON.stringify([{ id: 7, username: 'alice' }]));
+    executor.onMatch('members/all/7', JSON.stringify({ id: 7, access_level: 30 }));
+
+    const gateway = buildGateway(1_000);
+    await gateway.resolve('org/project', 'alice');
+    const commandsAfterFirst = executor.commands.length;
+    now += 2_000;
+    await gateway.resolve('org/project', 'alice');
+
+    expect(executor.commands.length).toBeGreaterThan(commandsAfterFirst);
+  });
+
+  it('returns null when the user lookup throws (fail-closed)', async () => {
+    executor.failOnMatch('users?username=alice');
+
+    const accessLevel = await buildGateway().resolve('org/project', 'alice');
+
+    expect(accessLevel).toBeNull();
+  });
+
+  it('returns null when the user lookup is ambiguous (more than one match)', async () => {
+    executor.onMatch(
+      'users?username=alice',
+      JSON.stringify([
+        { id: 7, username: 'alice' },
+        { id: 8, username: 'alice' },
+      ]),
+    );
+
+    const accessLevel = await buildGateway().resolve('org/project', 'alice');
+
+    expect(accessLevel).toBeNull();
+  });
+
+  it('returns null when the username is unknown (empty user list)', async () => {
+    executor.onMatch('users?username=ghost', JSON.stringify([]));
+
+    const accessLevel = await buildGateway().resolve('org/project', 'ghost');
+
+    expect(accessLevel).toBeNull();
+  });
+
+  it('returns null when the membership lookup throws (non-member, fail-closed)', async () => {
+    executor.onMatch('users?username=alice', JSON.stringify([{ id: 7, username: 'alice' }]));
+    executor.failOnMatch('members/all/7');
+
+    const accessLevel = await buildGateway().resolve('org/project', 'alice');
+
+    expect(accessLevel).toBeNull();
+  });
+
+  it('returns null when membership access_level is below the known scale', async () => {
+    executor.onMatch('users?username=alice', JSON.stringify([{ id: 7, username: 'alice' }]));
+    executor.onMatch('members/all/7', JSON.stringify({ id: 7, access_level: 999 }));
+
+    const accessLevel = await buildGateway().resolve('org/project', 'alice');
+
+    expect(accessLevel).toBeNull();
+  });
+});

--- a/src/tests/units/modules/platform-integration/gateways/scopedGitLabExecutor.test.ts
+++ b/src/tests/units/modules/platform-integration/gateways/scopedGitLabExecutor.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createScopedGitLabExecutor,
+} from '@/modules/platform-integration/interface-adapters/gateways/scopedGitLabExecutor.js'
+import { MissingExecutorTokenError } from '@/modules/platform-integration/services/scopedExecutorEnvironment.js'
+
+const TOKEN = 'glpat-scoped-exec-1'
+
+class RecordingFileWriter {
+  public readonly writes: Array<{ path: string; contents: string }> = []
+  write(path: string, contents: string): void {
+    this.writes.push({ path, contents })
+  }
+}
+
+class RecordingSpawn {
+  public readonly calls: Array<{ command: string; env: Record<string, string | undefined>; cwd: string }> = []
+  run = (command: string, env: Record<string, string | undefined>, cwd: string): string => {
+    this.calls.push({ command, env, cwd })
+    return '[]'
+  }
+}
+
+describe('scoped gitlab executor factory (AC1-AC4 wiring)', () => {
+  it('AC1: throws fail-closed when the service token is absent, never spawning', () => {
+    const spawn = new RecordingSpawn()
+    const fileWriter = new RecordingFileWriter()
+    expect(() =>
+      createScopedGitLabExecutor({
+        parentEnv: { PATH: '/usr/bin' },
+        isolatedDir: '/tmp/iso',
+        fileWriter,
+        spawn: spawn.run,
+      }),
+    ).toThrow(MissingExecutorTokenError)
+    expect(spawn.calls).toHaveLength(0)
+    expect(fileWriter.writes).toHaveLength(0)
+  })
+
+  it('AC1: returns a callable executor when the token is present', () => {
+    const spawn = new RecordingSpawn()
+    const fileWriter = new RecordingFileWriter()
+    const executor = createScopedGitLabExecutor({
+      parentEnv: { REVIEWFLOW_EXECUTOR_TOKEN: TOKEN, PATH: '/usr/bin' },
+      isolatedDir: '/tmp/iso',
+      fileWriter,
+      spawn: spawn.run,
+    })
+    expect(typeof executor).toBe('function')
+  })
+
+  it('AC3: the spawned env never carries the token value', () => {
+    const spawn = new RecordingSpawn()
+    const fileWriter = new RecordingFileWriter()
+    const executor = createScopedGitLabExecutor({
+      parentEnv: { REVIEWFLOW_EXECUTOR_TOKEN: TOKEN, PATH: '/usr/bin', AMBIENT_ADMIN_TOKEN: 'canary' },
+      isolatedDir: '/tmp/iso',
+      fileWriter,
+      spawn: spawn.run,
+    })
+    executor('glab api projects/x/merge_requests/1/discussions')
+    expect(spawn.calls).toHaveLength(1)
+    for (const value of Object.values(spawn.calls[0]!.env)) {
+      expect(value).not.toBe(TOKEN)
+    }
+    expect(spawn.calls[0]!.env.AMBIENT_ADMIN_TOKEN).toBeUndefined()
+  })
+
+  it('AC4: spawns with HOME and GLAB_CONFIG_DIR under the isolated dir', () => {
+    const spawn = new RecordingSpawn()
+    const fileWriter = new RecordingFileWriter()
+    const executor = createScopedGitLabExecutor({
+      parentEnv: { REVIEWFLOW_EXECUTOR_TOKEN: TOKEN, PATH: '/usr/bin' },
+      isolatedDir: '/tmp/iso',
+      fileWriter,
+      spawn: spawn.run,
+    })
+    executor('glab api projects/x/merge_requests/1/discussions')
+    expect(spawn.calls[0]!.env.HOME?.startsWith('/tmp/iso')).toBe(true)
+    expect(spawn.calls[0]!.env.GLAB_CONFIG_DIR?.startsWith('/tmp/iso')).toBe(true)
+  })
+
+  it('AC4: writes the token only into the isolated glab config file', () => {
+    const spawn = new RecordingSpawn()
+    const fileWriter = new RecordingFileWriter()
+    createScopedGitLabExecutor({
+      parentEnv: { REVIEWFLOW_EXECUTOR_TOKEN: TOKEN, PATH: '/usr/bin' },
+      isolatedDir: '/tmp/iso',
+      fileWriter,
+      spawn: spawn.run,
+    })
+    expect(fileWriter.writes).toHaveLength(1)
+    expect(fileWriter.writes[0]!.path.startsWith('/tmp/iso')).toBe(true)
+    expect(fileWriter.writes[0]!.contents).toContain(TOKEN)
+  })
+})

--- a/src/tests/units/modules/platform-integration/interface-adapters/controllers/webhook/gitlabIdempotency.controller.test.ts
+++ b/src/tests/units/modules/platform-integration/interface-adapters/controllers/webhook/gitlabIdempotency.controller.test.ts
@@ -1,0 +1,258 @@
+import { vi } from 'vitest';
+import type { FastifyRequest, FastifyReply } from 'fastify';
+import type { RepositoryConfig } from '@/config/loader.js';
+
+const mockConfig = {
+  server: { port: 3000 },
+  user: { gitlabUsername: 'claude-bot', githubUsername: 'claude-bot' },
+  queue: { maxConcurrent: 1, deduplicationWindowMs: 60000 },
+  repositories: [],
+};
+
+const mockRepoConfig: RepositoryConfig = {
+  name: 'test-project',
+  platform: 'gitlab',
+  localPath: '/home/user/projects/test-project',
+  remoteUrl: 'https://gitlab.com/test-org/test-project.git',
+  skill: 'review-front',
+  enabled: true,
+};
+
+vi.mock('@/config/loader.js', () => ({
+  loadConfig: vi.fn(() => mockConfig),
+  findRepositoryByProjectPath: vi.fn(() => mockRepoConfig),
+}));
+
+vi.mock('@/security/verifier.js', () => ({
+  verifyGitLabSignature: vi.fn(() => ({ valid: true })),
+  getGitLabEventType: vi.fn(() => 'Merge Request Hook'),
+  getGitLabEventUuid: vi.fn(
+    (request: FastifyRequest) => request.headers['x-gitlab-event-uuid'],
+  ),
+}));
+
+vi.mock('@/frameworks/queue/pQueueAdapter.js', () => ({
+  createJobId: vi.fn(() => 'gitlab-test-org/test-project-42'),
+  enqueueReview: vi.fn(() => Promise.resolve(true)),
+  updateJobProgress: vi.fn(),
+  cancelJob: vi.fn(),
+}));
+
+vi.mock('@/claude/invoker.js', () => ({
+  invokeClaudeReview: vi.fn(),
+  sendNotification: vi.fn(),
+}));
+
+vi.mock('@/main/websocket.js', () => ({
+  startWatchingReviewContext: vi.fn(),
+  stopWatchingReviewContext: vi.fn(),
+}));
+
+vi.mock('@/config/projectConfig.js', () => ({
+  loadProjectConfig: vi.fn(() => null),
+  getProjectAgents: vi.fn(() => null),
+  getProjectAgentsOrFocusDefaults: vi.fn(() => null),
+  getFollowupAgents: vi.fn(() => null),
+  getProjectLanguage: vi.fn(() => 'en'),
+}));
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { handleGitLabWebhook } from '@/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.js';
+import { GitLabEventFactory } from '@/tests/factories/gitLabEvent.factory.js';
+import { createStubLogger } from '@/tests/stubs/logger.stub.js';
+import { TrackedMrFactory } from '@/tests/factories/trackedMr.factory.js';
+import type { TrackedMr } from '@/modules/tracking/entities/tracking/trackedMr.js';
+import { TrackAssignmentUseCase } from '@/modules/tracking/usecases/tracking/trackAssignment.usecase.js';
+import { RecordReviewCompletionUseCase } from '@/modules/tracking/usecases/tracking/recordReviewCompletion.usecase.js';
+import { RecordPushUseCase } from '@/modules/tracking/usecases/tracking/recordPush.usecase.js';
+import { TransitionStateUseCase } from '@/modules/tracking/usecases/tracking/transitionState.usecase.js';
+import { CheckFollowupNeededUseCase } from '@/modules/tracking/usecases/tracking/checkFollowupNeeded.usecase.js';
+import { SyncThreadsUseCase } from '@/modules/tracking/usecases/tracking/syncThreads.usecase.js';
+import { RecordBypassUseCase } from '@/modules/tracking/usecases/tracking/recordBypass.usecase.js';
+import { HandlePlatformApprovalUseCase } from '@/modules/tracking/usecases/tracking/handlePlatformApproval.usecase.js';
+import { StubNoteCommentPostGateway } from '@/tests/stubs/noteCommentPost.stub.js';
+import { StubApprovalRevocationGateway } from '@/tests/stubs/approvalRevocation.stub.js';
+import { StubIdempotencyStore } from '@/tests/stubs/idempotencyStore.stub.js';
+import { InMemoryIdempotencyStore } from '@/modules/platform-integration/interface-adapters/gateways/inMemoryIdempotencyStore.gateway.js';
+import type {
+  GateClaudeInvocationInput,
+  GateClaudeInvocationResult,
+} from '@/modules/review-execution/usecases/gateClaudeInvocation.usecase.js';
+
+class StubGateClaudeInvocation {
+  invocationCount = 0;
+  private readonly result: GateClaudeInvocationResult;
+
+  constructor(result: GateClaudeInvocationResult = { status: 'enqueued', jobId: 'gitlab-test-org/test-project-42' }) {
+    this.result = result;
+  }
+
+  async execute(_input: GateClaudeInvocationInput): Promise<GateClaudeInvocationResult> {
+    this.invocationCount += 1;
+    return this.result;
+  }
+}
+
+function createMockTrackingGateway() {
+  const basicMr = TrackedMrFactory.create({
+    id: 'gitlab-test-org/test-project-42',
+    mrNumber: 42,
+    platform: 'gitlab',
+    project: 'test-org/test-project',
+  });
+
+  return {
+    getById: vi.fn((): TrackedMr | null => basicMr),
+    getByNumber: vi.fn(() => null),
+    create: vi.fn(),
+    update: vi.fn(),
+    getByState: vi.fn(() => []),
+    getActiveMrs: vi.fn(() => []),
+    remove: vi.fn(() => true),
+    archive: vi.fn(() => true),
+    recordReviewEvent: vi.fn(),
+    recordPush: vi.fn(() => null),
+    loadTracking: vi.fn(() => null),
+    saveTracking: vi.fn(),
+  };
+}
+
+function createStubContextGateway() {
+  return {
+    create: vi.fn(() => ({ success: true, filePath: '' })),
+    read: vi.fn(() => null),
+    delete: vi.fn(() => ({ success: true, deleted: true })),
+    exists: vi.fn(() => false),
+    getFilePath: vi.fn(() => ''),
+    appendAction: vi.fn(() => ({ success: true })),
+    updateProgress: vi.fn(() => ({ success: true })),
+    setResult: vi.fn(() => ({ success: true })),
+    listAll: vi.fn(() => []),
+  };
+}
+
+function createAcceptAllEnforceBudget() {
+  return {
+    execute: vi.fn(async () => ({
+      accepted: true,
+      status: {
+        limitUsd: 200,
+        consumedUsd: 0,
+        remainingUsd: 200,
+        percentUsed: 0,
+        exceeded: false,
+        periodStart: '2026-05-01T00:00:00.000Z',
+      },
+    })),
+  };
+}
+
+function createDeps(
+  trackingGateway: ReturnType<typeof createMockTrackingGateway>,
+  overrides: Record<string, unknown> = {},
+) {
+  const threadFetchGateway = { fetchThreads: vi.fn(() => []) };
+  return {
+    reviewContextGateway: createStubContextGateway(),
+    threadFetchGateway,
+    diffMetadataFetchGateway: { fetchDiffMetadata: vi.fn(() => ({ baseSha: 'abc', headSha: 'def', startSha: 'ghi' })) },
+    diffStatsFetchGateway: { fetchDiffStats: vi.fn(() => null) },
+    trackAssignment: new TrackAssignmentUseCase(trackingGateway),
+    recordCompletion: new RecordReviewCompletionUseCase(trackingGateway),
+    recordPush: new RecordPushUseCase(trackingGateway),
+    transitionState: new TransitionStateUseCase(trackingGateway),
+    checkFollowupNeeded: new CheckFollowupNeededUseCase(trackingGateway),
+    syncThreads: new SyncThreadsUseCase(trackingGateway, threadFetchGateway),
+    enforceBudget: createAcceptAllEnforceBudget(),
+    broadcastBudgetExceeded: vi.fn(),
+    getRepositories: vi.fn(() => []),
+    removeWorktree: vi.fn(async () => ({ status: 'removed' as const })),
+    recordBypass: new RecordBypassUseCase(trackingGateway),
+    noteCommentPostGateway: new StubNoteCommentPostGateway(),
+    handlePlatformApproval: new HandlePlatformApprovalUseCase(trackingGateway),
+    approvalRevocationGateway: new StubApprovalRevocationGateway(),
+    getQualityThreshold: (): number | null => null,
+    now: (): string => '2026-05-26T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function requestWith(uuid: string | undefined): FastifyRequest {
+  const headers: Record<string, string> = {};
+  if (uuid !== undefined) {
+    headers['x-gitlab-event-uuid'] = uuid;
+  }
+  return {
+    body: GitLabEventFactory.createWithReviewerAdded('claude-bot'),
+    headers,
+  } as unknown as FastifyRequest;
+}
+
+describe('handleGitLabWebhook idempotency guard', () => {
+  let mockReply: FastifyReply;
+  let mockGateway: ReturnType<typeof createMockTrackingGateway>;
+  const logger = createStubLogger();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReply = {
+      status: vi.fn().mockReturnThis(),
+      send: vi.fn().mockReturnThis(),
+    } as unknown as FastifyReply;
+    mockGateway = createMockTrackingGateway();
+    mockGateway.getById.mockReturnValue(null);
+  });
+
+  it('AC4: a duplicate UUID returns 200 no-op with a single invocation and pristine output stubs', async () => {
+    const idempotencyStore = new InMemoryIdempotencyStore({ ttlMs: 60_000, clock: () => 0 });
+    const gateClaudeInvocation = new StubGateClaudeInvocation();
+    const noteCommentPostGateway = new StubNoteCommentPostGateway();
+    const approvalRevocationGateway = new StubApprovalRevocationGateway();
+    const trackAssignment = new TrackAssignmentUseCase(mockGateway);
+    const trackSpy = vi.spyOn(trackAssignment, 'execute');
+    const deps = createDeps(mockGateway, {
+      idempotencyStore,
+      gateClaudeInvocation,
+      noteCommentPostGateway,
+      approvalRevocationGateway,
+      trackAssignment,
+    });
+
+    await handleGitLabWebhook(requestWith('uuid-A'), mockReply, logger, mockGateway, deps);
+
+    const trackCallsAfterFirst = trackSpy.mock.calls.length;
+
+    await handleGitLabWebhook(requestWith('uuid-A'), mockReply, logger, mockGateway, deps);
+
+    expect(gateClaudeInvocation.invocationCount).toBe(1);
+    expect(trackSpy.mock.calls.length).toBe(trackCallsAfterFirst);
+    expect(noteCommentPostGateway.calls).toHaveLength(0);
+    expect(approvalRevocationGateway.calls).toHaveLength(0);
+    expect(mockReply.status).toHaveBeenLastCalledWith(200);
+  });
+
+  it('AC5: two distinct UUIDs each proceed to the chokepoint (two invocations)', async () => {
+    const idempotencyStore = new InMemoryIdempotencyStore({ ttlMs: 60_000, clock: () => 0 });
+    const gateClaudeInvocation = new StubGateClaudeInvocation();
+    const deps = createDeps(mockGateway, { idempotencyStore, gateClaudeInvocation });
+
+    await handleGitLabWebhook(requestWith('uuid-A'), mockReply, logger, mockGateway, deps);
+    await handleGitLabWebhook(requestWith('uuid-B'), mockReply, logger, mockGateway, deps);
+
+    expect(gateClaudeInvocation.invocationCount).toBe(2);
+  });
+
+  it('AC6: a missing UUID reaches the chokepoint once and records no dedup entry', async () => {
+    const idempotencyStore = new StubIdempotencyStore();
+    const gateClaudeInvocation = new StubGateClaudeInvocation();
+    const deps = createDeps(mockGateway, { idempotencyStore, gateClaudeInvocation });
+
+    await handleGitLabWebhook(requestWith(undefined), mockReply, logger, mockGateway, deps);
+
+    expect(gateClaudeInvocation.invocationCount).toBe(1);
+    expect(idempotencyStore.recordedKeys).toHaveLength(0);
+    expect(idempotencyStore.entryCount).toBe(0);
+    expect(mockReply.status).not.toHaveBeenCalledWith(400);
+    expect(mockReply.status).not.toHaveBeenCalledWith(409);
+  });
+});

--- a/src/tests/units/modules/platform-integration/interface-adapters/gateways/inMemoryIdempotencyStore.test.ts
+++ b/src/tests/units/modules/platform-integration/interface-adapters/gateways/inMemoryIdempotencyStore.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { InMemoryIdempotencyStore } from '@/modules/platform-integration/interface-adapters/gateways/inMemoryIdempotencyStore.gateway.js';
+
+function createClock(start: number): { now: () => number; advance: (ms: number) => void } {
+  let current = start;
+  return {
+    now: () => current,
+    advance: (ms: number) => {
+      current += ms;
+    },
+  };
+}
+
+describe('InMemoryIdempotencyStore', () => {
+  it('records a new key as absent (returns true on first call)', async () => {
+    const store = new InMemoryIdempotencyStore({ ttlMs: 1000, clock: () => 0 });
+
+    const firstResult = await store.recordIfAbsent('event-1');
+
+    expect(firstResult).toBe(true);
+  });
+
+  it('reports an already-present key (returns false on immediate second call)', async () => {
+    const store = new InMemoryIdempotencyStore({ ttlMs: 1000, clock: () => 0 });
+
+    await store.recordIfAbsent('event-1');
+    const secondResult = await store.recordIfAbsent('event-1');
+
+    expect(secondResult).toBe(false);
+  });
+
+  it('treats distinct keys independently', async () => {
+    const store = new InMemoryIdempotencyStore({ ttlMs: 1000, clock: () => 0 });
+
+    const first = await store.recordIfAbsent('event-1');
+    const second = await store.recordIfAbsent('event-2');
+
+    expect(first).toBe(true);
+    expect(second).toBe(true);
+  });
+
+  it('keeps a key blocked while still within the TTL window', async () => {
+    const clock = createClock(0);
+    const store = new InMemoryIdempotencyStore({ ttlMs: 1000, clock: clock.now });
+
+    await store.recordIfAbsent('event-1');
+    clock.advance(999);
+    const withinWindow = await store.recordIfAbsent('event-1');
+
+    expect(withinWindow).toBe(false);
+  });
+
+  it('re-accepts a key after the TTL window elapses', async () => {
+    const clock = createClock(0);
+    const store = new InMemoryIdempotencyStore({ ttlMs: 1000, clock: clock.now });
+
+    await store.recordIfAbsent('event-1');
+    clock.advance(1001);
+    const afterWindow = await store.recordIfAbsent('event-1');
+
+    expect(afterWindow).toBe(true);
+  });
+});

--- a/src/tests/units/modules/platform-integration/interface-adapters/transport/clientIpResolver.forwardedFor.gateway.test.ts
+++ b/src/tests/units/modules/platform-integration/interface-adapters/transport/clientIpResolver.forwardedFor.gateway.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { ForwardedForClientIpResolver } from '@/modules/platform-integration/interface-adapters/gateways/transport/clientIpResolver.forwardedFor.gateway.js';
+
+describe('ForwardedForClientIpResolver', () => {
+  it('returns null and never reads forwardedFor when the socket is not trusted', () => {
+    const resolver = new ForwardedForClientIpResolver();
+
+    const resolved = resolver.resolve({
+      socketTrusted: false,
+      forwardedFor: '10.20.30.40, 127.0.0.1',
+    });
+
+    expect(resolved).toBeNull();
+  });
+
+  it('resolves the leftmost forwarded address once the socket is trusted', () => {
+    const resolver = new ForwardedForClientIpResolver();
+
+    const resolved = resolver.resolve({
+      socketTrusted: true,
+      forwardedFor: '10.20.30.40, 127.0.0.1',
+    });
+
+    expect(resolved).toBe('10.20.30.40');
+  });
+
+  it('returns null when trusted but no forwarded address is present', () => {
+    const resolver = new ForwardedForClientIpResolver();
+
+    const resolved = resolver.resolve({
+      socketTrusted: true,
+      forwardedFor: null,
+    });
+
+    expect(resolved).toBeNull();
+  });
+});

--- a/src/tests/units/modules/platform-integration/interface-adapters/transport/transportGuard.middleware.test.ts
+++ b/src/tests/units/modules/platform-integration/interface-adapters/transport/transportGuard.middleware.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { transportGuardMiddleware } from '@/modules/platform-integration/interface-adapters/controllers/webhook/transportGuard.middleware.js';
+import { ForwardedForClientIpResolver } from '@/modules/platform-integration/interface-adapters/gateways/transport/clientIpResolver.forwardedFor.gateway.js';
+import type { TransportGuardConfig } from '@/modules/platform-integration/interface-adapters/controllers/webhook/transportGuard.middleware.js';
+
+const TRUSTED_HOP = '127.0.0.1';
+
+const config: TransportGuardConfig = {
+  trustedHopAddress: TRUSTED_HOP,
+  allowedCidrRanges: ['10.20.30.0/24'],
+};
+
+interface FakeRequest {
+  socket: { remoteAddress: string | undefined };
+  headers: Record<string, string | undefined>;
+}
+
+class FakeResponse {
+  statusCode: number | null = null;
+  sent = false;
+
+  code(status: number): this {
+    this.statusCode = status;
+    return this;
+  }
+
+  send(): this {
+    this.sent = true;
+    return this;
+  }
+}
+
+function buildRequest(overrides: Partial<{ remoteAddress: string; proto: string; forwardedFor: string }> = {}): FakeRequest {
+  return {
+    socket: { remoteAddress: overrides.remoteAddress ?? TRUSTED_HOP },
+    headers: {
+      'x-forwarded-proto': overrides.proto ?? 'https',
+      'x-forwarded-for': overrides.forwardedFor ?? '10.20.30.40, 127.0.0.1',
+    },
+  };
+}
+
+describe('transportGuardMiddleware (AC5)', () => {
+  it('calls next on a fully valid transport and never sends a rejection', () => {
+    let nextCalled = false;
+    const request = buildRequest();
+    const reply = new FakeResponse();
+
+    transportGuardMiddleware(
+      { request, reply, next: () => { nextCalled = true; }, resolver: new ForwardedForClientIpResolver() },
+      config,
+    );
+
+    expect(nextCalled).toBe(true);
+    expect(reply.statusCode).toBeNull();
+    expect(reply.sent).toBe(false);
+  });
+
+  it('rejects with 403 and never calls next when the socket is untrusted', () => {
+    let nextCalled = false;
+    const request = buildRequest({ remoteAddress: '203.0.113.7' });
+    const reply = new FakeResponse();
+
+    transportGuardMiddleware(
+      { request, reply, next: () => { nextCalled = true; }, resolver: new ForwardedForClientIpResolver() },
+      config,
+    );
+
+    expect(nextCalled).toBe(false);
+    expect(reply.statusCode).toBe(403);
+    expect(reply.sent).toBe(true);
+  });
+
+  it('rejects with 403 when the forwarded protocol is not https', () => {
+    let nextCalled = false;
+    const request = buildRequest({ proto: 'http' });
+    const reply = new FakeResponse();
+
+    transportGuardMiddleware(
+      { request, reply, next: () => { nextCalled = true; }, resolver: new ForwardedForClientIpResolver() },
+      config,
+    );
+
+    expect(nextCalled).toBe(false);
+    expect(reply.statusCode).toBe(403);
+  });
+
+  it('rejects with 403 when the resolved client ip is off the allowlist', () => {
+    let nextCalled = false;
+    const request = buildRequest({ forwardedFor: '192.168.1.1' });
+    const reply = new FakeResponse();
+
+    transportGuardMiddleware(
+      { request, reply, next: () => { nextCalled = true; }, resolver: new ForwardedForClientIpResolver() },
+      config,
+    );
+
+    expect(nextCalled).toBe(false);
+    expect(reply.statusCode).toBe(403);
+  });
+});

--- a/src/tests/units/modules/platform-integration/services/autoExecutorActionFilter.test.ts
+++ b/src/tests/units/modules/platform-integration/services/autoExecutorActionFilter.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import {
+  filterAutoExecutorActions,
+  capabilityForAction,
+} from '@/modules/platform-integration/services/autoExecutorActionFilter.js'
+import type { ReviewAction } from '@/modules/review-execution/entities/reviewAction/reviewAction.js'
+
+describe('auto executor action filter (AC6/AC7)', () => {
+  it('maps each action type to its required capability (AC5)', () => {
+    expect(capabilityForAction({ type: 'FETCH_THREADS' })).toBe('readMr')
+    expect(capabilityForAction({ type: 'POST_COMMENT', body: 'x' })).toBe('postComment')
+    expect(capabilityForAction({ type: 'THREAD_REPLY', threadId: '1', message: 'x' })).toBe(
+      'postComment',
+    )
+    expect(capabilityForAction({ type: 'POST_INLINE_COMMENT', filePath: 'a', line: 1, body: 'x' })).toBe(
+      'postComment',
+    )
+    expect(capabilityForAction({ type: 'THREAD_RESOLVE', threadId: '1' })).toBe('threadResolve')
+    expect(capabilityForAction({ type: 'ADD_LABEL', label: 'x' })).toBe('addLabel')
+  })
+
+  it('AC6: drops THREAD_RESOLVE from the auto action set', () => {
+    const actions: ReviewAction[] = [
+      { type: 'POST_COMMENT', body: 'hello' },
+      { type: 'THREAD_RESOLVE', threadId: '42' },
+    ]
+    const { allowed, dropped } = filterAutoExecutorActions(actions)
+    expect(allowed).toEqual([{ type: 'POST_COMMENT', body: 'hello' }])
+    expect(dropped).toEqual([{ type: 'THREAD_RESOLVE', threadId: '42' }])
+  })
+
+  it('AC7: keeps POST_COMMENT and FETCH_THREADS, drops THREAD_RESOLVE, no throw', () => {
+    const actions: ReviewAction[] = [
+      { type: 'POST_COMMENT', body: 'one' },
+      { type: 'THREAD_RESOLVE', threadId: '7' },
+      { type: 'FETCH_THREADS' },
+    ]
+    const { allowed, dropped } = filterAutoExecutorActions(actions)
+    expect(allowed).toEqual([{ type: 'POST_COMMENT', body: 'one' }, { type: 'FETCH_THREADS' }])
+    expect(dropped).toEqual([{ type: 'THREAD_RESOLVE', threadId: '7' }])
+  })
+
+  it('AC6: drops ADD_LABEL since it exceeds the read+postComment set', () => {
+    const actions: ReviewAction[] = [{ type: 'ADD_LABEL', label: 'reviewed' }]
+    const { allowed, dropped } = filterAutoExecutorActions(actions)
+    expect(allowed).toEqual([])
+    expect(dropped).toEqual([{ type: 'ADD_LABEL', label: 'reviewed' }])
+  })
+})

--- a/src/tests/units/modules/platform-integration/services/autoExecutorCapabilityGate.test.ts
+++ b/src/tests/units/modules/platform-integration/services/autoExecutorCapabilityGate.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import {
+  EXECUTOR_CAPABILITY_TABLE,
+  AUTO_EXECUTOR_CAPABILITIES,
+} from '@/modules/platform-integration/entities/executorToken/executorCapability.js'
+import {
+  capabilityForAction,
+  filterAutoExecutorActions,
+} from '@/modules/platform-integration/services/autoExecutorActionFilter.js'
+import { reviewActionSchema } from '@/modules/review-execution/entities/reviewAction/reviewAction.schema.js'
+import type { ReviewAction } from '@/modules/review-execution/entities/reviewAction/reviewAction.js'
+
+// AC8 — merge-blocking privilege contract gate.
+// This structural test pins the production auto-executor capability set to exactly
+// {readMr, postComment}. Re-wiring revoke/THREAD_RESOLVE into the auto path, or
+// widening the token's capability set, turns this red.
+describe('auto executor capability gate (AC8)', () => {
+  it('freezes the auto capability set to exactly {readMr, postComment}', () => {
+    expect([...AUTO_EXECUTOR_CAPABILITIES].sort()).toEqual(['postComment', 'readMr'])
+  })
+
+  it('keeps threadResolve and revoke declared as non-auto in the source-of-truth table', () => {
+    expect(EXECUTOR_CAPABILITY_TABLE.threadResolve.autoPath).toBe(false)
+    expect(EXECUTOR_CAPABILITY_TABLE.revoke.autoPath).toBe(false)
+  })
+
+  it('lets every parseable review action verb through the production filter only if its capability is auto', () => {
+    const sampleByType: Record<string, ReviewAction> = {
+      FETCH_THREADS: { type: 'FETCH_THREADS' },
+      POST_COMMENT: { type: 'POST_COMMENT', body: 'b' },
+      THREAD_REPLY: { type: 'THREAD_REPLY', threadId: '1', message: 'm' },
+      POST_INLINE_COMMENT: { type: 'POST_INLINE_COMMENT', filePath: 'f', line: 1, body: 'b' },
+      THREAD_RESOLVE: { type: 'THREAD_RESOLVE', threadId: '1' },
+      ADD_LABEL: { type: 'ADD_LABEL', label: 'l' },
+    }
+
+    const allUnionTypes = reviewActionSchema.options.map(option => option.shape.type.value)
+    // Guard: the gate must cover every verb the schema can parse.
+    expect(Object.keys(sampleByType).sort()).toEqual([...allUnionTypes].sort())
+
+    const actions = Object.values(sampleByType)
+    const { allowed, dropped } = filterAutoExecutorActions(actions)
+
+    const autoVerbs = ['FETCH_THREADS', 'POST_COMMENT', 'THREAD_REPLY', 'POST_INLINE_COMMENT']
+    const nonAutoVerbs = ['THREAD_RESOLVE', 'ADD_LABEL']
+
+    expect(allowed.map(a => a.type).sort()).toEqual([...autoVerbs].sort())
+    expect(dropped.map(a => a.type).sort()).toEqual([...nonAutoVerbs].sort())
+
+    for (const action of allowed) {
+      expect(['readMr', 'postComment']).toContain(capabilityForAction(action))
+    }
+  })
+})

--- a/src/tests/units/modules/platform-integration/services/pinnedThreadFetchTarget.test.ts
+++ b/src/tests/units/modules/platform-integration/services/pinnedThreadFetchTarget.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { resolvePinnedThreadFetchTarget } from '@/modules/platform-integration/services/pinnedThreadFetchTarget.js'
+
+class RecordingThreadFetch {
+  public readonly calls: Array<{ projectPath: string; mrNumber: number }> = []
+  fetchThreads = (projectPath: string, mrNumber: number) => {
+    this.calls.push({ projectPath, mrNumber })
+    return []
+  }
+}
+
+describe('pinned thread-fetch target provenance (AC9)', () => {
+  it('resolves the validated pair when project is configured and mrNumber matches the gated MR', () => {
+    const target = resolvePinnedThreadFetchTarget({
+      payloadProjectPath: 'group/proj',
+      payloadMrNumber: 5,
+      findRepository: () => ({ projectPath: 'group/proj', localPath: '/repo' }),
+      gatedMrNumber: 5,
+    })
+
+    expect(target).toEqual({ projectPath: 'group/proj', mrNumber: 5 })
+  })
+
+  it('fails closed (null) when projectPath is not in the registry', () => {
+    const target = resolvePinnedThreadFetchTarget({
+      payloadProjectPath: 'attacker/unknown',
+      payloadMrNumber: 5,
+      findRepository: () => null,
+      gatedMrNumber: 5,
+    })
+
+    expect(target).toBeNull()
+  })
+
+  it('fails closed (null) when payload mrNumber differs from the gated MR', () => {
+    const target = resolvePinnedThreadFetchTarget({
+      payloadProjectPath: 'group/proj',
+      payloadMrNumber: 999,
+      findRepository: () => ({ projectPath: 'group/proj', localPath: '/repo' }),
+      gatedMrNumber: 5,
+    })
+
+    expect(target).toBeNull()
+  })
+
+  it('AC9(1): unrecognized project means fetchThreads is never called', () => {
+    const fetch = new RecordingThreadFetch()
+    const target = resolvePinnedThreadFetchTarget({
+      payloadProjectPath: 'attacker/unknown',
+      payloadMrNumber: 5,
+      findRepository: () => null,
+      gatedMrNumber: 5,
+    })
+    if (target) fetch.fetchThreads(target.projectPath, target.mrNumber)
+
+    expect(fetch.calls).toHaveLength(0)
+  })
+
+  it('AC9(2): forged mrNumber never retargets fetchThreads at the foreign MR', () => {
+    const fetch = new RecordingThreadFetch()
+    const target = resolvePinnedThreadFetchTarget({
+      payloadProjectPath: 'group/proj',
+      payloadMrNumber: 999,
+      findRepository: () => ({ projectPath: 'group/proj', localPath: '/repo' }),
+      gatedMrNumber: 5,
+    })
+    if (target) fetch.fetchThreads(target.projectPath, target.mrNumber)
+
+    expect(fetch.calls.find(c => c.mrNumber === 999)).toBeUndefined()
+    expect(fetch.calls).toHaveLength(0)
+  })
+
+  it('uses the configured projectPath, never the raw payload, to fetch', () => {
+    const fetch = new RecordingThreadFetch()
+    const target = resolvePinnedThreadFetchTarget({
+      payloadProjectPath: 'group/proj',
+      payloadMrNumber: 5,
+      findRepository: () => ({ projectPath: 'group/proj-canonical', localPath: '/repo' }),
+      gatedMrNumber: 5,
+    })
+    if (target) fetch.fetchThreads(target.projectPath, target.mrNumber)
+
+    expect(fetch.calls).toEqual([{ projectPath: 'group/proj-canonical', mrNumber: 5 }])
+  })
+})

--- a/src/tests/units/modules/platform-integration/services/scopedExecutorEnvironment.test.ts
+++ b/src/tests/units/modules/platform-integration/services/scopedExecutorEnvironment.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildScopedExecutorEnvironment,
+  ENV_ALLOWLIST,
+  MissingExecutorTokenError,
+} from '@/modules/platform-integration/services/scopedExecutorEnvironment.js'
+
+class RecordingFileWriter {
+  public readonly writes: Array<{ path: string; contents: string }> = []
+  write(path: string, contents: string): void {
+    this.writes.push({ path, contents })
+  }
+}
+
+const TOKEN = 'glpat-service-token-xyz'
+const TEMP_ROOT = '/tmp/reviewflow-executor-abc123'
+
+describe('scoped executor environment (AC1/AC2/AC3/AC4)', () => {
+  it('AC1: throws fail-closed when the service token is absent', () => {
+    const fileWriter = new RecordingFileWriter()
+    expect(() =>
+      buildScopedExecutorEnvironment({
+        parentEnv: { PATH: '/usr/bin' },
+        isolatedDir: TEMP_ROOT,
+        fileWriter,
+      }),
+    ).toThrow(MissingExecutorTokenError)
+    expect(fileWriter.writes).toHaveLength(0)
+  })
+
+  it('AC1: throws fail-closed when the service token is empty', () => {
+    const fileWriter = new RecordingFileWriter()
+    expect(() =>
+      buildScopedExecutorEnvironment({
+        parentEnv: { REVIEWFLOW_EXECUTOR_TOKEN: '   ' },
+        isolatedDir: TEMP_ROOT,
+        fileWriter,
+      }),
+    ).toThrow(MissingExecutorTokenError)
+    expect(fileWriter.writes).toHaveLength(0)
+  })
+
+  it('AC1: returns a configured environment when the token is present', () => {
+    const fileWriter = new RecordingFileWriter()
+    const result = buildScopedExecutorEnvironment({
+      parentEnv: { REVIEWFLOW_EXECUTOR_TOKEN: TOKEN, PATH: '/usr/bin' },
+      isolatedDir: TEMP_ROOT,
+      fileWriter,
+    })
+    expect(result.env).toBeDefined()
+    expect(fileWriter.writes).toHaveLength(1)
+  })
+
+  it('AC2: child env keyset is a subset of the declared allowlist', () => {
+    const fileWriter = new RecordingFileWriter()
+    const { env } = buildScopedExecutorEnvironment({
+      parentEnv: {
+        REVIEWFLOW_EXECUTOR_TOKEN: TOKEN,
+        PATH: '/usr/bin',
+        LANG: 'en_US.UTF-8',
+        AMBIENT_ADMIN_TOKEN: 'canary',
+      },
+      isolatedDir: TEMP_ROOT,
+      fileWriter,
+    })
+    for (const key of Object.keys(env)) {
+      expect(ENV_ALLOWLIST).toContain(key)
+    }
+  })
+
+  it('AC2: a parent canary secret is absent from the child env', () => {
+    const fileWriter = new RecordingFileWriter()
+    const { env } = buildScopedExecutorEnvironment({
+      parentEnv: {
+        REVIEWFLOW_EXECUTOR_TOKEN: TOKEN,
+        PATH: '/usr/bin',
+        AMBIENT_ADMIN_TOKEN: 'canary',
+      },
+      isolatedDir: TEMP_ROOT,
+      fileWriter,
+    })
+    expect('AMBIENT_ADMIN_TOKEN' in env).toBe(false)
+  })
+
+  it('AC3: no child env value equals the token string', () => {
+    const fileWriter = new RecordingFileWriter()
+    const { env } = buildScopedExecutorEnvironment({
+      parentEnv: { REVIEWFLOW_EXECUTOR_TOKEN: TOKEN, PATH: '/usr/bin' },
+      isolatedDir: TEMP_ROOT,
+      fileWriter,
+    })
+    for (const value of Object.values(env)) {
+      expect(value).not.toBe(TOKEN)
+    }
+  })
+
+  it('AC3: the token appears only in the rendered config-file contents', () => {
+    const fileWriter = new RecordingFileWriter()
+    buildScopedExecutorEnvironment({
+      parentEnv: { REVIEWFLOW_EXECUTOR_TOKEN: TOKEN, PATH: '/usr/bin' },
+      isolatedDir: TEMP_ROOT,
+      fileWriter,
+    })
+    expect(fileWriter.writes[0]?.contents).toContain(TOKEN)
+  })
+
+  it('AC4: HOME and GLAB_CONFIG_DIR resolve under the isolated temp root', () => {
+    const fileWriter = new RecordingFileWriter()
+    const { env } = buildScopedExecutorEnvironment({
+      parentEnv: { REVIEWFLOW_EXECUTOR_TOKEN: TOKEN, PATH: '/usr/bin' },
+      isolatedDir: TEMP_ROOT,
+      fileWriter,
+    })
+    expect(env.HOME?.startsWith(TEMP_ROOT)).toBe(true)
+    expect(env.GLAB_CONFIG_DIR?.startsWith(TEMP_ROOT)).toBe(true)
+  })
+
+  it('AC4: the config file is written under GLAB_CONFIG_DIR/glab-cli/config.yml', () => {
+    const fileWriter = new RecordingFileWriter()
+    const { env } = buildScopedExecutorEnvironment({
+      parentEnv: { REVIEWFLOW_EXECUTOR_TOKEN: TOKEN, PATH: '/usr/bin' },
+      isolatedDir: TEMP_ROOT,
+      fileWriter,
+    })
+    expect(fileWriter.writes[0]?.path).toBe(`${env.GLAB_CONFIG_DIR}/glab-cli/config.yml`)
+  })
+
+  it('AC4: every written path stays under the isolated temp root', () => {
+    const fileWriter = new RecordingFileWriter()
+    buildScopedExecutorEnvironment({
+      parentEnv: { REVIEWFLOW_EXECUTOR_TOKEN: TOKEN, PATH: '/usr/bin' },
+      isolatedDir: TEMP_ROOT,
+      fileWriter,
+    })
+    for (const write of fileWriter.writes) {
+      expect(write.path.startsWith(TEMP_ROOT)).toBe(true)
+    }
+  })
+})

--- a/src/tests/units/modules/platform-integration/usecases/isTrustedActor.usecase.test.ts
+++ b/src/tests/units/modules/platform-integration/usecases/isTrustedActor.usecase.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { IsTrustedActorUseCase } from '@/modules/platform-integration/usecases/isTrustedActor.usecase.js';
+import { StubMemberAccessGateway } from '@/tests/stubs/memberAccess.stub.js';
+import { MEMBER_ACCESS_LEVELS } from '@/modules/platform-integration/entities/memberAccess/memberAccess.js';
+
+describe('IsTrustedActorUseCase', () => {
+  let gateway: StubMemberAccessGateway;
+  let useCase: IsTrustedActorUseCase;
+
+  beforeEach(() => {
+    gateway = new StubMemberAccessGateway();
+    useCase = new IsTrustedActorUseCase(gateway);
+  });
+
+  it('trusts a Developer+ actor', async () => {
+    gateway.setAccess('alice', MEMBER_ACCESS_LEVELS.developer);
+
+    const trusted = await useCase.execute({ username: 'alice', projectPath: 'org/project' });
+
+    expect(trusted).toBe(true);
+    expect(gateway.calls).toEqual([{ projectPath: 'org/project', username: 'alice' }]);
+  });
+
+  it('does not trust an actor below Developer', async () => {
+    gateway.setAccess('bob', MEMBER_ACCESS_LEVELS.reporter);
+
+    const trusted = await useCase.execute({ username: 'bob', projectPath: 'org/project' });
+
+    expect(trusted).toBe(false);
+  });
+
+  it('does not trust an unknown username (fail-closed)', async () => {
+    const trusted = await useCase.execute({ username: 'stranger', projectPath: 'org/project' });
+
+    expect(trusted).toBe(false);
+  });
+
+  it('does not trust when the gateway throws (fail-closed)', async () => {
+    gateway.setShouldFail(true);
+
+    const trusted = await useCase.execute({ username: 'alice', projectPath: 'org/project' });
+
+    expect(trusted).toBe(false);
+  });
+});

--- a/src/tests/units/modules/platform-integration/usecases/transport/evaluateTransport.usecase.test.ts
+++ b/src/tests/units/modules/platform-integration/usecases/transport/evaluateTransport.usecase.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateTransport } from '@/modules/platform-integration/usecases/transport/evaluateTransport.usecase.js';
+import { TransportContextFactory } from '@/tests/factories/transportContext.factory.js';
+
+describe('evaluateTransport', () => {
+  describe('AC1 - untrusted socket', () => {
+    it('rejects with 403 when the direct socket address is not the trusted hop, ignoring headers', () => {
+      const context = TransportContextFactory.valid({
+        directSocketAddress: '203.0.113.7',
+        forwardedProto: 'https',
+        resolvedClientIp: '10.20.30.40',
+      });
+
+      const decision = evaluateTransport(context);
+
+      expect(decision).toEqual({ kind: 'reject', status: 403, reason: 'untrusted-socket' });
+    });
+
+    it('does not consult the protocol or client ip once the socket fails', () => {
+      const context = TransportContextFactory.valid({
+        directSocketAddress: '203.0.113.7',
+        forwardedProto: 'http',
+        resolvedClientIp: null,
+        allowedCidrRanges: [],
+      });
+
+      const decision = evaluateTransport(context);
+
+      expect(decision.kind).toBe('reject');
+    });
+  });
+
+  describe('AC2 - non-https', () => {
+    it('rejects with 403 when the forwarded protocol is not https', () => {
+      const context = TransportContextFactory.valid({ forwardedProto: 'http' });
+
+      const decision = evaluateTransport(context);
+
+      expect(decision).toEqual({ kind: 'reject', status: 403, reason: 'non-https' });
+    });
+
+    it('rejects with 403 when no forwarded protocol is present', () => {
+      const context = TransportContextFactory.valid({ forwardedProto: null });
+
+      const decision = evaluateTransport(context);
+
+      expect(decision).toEqual({ kind: 'reject', status: 403, reason: 'non-https' });
+    });
+  });
+
+  describe('AC3 - allowlisted, https, hop-trusted', () => {
+    it('accepts a fully valid transport context', () => {
+      const context = TransportContextFactory.valid();
+
+      const decision = evaluateTransport(context);
+
+      expect(decision).toEqual({ kind: 'accept' });
+    });
+  });
+
+  describe('AC4 - off-allowlist', () => {
+    it('rejects with 403 when the resolved client ip is outside every configured range', () => {
+      const context = TransportContextFactory.valid({
+        resolvedClientIp: '192.168.1.1',
+        allowedCidrRanges: ['10.20.30.0/24'],
+      });
+
+      const decision = evaluateTransport(context);
+
+      expect(decision).toEqual({ kind: 'reject', status: 403, reason: 'off-allowlist' });
+    });
+
+    it('rejects with 403 when the client ip could not be resolved', () => {
+      const context = TransportContextFactory.valid({ resolvedClientIp: null });
+
+      const decision = evaluateTransport(context);
+
+      expect(decision).toEqual({ kind: 'reject', status: 403, reason: 'off-allowlist' });
+    });
+
+    it('accepts when the resolved client ip falls inside one of several ranges', () => {
+      const context = TransportContextFactory.valid({
+        resolvedClientIp: '172.16.5.9',
+        allowedCidrRanges: ['10.0.0.0/8', '172.16.0.0/12'],
+      });
+
+      const decision = evaluateTransport(context);
+
+      expect(decision).toEqual({ kind: 'accept' });
+    });
+  });
+});

--- a/src/tests/units/modules/review-execution/entities/actionProvenance/actionProvenance.test.ts
+++ b/src/tests/units/modules/review-execution/entities/actionProvenance/actionProvenance.test.ts
@@ -1,0 +1,28 @@
+import { resolveProvenance } from '@/modules/review-execution/entities/actionProvenance/actionProvenance.js'
+
+describe('resolveProvenance (AC-1 fail-closed provenance)', () => {
+  const nonCanonical: unknown[] = [
+    undefined,
+    null,
+    '',
+    'TRUSTED',
+    'trusted ',
+    ' trusted',
+    'Trusted',
+    'untrusted',
+    'admin',
+    {},
+    0,
+    true,
+  ]
+
+  for (const input of nonCanonical) {
+    it(`resolves non-canonical input ${JSON.stringify(input)} to untrusted`, () => {
+      expect(resolveProvenance(input)).toBe('untrusted')
+    })
+  }
+
+  it('resolves the exact canonical token "trusted" to trusted', () => {
+    expect(resolveProvenance('trusted')).toBe('trusted')
+  })
+})

--- a/src/tests/units/modules/review-execution/interface-adapters/gateways/threadInventory.gitlab.gateway.test.ts
+++ b/src/tests/units/modules/review-execution/interface-adapters/gateways/threadInventory.gitlab.gateway.test.ts
@@ -1,0 +1,49 @@
+import { GitLabThreadInventoryGateway } from '@/modules/review-execution/interface-adapters/gateways/threadInventory.gitlab.gateway.js'
+
+class RecordingExecutor {
+  readonly commands: string[] = []
+  private responses: Array<{ headers: string; body: string }> = []
+  setResponses(responses: Array<{ headers: string; body: string }>): void {
+    this.responses = responses
+  }
+  run = (command: string): string => {
+    this.commands.push(command)
+    const index = this.commands.length - 1
+    const response = this.responses[index]
+    if (!response) throw new Error('no response configured')
+    return `${response.headers}\r\n\r\n${response.body}`
+  }
+}
+
+describe('GitLabThreadInventoryGateway', () => {
+  it('requests the discussions endpoint with the pinned project and MR, including headers', () => {
+    const executor = new RecordingExecutor()
+    executor.setResponses([
+      {
+        headers: 'X-Total-Pages: 1',
+        body: JSON.stringify([{ id: 'd1' }, { id: 'd2' }]),
+      },
+    ])
+
+    const gateway = new GitLabThreadInventoryGateway(executor.run)
+    const page = gateway.fetchPage('group/sub/project', 7, 1)
+
+    expect(executor.commands[0]).toContain('group%2Fsub%2Fproject')
+    expect(executor.commands[0]).toContain('/merge_requests/7/discussions')
+    expect(executor.commands[0]).toContain('page=1')
+    expect(page.totalPages).toBe(1)
+    expect(page.threadIds.sort()).toEqual(['d1', 'd2'])
+  })
+
+  it('reads totalPages from the X-Total-Pages header so completeness can be proven', () => {
+    const executor = new RecordingExecutor()
+    executor.setResponses([
+      { headers: 'X-Total-Pages: 3', body: JSON.stringify([{ id: 'a' }]) },
+    ])
+
+    const gateway = new GitLabThreadInventoryGateway(executor.run)
+    const page = gateway.fetchPage('g/p', 1, 1)
+
+    expect(page.totalPages).toBe(3)
+  })
+})

--- a/src/tests/units/modules/review-execution/services/constrainActionSurface.parity.test.ts
+++ b/src/tests/units/modules/review-execution/services/constrainActionSurface.parity.test.ts
@@ -1,0 +1,36 @@
+import { constrainActionSurface } from '@/modules/review-execution/services/constrainActionSurface.js'
+import { parseThreadActions } from '@/modules/review-execution/services/threadActionsParser.js'
+import type { ReviewAction } from '@/modules/review-execution/entities/reviewAction/reviewAction.js'
+
+describe('AC-3 parser drops non-allowlisted token types', () => {
+  it('parses only allowlisted markers and ignores unknown ones', () => {
+    const stdout = '[UNKNOWN:1] [DROP_DB] [POST_COMMENT:hello]'
+    const parsed = parseThreadActions(stdout)
+    expect(parsed).toEqual([{ type: 'POST_COMMENT', body: 'hello' }])
+  })
+})
+
+describe('AC-4 stdout / context-file parity', () => {
+  it('produces a byte-identical constrained set whichever path the actions arrive from', () => {
+    const stdoutActions = parseThreadActions(
+      '[THREAD_RESOLVE:10][THREAD_REPLY:999:nope][POST_COMMENT:hi][FETCH_THREADS]'
+    )
+    const contextFileActions: ReviewAction[] = [
+      { type: 'THREAD_RESOLVE', threadId: '10' },
+      { type: 'THREAD_REPLY', threadId: '999', message: 'nope' },
+      { type: 'POST_COMMENT', body: 'hi' },
+      { type: 'FETCH_THREADS' },
+    ]
+
+    const constraints = {
+      provenance: 'untrusted' as const,
+      threadInventory: new Set(['10']),
+    }
+
+    const fromStdout = constrainActionSurface(stdoutActions, constraints)
+    const fromContextFile = constrainActionSurface(contextFileActions, constraints)
+
+    expect(fromStdout).toEqual(fromContextFile)
+    expect(fromStdout).toEqual([{ type: 'POST_COMMENT', body: 'hi' }])
+  })
+})

--- a/src/tests/units/modules/review-execution/services/constrainActionSurface.test.ts
+++ b/src/tests/units/modules/review-execution/services/constrainActionSurface.test.ts
@@ -1,0 +1,128 @@
+import { constrainActionSurface } from '@/modules/review-execution/services/constrainActionSurface.js'
+import type { ReviewAction } from '@/modules/review-execution/entities/reviewAction/reviewAction.js'
+
+const inventory = (...ids: string[]): ReadonlySet<string> => new Set(ids)
+
+describe('constrainActionSurface', () => {
+  describe('AC-2 untrusted write surface = postComment only', () => {
+    it('keeps only postComment for an untrusted job, dropping resolve/reply/fetch', () => {
+      const actions: ReviewAction[] = [
+        { type: 'THREAD_RESOLVE', threadId: '10' },
+        { type: 'THREAD_REPLY', threadId: '10', message: 'hi' },
+        { type: 'POST_COMMENT', body: 'ok' },
+        { type: 'FETCH_THREADS' },
+      ]
+
+      const result = constrainActionSurface(actions, {
+        provenance: 'untrusted',
+        threadInventory: inventory('10'),
+      })
+
+      expect(result).toEqual([{ type: 'POST_COMMENT', body: 'ok' }])
+    })
+  })
+
+  describe('AC-5 FETCH_THREADS restricted to trusted (read-amplification gate)', () => {
+    it('drops FETCH_THREADS for untrusted', () => {
+      const result = constrainActionSurface([{ type: 'FETCH_THREADS' }], {
+        provenance: 'untrusted',
+        threadInventory: inventory('10'),
+      })
+      expect(result).toEqual([])
+    })
+
+    it('keeps FETCH_THREADS for trusted', () => {
+      const result = constrainActionSurface([{ type: 'FETCH_THREADS' }], {
+        provenance: 'trusted',
+        threadInventory: inventory('10'),
+      })
+      expect(result).toEqual([{ type: 'FETCH_THREADS' }])
+    })
+  })
+
+  describe('AC-6 THREAD_RESOLVE target validation', () => {
+    it('keeps in-set ids (with trim) and drops out-of-set on a trusted job', () => {
+      const actions: ReviewAction[] = [
+        { type: 'THREAD_RESOLVE', threadId: '10' },
+        { type: 'THREAD_RESOLVE', threadId: '999' },
+        { type: 'THREAD_RESOLVE', threadId: '11 ' },
+      ]
+      const result = constrainActionSurface(actions, {
+        provenance: 'trusted',
+        threadInventory: inventory('10', '11'),
+      })
+      expect(result).toEqual([
+        { type: 'THREAD_RESOLVE', threadId: '10' },
+        { type: 'THREAD_RESOLVE', threadId: '11' },
+      ])
+    })
+  })
+
+  describe('AC-7 THREAD_REPLY target validation', () => {
+    it('keeps in-set id and drops out-of-set on a trusted job', () => {
+      const actions: ReviewAction[] = [
+        { type: 'THREAD_REPLY', threadId: '10', message: 'a' },
+        { type: 'THREAD_REPLY', threadId: '999', message: 'b' },
+      ]
+      const result = constrainActionSurface(actions, {
+        provenance: 'trusted',
+        threadInventory: inventory('10', '11'),
+      })
+      expect(result).toEqual([{ type: 'THREAD_REPLY', threadId: '10', message: 'a' }])
+    })
+  })
+
+  describe('AC-8 target validation precedes provenance, both required for resolve/reply', () => {
+    const matrix = [
+      { provenance: 'trusted' as const, threadId: '10', kept: true },
+      { provenance: 'trusted' as const, threadId: '999', kept: false },
+      { provenance: 'untrusted' as const, threadId: '10', kept: false },
+      { provenance: 'untrusted' as const, threadId: '999', kept: false },
+    ]
+
+    for (const verb of ['THREAD_RESOLVE', 'THREAD_REPLY'] as const) {
+      for (const cell of matrix) {
+        it(`${verb} ${cell.provenance} ${cell.threadId} -> ${cell.kept ? 'kept' : 'dropped'}`, () => {
+          const action: ReviewAction =
+            verb === 'THREAD_RESOLVE'
+              ? { type: 'THREAD_RESOLVE', threadId: cell.threadId }
+              : { type: 'THREAD_REPLY', threadId: cell.threadId, message: 'x' }
+          const result = constrainActionSurface([action], {
+            provenance: cell.provenance,
+            threadInventory: inventory('10', '11'),
+          })
+          expect(result.length).toBe(cell.kept ? 1 : 0)
+        })
+      }
+    }
+  })
+
+  describe('AC-9 inventory is authoritative single source', () => {
+    it('acts only on ids present in the passed inventory, ignoring spoofed look-alike ids', () => {
+      const actions: ReviewAction[] = [
+        { type: 'THREAD_RESOLVE', threadId: '42' },
+        { type: 'THREAD_RESOLVE', threadId: '7' },
+      ]
+      const result = constrainActionSurface(actions, {
+        provenance: 'trusted',
+        threadInventory: inventory('42'),
+      })
+      expect(result).toEqual([{ type: 'THREAD_RESOLVE', threadId: '42' }])
+    })
+  })
+
+  describe('AC-10 empty inventory drops all resolve/reply', () => {
+    it('drops every resolve/reply when the authenticated inventory is empty (fail-closed)', () => {
+      const actions: ReviewAction[] = [
+        { type: 'THREAD_RESOLVE', threadId: '10' },
+        { type: 'THREAD_REPLY', threadId: '10', message: 'a' },
+        { type: 'POST_COMMENT', body: 'still ok' },
+      ]
+      const result = constrainActionSurface(actions, {
+        provenance: 'trusted',
+        threadInventory: inventory(),
+      })
+      expect(result).toEqual([{ type: 'POST_COMMENT', body: 'still ok' }])
+    })
+  })
+})

--- a/src/tests/units/modules/review-execution/services/contextActionsExecutor.autopath.test.ts
+++ b/src/tests/units/modules/review-execution/services/contextActionsExecutor.autopath.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { executeActionsFromContext } from '@/modules/review-execution/services/contextActionsExecutor.js'
+import type { ReviewContext } from '@/modules/review-execution/entities/reviewContext/reviewContext.js'
+
+class RecordingCommandExecutor {
+  public readonly calls: Array<{ command: string; args: string[]; cwd: string }> = []
+  run = (command: string, args: string[], cwd: string): void => {
+    this.calls.push({ command, args, cwd })
+  }
+}
+
+const silentLogger = {
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+  debug: () => undefined,
+}
+
+function buildContext(actions: ReviewContext['actions']): ReviewContext {
+  return {
+    localPath: '/repo',
+    mergeRequestId: 'gitlab-group/proj-5',
+    platform: 'gitlab',
+    projectPath: 'group/proj',
+    mergeRequestNumber: 5,
+    threads: [],
+    agents: [],
+    actions,
+    diffMetadata: undefined,
+  } as unknown as ReviewContext
+}
+
+describe('auto path context executor blocks write verbs (AC6/AC7)', () => {
+  it('AC6: never sends a THREAD_RESOLVE command to the executor', async () => {
+    const executor = new RecordingCommandExecutor()
+    const context = buildContext([
+      { type: 'POST_COMMENT', body: 'hello' },
+      { type: 'THREAD_RESOLVE', threadId: '42' },
+    ])
+
+    await executeActionsFromContext(context, '/repo', silentLogger, executor.run, null)
+
+    const resolveCalls = executor.calls.filter(c =>
+      c.args.some(a => a.includes('discussions/42') && c.args.includes('resolved=true')),
+    )
+    expect(resolveCalls).toHaveLength(0)
+  })
+
+  it('AC7: still posts the comment and does not throw on a mixed verb stream', async () => {
+    const executor = new RecordingCommandExecutor()
+    const context = buildContext([
+      { type: 'POST_COMMENT', body: 'one' },
+      { type: 'THREAD_RESOLVE', threadId: '7' },
+      { type: 'FETCH_THREADS' },
+    ])
+
+    const result = await executeActionsFromContext(
+      context,
+      '/repo',
+      silentLogger,
+      executor.run,
+      null,
+    )
+
+    const postCalls = executor.calls.filter(c => c.args.some(a => a.startsWith('body=')))
+    expect(postCalls).toHaveLength(1)
+    expect(result.total).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/src/tests/units/modules/review-execution/services/dispatchConstrainedActions.test.ts
+++ b/src/tests/units/modules/review-execution/services/dispatchConstrainedActions.test.ts
@@ -1,0 +1,147 @@
+import { dispatchConstrainedActions } from '@/modules/review-execution/services/dispatchConstrainedActions.js'
+import type { ReviewAction } from '@/modules/review-execution/entities/reviewAction/reviewAction.js'
+import type {
+  ThreadInventoryGateway,
+  ThreadInventoryPage,
+} from '@/modules/review-execution/entities/threadInventory/threadInventory.gateway.js'
+
+class RecordingExecutor {
+  readonly calls: Array<{ command: string; args: string[] }> = []
+  run = (command: string, args: string[]): void => {
+    this.calls.push({ command, args })
+  }
+}
+
+class RecordingLogger {
+  readonly errors: string[] = []
+  info(): void {}
+  warn(): void {}
+  debug(): void {}
+  error(_obj: object, message: string): void {
+    this.errors.push(message)
+  }
+}
+
+class StubInventoryGateway implements ThreadInventoryGateway {
+  private pages: ThreadInventoryPage[] = []
+  private failure: Error | null = null
+  setPages(pages: ThreadInventoryPage[]): void {
+    this.pages = pages
+  }
+  setFailure(error: Error): void {
+    this.failure = error
+  }
+  fetchPage(_p: string, _m: number, page: number): ThreadInventoryPage {
+    if (this.failure) throw this.failure
+    const found = this.pages.find(x => x.page === page)
+    if (!found) throw new Error(`no page ${page}`)
+    return found
+  }
+}
+
+const baseContext = {
+  platform: 'gitlab' as const,
+  projectPath: 'group/project',
+  mrNumber: 42,
+  localPath: '/tmp/repo',
+}
+
+function resolvedDiscussions(executor: RecordingExecutor): string[] {
+  return executor.calls
+    .filter(c => c.args.includes('PUT'))
+    .map(c => c.args.find(a => a.includes('/discussions/')) ?? '')
+}
+
+describe('dispatchConstrainedActions (breach closure: forged ids never reach live writes)', () => {
+  it('forged out-of-MR resolve id never produces a glab write call', async () => {
+    const executor = new RecordingExecutor()
+    const inventory = new StubInventoryGateway()
+    inventory.setPages([{ page: 1, totalPages: 1, threadIds: ['10'] }])
+
+    const actions: ReviewAction[] = [
+      { type: 'THREAD_RESOLVE', threadId: '999' },
+      { type: 'THREAD_RESOLVE', threadId: '10' },
+    ]
+
+    await dispatchConstrainedActions(actions, {
+      context: baseContext,
+      provenance: 'trusted',
+      inventoryGateway: inventory,
+      logger: new RecordingLogger(),
+      executor: executor.run,
+    })
+
+    const resolves = resolvedDiscussions(executor)
+    expect(resolves.some(r => r.includes('/discussions/999'))).toBe(false)
+    expect(resolves.filter(r => r.includes('/discussions/10')).length).toBe(1)
+  })
+
+  it('untrusted job: only postComment reaches the executor', async () => {
+    const executor = new RecordingExecutor()
+    const inventory = new StubInventoryGateway()
+    inventory.setPages([{ page: 1, totalPages: 1, threadIds: ['10'] }])
+
+    const actions: ReviewAction[] = [
+      { type: 'THREAD_RESOLVE', threadId: '10' },
+      { type: 'THREAD_REPLY', threadId: '10', message: 'x' },
+      { type: 'FETCH_THREADS' },
+      { type: 'POST_COMMENT', body: 'hi' },
+    ]
+
+    await dispatchConstrainedActions(actions, {
+      context: baseContext,
+      provenance: 'untrusted',
+      inventoryGateway: inventory,
+      logger: new RecordingLogger(),
+      executor: executor.run,
+    })
+
+    expect(executor.calls.length).toBe(1)
+    expect(executor.calls[0].args).toContain('POST')
+    expect(executor.calls[0].args.some(a => a.endsWith('/notes'))).toBe(true)
+  })
+
+  it('AC-10 fail-closed: when the authenticated inventory fetch fails, zero resolve/reply writes occur', async () => {
+    const executor = new RecordingExecutor()
+    const inventory = new StubInventoryGateway()
+    inventory.setFailure(new Error('auth failure'))
+    const logger = new RecordingLogger()
+
+    const actions: ReviewAction[] = [
+      { type: 'THREAD_RESOLVE', threadId: '10' },
+      { type: 'THREAD_REPLY', threadId: '10', message: 'x' },
+    ]
+
+    await dispatchConstrainedActions(actions, {
+      context: baseContext,
+      provenance: 'trusted',
+      inventoryGateway: inventory,
+      logger,
+      executor: executor.run,
+    })
+
+    expect(executor.calls.length).toBe(0)
+    expect(logger.errors.length).toBeGreaterThan(0)
+  })
+
+  it('AC-10.1 forged payload inventory is ignored; only authenticated ids are honored', async () => {
+    const executor = new RecordingExecutor()
+    const inventory = new StubInventoryGateway()
+    inventory.setPages([{ page: 1, totalPages: 1, threadIds: ['authentic-1'] }])
+
+    const actions: ReviewAction[] = [
+      { type: 'THREAD_RESOLVE', threadId: 'forged-1' },
+      { type: 'THREAD_REPLY', threadId: 'forged-2', message: 'x' },
+    ]
+
+    await dispatchConstrainedActions(actions, {
+      context: baseContext,
+      provenance: 'trusted',
+      inventoryGateway: inventory,
+      logger: new RecordingLogger(),
+      executor: executor.run,
+    })
+
+    expect(executor.calls.length).toBe(0)
+  })
+})

--- a/src/tests/units/modules/review-execution/services/resolveThreadInventory.test.ts
+++ b/src/tests/units/modules/review-execution/services/resolveThreadInventory.test.ts
@@ -1,0 +1,86 @@
+import { resolveThreadInventory } from '@/modules/review-execution/services/resolveThreadInventory.js'
+import type {
+  ThreadInventoryGateway,
+  ThreadInventoryPage,
+} from '@/modules/review-execution/entities/threadInventory/threadInventory.gateway.js'
+
+class RecordingLogger {
+  readonly errors: string[] = []
+  info(): void {}
+  warn(): void {}
+  debug(): void {}
+  error(_obj: object, message: string): void {
+    this.errors.push(message)
+  }
+}
+
+class StubThreadInventoryGateway implements ThreadInventoryGateway {
+  readonly calls: Array<{ projectPath: string; mrNumber: number; page: number }> = []
+  private pages: ThreadInventoryPage[] = []
+  private failure: Error | null = null
+
+  setPages(pages: ThreadInventoryPage[]): void {
+    this.pages = pages
+  }
+
+  setFailure(error: Error): void {
+    this.failure = error
+  }
+
+  fetchPage(projectPath: string, mrNumber: number, page: number): ThreadInventoryPage {
+    this.calls.push({ projectPath, mrNumber, page })
+    if (this.failure) throw this.failure
+    const found = this.pages.find(p => p.page === page)
+    if (!found) throw new Error(`no page ${page}`)
+    return found
+  }
+}
+
+const pinned = { projectPath: 'group/project', mrNumber: 42 }
+
+describe('resolveThreadInventory (AC-10 authenticated, complete, fail-closed)', () => {
+  it('assembles a complete inventory across all advertised pages', () => {
+    const gateway = new StubThreadInventoryGateway()
+    gateway.setPages([
+      { page: 1, totalPages: 2, threadIds: ['10', '11'] },
+      { page: 2, totalPages: 2, threadIds: ['12'] },
+    ])
+
+    const result = resolveThreadInventory(gateway, pinned, new RecordingLogger())
+
+    expect([...result].sort()).toEqual(['10', '11', '12'])
+    expect(gateway.calls).toEqual([
+      { projectPath: 'group/project', mrNumber: 42, page: 1 },
+      { projectPath: 'group/project', mrNumber: 42, page: 2 },
+    ])
+  })
+
+  it('AC-10.2 fail-closed on fetch failure -> empty set, failure logged, no fallback', () => {
+    const gateway = new StubThreadInventoryGateway()
+    gateway.setFailure(new Error('auth failure'))
+    const logger = new RecordingLogger()
+
+    const result = resolveThreadInventory(gateway, pinned, logger)
+
+    expect(result.size).toBe(0)
+    expect(logger.errors.length).toBeGreaterThan(0)
+  })
+
+  it('AC-10.3 fail-closed on incomplete pagination -> empty set (not the partial first page)', () => {
+    const gateway = new StubThreadInventoryGateway()
+    gateway.setPages([{ page: 1, totalPages: 2, threadIds: ['10', '11'] }])
+
+    const result = resolveThreadInventory(gateway, pinned, new RecordingLogger())
+
+    expect(result.size).toBe(0)
+  })
+
+  it('uses the pinned (projectPath, mrNumber) for every page request', () => {
+    const gateway = new StubThreadInventoryGateway()
+    gateway.setPages([{ page: 1, totalPages: 1, threadIds: ['99'] }])
+
+    resolveThreadInventory(gateway, pinned, new RecordingLogger())
+
+    expect(gateway.calls[0]).toEqual({ projectPath: 'group/project', mrNumber: 42, page: 1 })
+  })
+})

--- a/src/tests/units/modules/review-execution/usecases/gateClaudeInvocation.usecase.test.ts
+++ b/src/tests/units/modules/review-execution/usecases/gateClaudeInvocation.usecase.test.ts
@@ -154,4 +154,52 @@ describe('GateClaudeInvocationUseCase', () => {
       expect(gateway.saveCount).toBe(0);
     });
   });
+
+  describe('Rule: a non-trusted actor parks pending even in full-auto (SPEC-197)', () => {
+    it('parks the job and never enqueues when actorTrusted is false', async () => {
+      const useCase = new GateClaudeInvocationUseCase({
+        triggerMode: 'full-auto',
+        pendingReviewRequestGateway: gateway,
+        enqueue: enqueueSuccess,
+        broadcastPendingChanged: () => {
+          broadcasts += 1;
+        },
+        logger,
+      });
+
+      const result = await useCase.execute({
+        job: buildReviewJob(),
+        triggerSource: 'webhook-initial',
+        processor,
+        actorTrusted: false,
+      });
+
+      expect(result.status).toBe('pending');
+      expect(enqueueCalls).toHaveLength(0);
+      expect(processorRuns).toBe(0);
+      expect(gateway.saveCount).toBe(1);
+      expect(broadcasts).toBe(1);
+    });
+
+    it('enqueues normally in full-auto when actorTrusted is true', async () => {
+      const useCase = new GateClaudeInvocationUseCase({
+        triggerMode: 'full-auto',
+        pendingReviewRequestGateway: gateway,
+        enqueue: enqueueSuccess,
+        broadcastPendingChanged: () => {},
+        logger,
+      });
+
+      const result = await useCase.execute({
+        job: buildReviewJob(),
+        triggerSource: 'webhook-initial',
+        processor,
+        actorTrusted: true,
+      });
+
+      expect(result.status).toBe('enqueued');
+      expect(processorRuns).toBe(1);
+      expect(gateway.saveCount).toBe(0);
+    });
+  });
 });

--- a/src/tests/units/security/gitlabTokenRotation.test.ts
+++ b/src/tests/units/security/gitlabTokenRotation.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createFastifyRequestStub } from '@/tests/stubs/fastifyRequest.stub.js';
+import { verifyGitLabSignature } from '@/security/verifier.js';
+import { __resetGitlabTokenCacheForTests } from '@/security/gitlabWebhookTokenSource.js';
+
+const ENV_KEY = 'GITLAB_WEBHOOK_TOKEN';
+
+describe('verifyGitLabSignature token rotation (AC9)', () => {
+  let original: string | undefined;
+
+  beforeEach(() => {
+    original = process.env[ENV_KEY];
+    __resetGitlabTokenCacheForTests();
+  });
+
+  afterEach(() => {
+    if (original === undefined) {
+      Reflect.deleteProperty(process.env, ENV_KEY);
+    } else {
+      process.env[ENV_KEY] = original;
+    }
+    __resetGitlabTokenCacheForTests();
+  });
+
+  it('reads the current configured token, not a value captured at bootstrap', () => {
+    process.env[ENV_KEY] = 'first-token-value';
+    const firstRequest = createFastifyRequestStub({ headers: { 'x-gitlab-token': 'first-token-value' } });
+    expect(verifyGitLabSignature(firstRequest).valid).toBe(true);
+
+    process.env[ENV_KEY] = 'rotated-token-value';
+
+    const staleRequest = createFastifyRequestStub({ headers: { 'x-gitlab-token': 'first-token-value' } });
+    expect(verifyGitLabSignature(staleRequest).valid).toBe(false);
+
+    const rotatedRequest = createFastifyRequestStub({ headers: { 'x-gitlab-token': 'rotated-token-value' } });
+    expect(verifyGitLabSignature(rotatedRequest).valid).toBe(true);
+  });
+
+  it('rejects a token of different length without a length-based short circuit', () => {
+    process.env[ENV_KEY] = 'a-token-of-some-length';
+    const shortRequest = createFastifyRequestStub({ headers: { 'x-gitlab-token': 'short' } });
+
+    const result = verifyGitLabSignature(shortRequest);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('invalide');
+  });
+});

--- a/src/tests/units/security/noSpoofableTransportGuard.test.ts
+++ b/src/tests/units/security/noSpoofableTransportGuard.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..', '..', '..');
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(repoRoot, relativePath), 'utf-8');
+}
+
+describe('no spoofable transport guard (AC6)', () => {
+  const middleware = readSource(
+    'src/modules/platform-integration/interface-adapters/controllers/webhook/transportGuard.middleware.ts',
+  );
+  const routes = readSource('src/main/routes.ts');
+
+  it('the transport guard never reads request.protocol or request.ip as a trust input', () => {
+    expect(middleware).not.toMatch(/\.protocol\b/);
+    expect(middleware).not.toMatch(/\brequest\.ip\b/);
+    expect(middleware).not.toMatch(/\breq\.ip\b/);
+  });
+
+  it('the transport guard derives the socket address from socket.remoteAddress only', () => {
+    expect(middleware).toContain('socket.remoteAddress');
+  });
+
+  it('the webhook routes never use request.protocol or request.ip as a trust guard', () => {
+    expect(routes).not.toMatch(/request\.protocol\b/);
+    expect(routes).not.toMatch(/\brequest\.ip\b/);
+    expect(routes).not.toMatch(/\breq\.ip\b/);
+  });
+
+  it('the webhook routes feed the guard from the raw socket address', () => {
+    expect(routes).toContain('request.socket.remoteAddress');
+  });
+});

--- a/src/tests/units/security/transportGuardConfig.test.ts
+++ b/src/tests/units/security/transportGuardConfig.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  DEFAULT_LOOPBACK_HOP,
+  resolveTrustedHopAddress,
+  resolveAllowedCidrRanges,
+  transportTrustProxyValue,
+} from '@/security/transportGuardConfig.js';
+
+const HOP_KEY = 'WEBHOOK_TRUSTED_HOP';
+const CIDR_KEY = 'WEBHOOK_ALLOWED_CIDR_RANGES';
+
+describe('transportGuardConfig (AC8)', () => {
+  const originalHop = process.env[HOP_KEY];
+  const originalCidr = process.env[CIDR_KEY];
+
+  afterEach(() => {
+    if (originalHop === undefined) Reflect.deleteProperty(process.env, HOP_KEY);
+    else process.env[HOP_KEY] = originalHop;
+    if (originalCidr === undefined) Reflect.deleteProperty(process.env, CIDR_KEY);
+    else process.env[CIDR_KEY] = originalCidr;
+  });
+
+  it('defaults the trusted hop to the loopback address', () => {
+    Reflect.deleteProperty(process.env, HOP_KEY);
+    expect(resolveTrustedHopAddress()).toBe(DEFAULT_LOOPBACK_HOP);
+  });
+
+  it('the trust proxy value equals the configured hop and is never the boolean true', () => {
+    process.env[HOP_KEY] = '127.0.0.1';
+    const value = transportTrustProxyValue();
+
+    expect(value).toBe('127.0.0.1');
+    expect(typeof value).toBe('string');
+    expect(value).not.toBe(true);
+  });
+
+  it('parses a comma-separated CIDR allowlist into trimmed entries', () => {
+    process.env[CIDR_KEY] = ' 10.0.0.0/8 , 172.16.0.0/12 ';
+    expect(resolveAllowedCidrRanges()).toEqual(['10.0.0.0/8', '172.16.0.0/12']);
+  });
+
+  it('returns an empty allowlist when none is configured', () => {
+    Reflect.deleteProperty(process.env, CIDR_KEY);
+    expect(resolveAllowedCidrRanges()).toEqual([]);
+  });
+});

--- a/src/tests/units/security/verifier.test.ts
+++ b/src/tests/units/security/verifier.test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { vi, beforeAll, afterAll } from 'vitest'
 import { createHmac } from 'node:crypto'
 import { createFastifyRequestStub } from '../../stubs/fastifyRequest.stub.js'
 
@@ -20,6 +20,21 @@ import {
 } from '../../../security/verifier.js'
 
 describe('verifyGitLabSignature', () => {
+  let originalToken: string | undefined
+
+  beforeAll(() => {
+    originalToken = process.env.GITLAB_WEBHOOK_TOKEN
+    process.env.GITLAB_WEBHOOK_TOKEN = TEST_GITLAB_TOKEN
+  })
+
+  afterAll(() => {
+    if (originalToken === undefined) {
+      Reflect.deleteProperty(process.env, 'GITLAB_WEBHOOK_TOKEN')
+    } else {
+      process.env.GITLAB_WEBHOOK_TOKEN = originalToken
+    }
+  })
+
   describe('when token is valid', () => {
     it('should return valid: true', () => {
       const request = createFastifyRequestStub({

--- a/src/tests/units/security/verifier.test.ts
+++ b/src/tests/units/security/verifier.test.ts
@@ -16,6 +16,7 @@ import {
   verifyGitLabSignature,
   verifyGitHubSignature,
   getGitLabEventType,
+  getGitLabEventUuid,
   getGitHubEventType,
 } from '../../../security/verifier.js'
 
@@ -228,6 +229,30 @@ describe('getGitLabEventType', () => {
     })
 
     const result = getGitLabEventType(request)
+
+    expect(result).toBeUndefined()
+  })
+})
+
+describe('getGitLabEventUuid', () => {
+  it('should extract the event UUID from the header', () => {
+    const request = createFastifyRequestStub({
+      headers: {
+        'x-gitlab-event-uuid': '13be3e1e-1d3f-4c2a-9b1a-0f0e0d0c0b0a',
+      },
+    })
+
+    const result = getGitLabEventUuid(request)
+
+    expect(result).toBe('13be3e1e-1d3f-4c2a-9b1a-0f0e0d0c0b0a')
+  })
+
+  it('should return undefined when the header is missing', () => {
+    const request = createFastifyRequestStub({
+      headers: {},
+    })
+
+    const result = getGitLabEventUuid(request)
 
     expect(result).toBeUndefined()
   })

--- a/src/tests/units/services/contextActionsExecutor.egress.test.ts
+++ b/src/tests/units/services/contextActionsExecutor.egress.test.ts
@@ -88,7 +88,7 @@ describe('executeActionsFromContext — egress routing (pentest amendment AC7/AC
     expect(rawSecretCalls).toHaveLength(0);
   });
 
-  it('AC9 — public-output verbs reach the decorated sink while other verbs use the CLI primitive', async () => {
+  it('AC9 — public-output verbs reach the decorated sink while other allowed verbs use the CLI primitive', async () => {
     const { sink, gateway } = buildDecoratedSink();
     const rawCalls: string[][] = [];
     const recordingExecutor: CommandExecutor = (_command, args) => {
@@ -96,11 +96,11 @@ describe('executeActionsFromContext — egress routing (pentest amendment AC7/AC
     };
     const context: ReviewContext = {
       ...baseContext,
+      diffMetadata: { baseSha: 'base', headSha: 'head', startSha: 'start' },
       actions: [
         { type: 'POST_COMMENT', body: `comment ${SECRET}` },
         { type: 'THREAD_REPLY', threadId: 't1', message: `reply ${SECRET}` },
-        { type: 'THREAD_RESOLVE', threadId: 't1' },
-        { type: 'ADD_LABEL', label: 'approved' },
+        { type: 'POST_INLINE_COMMENT', filePath: 'src/a.ts', line: 3, body: 'inline note' },
       ],
     };
 
@@ -112,6 +112,27 @@ describe('executeActionsFromContext — egress routing (pentest amendment AC7/AC
     }
     const rawSecretCalls = rawCalls.filter((args) => args.some((arg) => arg.includes(SECRET)));
     expect(rawSecretCalls).toHaveLength(0);
-    expect(rawCalls.some((args) => args.includes('resolved=true'))).toBe(true);
+    expect(rawCalls.some((args) => args.some((arg) => arg.includes('/discussions')))).toBe(true);
+  });
+
+  it('SPEC-196 unwire: THREAD_RESOLVE / ADD_LABEL are dropped from the sinked auto path', async () => {
+    const { sink, gateway } = buildDecoratedSink();
+    const rawCalls: string[][] = [];
+    const recordingExecutor: CommandExecutor = (_command, args) => {
+      rawCalls.push(args);
+    };
+    const context: ReviewContext = {
+      ...baseContext,
+      actions: [
+        { type: 'POST_COMMENT', body: 'comment' },
+        { type: 'THREAD_RESOLVE', threadId: 't1' },
+        { type: 'ADD_LABEL', label: 'approved' },
+      ],
+    };
+
+    await executeActionsFromContext(context, '/tmp/repo', silentLogger, recordingExecutor, null, gateway);
+
+    expect(sink.calls).toHaveLength(1);
+    expect(rawCalls.some((args) => args.includes('resolved=true'))).toBe(false);
   });
 });

--- a/src/tests/units/services/contextActionsExecutor.egress.test.ts
+++ b/src/tests/units/services/contextActionsExecutor.egress.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { executeActionsFromContext } from '@/modules/review-execution/services/contextActionsExecutor.js';
+import type { ReviewContext } from '@/modules/review-execution/entities/reviewContext/reviewContext.js';
+import type { CommandExecutor } from '@/modules/review-execution/entities/reviewAction/reviewAction.gateway.js';
+import { EgressScannedNoteCommentPostGateway } from '@/modules/platform-integration/interface-adapters/gateways/egressScanned.noteCommentPost.gateway.js';
+import { createEgressScanner } from '@/modules/platform-integration/entities/egressScan/egressScan.scanner.js';
+import type { EgressScanConfig } from '@/modules/platform-integration/entities/egressScan/egressScan.scanner.js';
+import { StubNoteCommentPostGateway } from '@/tests/stubs/noteCommentPost.stub.js';
+import { StubEgressTraceGateway } from '@/tests/stubs/egressScan.stub.js';
+
+const SECRET = 'glpat-abcdefghij1234567890';
+
+const redactConfig: EgressScanConfig = {
+  secretShapeMode: 'redact',
+  lengthMode: 'redact',
+  outOfScopeMode: 'redact',
+  maxBodyLength: 10000,
+  redactionMarker: '[REDACTED]',
+  truncationMarker: '…[TRUNCATED]',
+};
+
+const silentLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+function buildDecoratedSink() {
+  const sink = new StubNoteCommentPostGateway();
+  const trace = new StubEgressTraceGateway();
+  const scanner = createEgressScanner(redactConfig);
+  const gateway = new EgressScannedNoteCommentPostGateway(sink, scanner, trace);
+  return { sink, gateway };
+}
+
+const baseContext: ReviewContext = {
+  version: '1.0',
+  mergeRequestId: 'gitlab-group/app-7',
+  platform: 'gitlab',
+  projectPath: 'group/app',
+  mergeRequestNumber: 7,
+  createdAt: '2026-02-02T10:00:00Z',
+  threads: [],
+  actions: [],
+  progress: { phase: 'completed', currentStep: null },
+};
+
+describe('executeActionsFromContext — egress routing (pentest amendment AC7/AC9)', () => {
+  it('routes a POST_COMMENT body through the decorated sink, never the raw CLI primitive', async () => {
+    const { sink, gateway } = buildDecoratedSink();
+    const rawCalls: string[][] = [];
+    const recordingExecutor: CommandExecutor = (_command, args) => {
+      rawCalls.push(args);
+    };
+    const context: ReviewContext = {
+      ...baseContext,
+      actions: [{ type: 'POST_COMMENT', body: `## Review\ntoken ${SECRET}` }],
+    };
+
+    await executeActionsFromContext(context, '/tmp/repo', silentLogger, recordingExecutor, null, gateway);
+
+    expect(sink.calls).toHaveLength(1);
+    expect(sink.calls[0].body).toContain('[REDACTED]');
+    expect(sink.calls[0].body).not.toContain(SECRET);
+
+    const rawSecretCalls = rawCalls.filter((args) => args.some((arg) => arg.includes(SECRET)));
+    expect(rawSecretCalls).toHaveLength(0);
+  });
+
+  it('routes a THREAD_REPLY body through the decorated sink, never the raw CLI primitive', async () => {
+    const { sink, gateway } = buildDecoratedSink();
+    const rawCalls: string[][] = [];
+    const recordingExecutor: CommandExecutor = (_command, args) => {
+      rawCalls.push(args);
+    };
+    const context: ReviewContext = {
+      ...baseContext,
+      actions: [{ type: 'THREAD_REPLY', threadId: 'abc', message: `fixed ${SECRET}` }],
+    };
+
+    await executeActionsFromContext(context, '/tmp/repo', silentLogger, recordingExecutor, null, gateway);
+
+    expect(sink.calls).toHaveLength(1);
+    expect(sink.calls[0].body).not.toContain(SECRET);
+
+    const rawSecretCalls = rawCalls.filter((args) => args.some((arg) => arg.includes(SECRET)));
+    expect(rawSecretCalls).toHaveLength(0);
+  });
+
+  it('AC9 — public-output verbs reach the decorated sink while other verbs use the CLI primitive', async () => {
+    const { sink, gateway } = buildDecoratedSink();
+    const rawCalls: string[][] = [];
+    const recordingExecutor: CommandExecutor = (_command, args) => {
+      rawCalls.push(args);
+    };
+    const context: ReviewContext = {
+      ...baseContext,
+      actions: [
+        { type: 'POST_COMMENT', body: `comment ${SECRET}` },
+        { type: 'THREAD_REPLY', threadId: 't1', message: `reply ${SECRET}` },
+        { type: 'THREAD_RESOLVE', threadId: 't1' },
+        { type: 'ADD_LABEL', label: 'approved' },
+      ],
+    };
+
+    await executeActionsFromContext(context, '/tmp/repo', silentLogger, recordingExecutor, null, gateway);
+
+    expect(sink.calls).toHaveLength(2);
+    for (const call of sink.calls) {
+      expect(call.body).not.toContain(SECRET);
+    }
+    const rawSecretCalls = rawCalls.filter((args) => args.some((arg) => arg.includes(SECRET)));
+    expect(rawSecretCalls).toHaveLength(0);
+    expect(rawCalls.some((args) => args.includes('resolved=true'))).toBe(true);
+  });
+});

--- a/src/tests/units/services/contextActionsExecutor.test.ts
+++ b/src/tests/units/services/contextActionsExecutor.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { executeActionsFromContext } from '@/modules/review-execution/services/contextActionsExecutor.js'
 import type { ReviewContext } from '@/modules/review-execution/entities/reviewContext/reviewContext.js'
 
-describe('executeActionsFromContext', () => {
+// AC6/AC7: the context auto-path executor is bounded to read + postComment.
+// THREAD_RESOLVE / ADD_LABEL are dropped (no-op, logged), POST_COMMENT executes.
+describe('executeActionsFromContext (auto path, capability-bounded)', () => {
   const mockLogger = {
     info: vi.fn(),
     warn: vi.fn(),
@@ -28,7 +30,7 @@ describe('executeActionsFromContext', () => {
     vi.clearAllMocks()
   })
 
-  it('should return empty result when no actions in context', async () => {
+  it('returns an empty result when no actions are present', async () => {
     const context = { ...baseContext, actions: [] }
 
     const result = await executeActionsFromContext(context, '/tmp/repo', mockLogger, mockExecutor)
@@ -38,31 +40,22 @@ describe('executeActionsFromContext', () => {
     expect(mockExecutor).not.toHaveBeenCalled()
   })
 
-  it('should execute THREAD_RESOLVE action via GitHub API', async () => {
+  it('drops THREAD_RESOLVE without invoking the executor', async () => {
     const context: ReviewContext = {
       ...baseContext,
-      actions: [
-        { type: 'THREAD_RESOLVE', threadId: 'PRRT_kwDONxxx' },
-      ],
+      actions: [{ type: 'THREAD_RESOLVE', threadId: 'PRRT_kwDONxxx' }],
     }
 
     const result = await executeActionsFromContext(context, '/tmp/repo', mockLogger, mockExecutor)
 
-    expect(result.total).toBe(1)
-    expect(result.succeeded).toBe(1)
-    expect(mockExecutor).toHaveBeenCalledWith(
-      'gh',
-      expect.arrayContaining(['api', 'graphql']),
-      '/tmp/repo'
-    )
+    expect(result.total).toBe(0)
+    expect(mockExecutor).not.toHaveBeenCalled()
   })
 
-  it('should execute POST_COMMENT action', async () => {
+  it('executes POST_COMMENT action', async () => {
     const context: ReviewContext = {
       ...baseContext,
-      actions: [
-        { type: 'POST_COMMENT', body: '## Follow-up Review\n\nAll fixed.' },
-      ],
+      actions: [{ type: 'POST_COMMENT', body: '## Follow-up Review\n\nAll fixed.' }],
     }
 
     const result = await executeActionsFromContext(context, '/tmp/repo', mockLogger, mockExecutor)
@@ -76,26 +69,19 @@ describe('executeActionsFromContext', () => {
     )
   })
 
-  it('should execute ADD_LABEL action', async () => {
+  it('drops ADD_LABEL without invoking the executor', async () => {
     const context: ReviewContext = {
       ...baseContext,
-      actions: [
-        { type: 'ADD_LABEL', label: 'needs_approve' },
-      ],
+      actions: [{ type: 'ADD_LABEL', label: 'needs_approve' }],
     }
 
     const result = await executeActionsFromContext(context, '/tmp/repo', mockLogger, mockExecutor)
 
-    expect(result.total).toBe(1)
-    expect(result.succeeded).toBe(1)
-    expect(mockExecutor).toHaveBeenCalledWith(
-      'gh',
-      expect.arrayContaining(['repos/owner/repo/issues/42/labels']),
-      '/tmp/repo'
-    )
+    expect(result.total).toBe(0)
+    expect(mockExecutor).not.toHaveBeenCalled()
   })
 
-  it('should execute multiple actions in order', async () => {
+  it('keeps only allowed verbs in a mixed stream', async () => {
     const context: ReviewContext = {
       ...baseContext,
       actions: [
@@ -108,18 +94,17 @@ describe('executeActionsFromContext', () => {
 
     const result = await executeActionsFromContext(context, '/tmp/repo', mockLogger, mockExecutor)
 
-    expect(result.total).toBe(4)
-    expect(result.succeeded).toBe(4)
-    expect(mockExecutor).toHaveBeenCalledTimes(4)
+    // Only the single POST_COMMENT survives the capability filter.
+    expect(result.total).toBe(1)
+    expect(result.succeeded).toBe(1)
+    expect(mockExecutor).toHaveBeenCalledTimes(1)
   })
 
-  it('should handle GitLab platform', async () => {
+  it('handles GitLab platform postComment', async () => {
     const context: ReviewContext = {
       ...baseContext,
       platform: 'gitlab',
-      actions: [
-        { type: 'THREAD_RESOLVE', threadId: 'abc123' },
-      ],
+      actions: [{ type: 'POST_COMMENT', body: 'note' }],
     }
 
     const result = await executeActionsFromContext(context, '/tmp/repo', mockLogger, mockExecutor)
@@ -132,7 +117,7 @@ describe('executeActionsFromContext', () => {
     )
   })
 
-  it('should continue executing when one action fails', async () => {
+  it('continues executing when one allowed action fails', async () => {
     mockExecutor.mockImplementationOnce(() => {
       throw new Error('API error')
     })
@@ -140,8 +125,8 @@ describe('executeActionsFromContext', () => {
     const context: ReviewContext = {
       ...baseContext,
       actions: [
-        { type: 'THREAD_RESOLVE', threadId: 'thread-1' },
-        { type: 'POST_COMMENT', body: 'Done' },
+        { type: 'POST_COMMENT', body: 'first' },
+        { type: 'POST_COMMENT', body: 'second' },
       ],
     }
 

--- a/src/tests/units/services/publicOutputExecutor.test.ts
+++ b/src/tests/units/services/publicOutputExecutor.test.ts
@@ -1,0 +1,90 @@
+import { executePublicOutput } from '@/modules/review-execution/services/publicOutputExecutor.js';
+import type { PublicOutputAction } from '@/modules/review-execution/services/publicOutputExecutor.js';
+import { EgressScannedNoteCommentPostGateway } from '@/modules/platform-integration/interface-adapters/gateways/egressScanned.noteCommentPost.gateway.js';
+import { createEgressScanner } from '@/modules/platform-integration/entities/egressScan/egressScan.scanner.js';
+import type { EgressScanConfig } from '@/modules/platform-integration/entities/egressScan/egressScan.scanner.js';
+import { StubNoteCommentPostGateway } from '@/tests/stubs/noteCommentPost.stub.js';
+import { StubEgressTraceGateway } from '@/tests/stubs/egressScan.stub.js';
+
+const SECRET = 'glpat-abcdefghij1234567890';
+
+const redactConfig: EgressScanConfig = {
+  secretShapeMode: 'redact',
+  lengthMode: 'redact',
+  outOfScopeMode: 'redact',
+  maxBodyLength: 10000,
+  redactionMarker: '[REDACTED]',
+  truncationMarker: '…[TRUNCATED]',
+};
+
+function buildDecoratedGateway() {
+  const sink = new StubNoteCommentPostGateway();
+  const trace = new StubEgressTraceGateway();
+  const scanner = createEgressScanner(redactConfig);
+  const gateway = new EgressScannedNoteCommentPostGateway(sink, scanner, trace);
+  return { sink, gateway };
+}
+
+const context = { projectPath: 'group/project', mrNumber: 42 };
+
+describe('executePublicOutput', () => {
+  describe('AC7 — THREAD_REPLY egress is scanned', () => {
+    it('routes a THREAD_REPLY body through the decorated sink with redaction', async () => {
+      const { sink, gateway } = buildDecoratedGateway();
+      const actions: PublicOutputAction[] = [
+        { type: 'THREAD_REPLY', threadId: 'abc', message: `fixed, token ${SECRET}` },
+      ];
+
+      await executePublicOutput(actions, context, gateway);
+
+      expect(sink.calls).toHaveLength(1);
+      expect(sink.calls[0].body).toContain('[REDACTED]');
+      expect(sink.calls[0].body).not.toContain(SECRET);
+    });
+  });
+
+  describe('AC9 — channel exhaustiveness', () => {
+    const verbCases: { label: string; action: PublicOutputAction }[] = [
+      { label: 'THREAD_REPLY', action: { type: 'THREAD_REPLY', threadId: 'abc', message: `m ${SECRET}` } },
+      { label: 'POST_COMMENT', action: { type: 'POST_COMMENT', body: `c ${SECRET}` } },
+    ];
+
+    it.each(verbCases)('routes %s through the same decorated sink', async ({ action }) => {
+      const { sink, gateway } = buildDecoratedGateway();
+
+      await executePublicOutput([action], context, gateway);
+
+      expect(sink.calls).toHaveLength(1);
+      expect(sink.calls[0].body).not.toContain(SECRET);
+      expect(sink.calls[0].body).toContain('[REDACTED]');
+    });
+
+    it('every auto-path public-output verb resolves to one shared decorated sink', async () => {
+      const { sink, gateway } = buildDecoratedGateway();
+      const actions: PublicOutputAction[] = [
+        { type: 'POST_COMMENT', body: `comment ${SECRET}` },
+        { type: 'THREAD_REPLY', threadId: 't1', message: `reply ${SECRET}` },
+      ];
+
+      await executePublicOutput(actions, context, gateway);
+
+      expect(sink.calls).toHaveLength(2);
+      for (const call of sink.calls) {
+        expect(call.body).not.toContain(SECRET);
+        expect(call.body).toContain('[REDACTED]');
+      }
+    });
+
+    it('ignores non-public-output verbs (no body leaves the system)', async () => {
+      const { sink, gateway } = buildDecoratedGateway();
+      const actions: PublicOutputAction[] = [
+        { type: 'THREAD_RESOLVE', threadId: 't1' },
+        { type: 'FETCH_THREADS' },
+      ];
+
+      await executePublicOutput(actions, context, gateway);
+
+      expect(sink.calls).toHaveLength(0);
+    });
+  });
+});

--- a/src/tests/units/services/threadActionsExecutor.egress.test.ts
+++ b/src/tests/units/services/threadActionsExecutor.egress.test.ts
@@ -84,7 +84,27 @@ describe('executeThreadActions — egress routing (pentest amendment AC7/AC9)', 
     expect(rawSecretCalls).toHaveLength(0);
   });
 
-  it('still routes non-public-output verbs (THREAD_RESOLVE) through the CLI primitive', async () => {
+  it('routes non-public-output postComment verbs (POST_INLINE_COMMENT) through the CLI primitive', async () => {
+    const { sink, gateway } = buildDecoratedSink();
+    const rawCalls: string[][] = [];
+    const recordingExecutor: CommandExecutor = (_command, args) => {
+      rawCalls.push(args);
+    };
+    const actions: ThreadAction[] = [
+      { type: 'POST_INLINE_COMMENT', filePath: 'src/a.ts', line: 3, body: 'inline note' },
+    ];
+    const inlineContext: ExecutionContext = {
+      ...gitlabContext,
+      diffMetadata: { baseSha: 'base', headSha: 'head', startSha: 'start' },
+    };
+
+    await executeThreadActions(actions, inlineContext, silentLogger, recordingExecutor, gateway);
+
+    expect(sink.calls).toHaveLength(0);
+    expect(rawCalls.some((args) => args.some((arg) => arg.includes('/discussions')))).toBe(true);
+  });
+
+  it('drops THREAD_RESOLVE from the auto path (SPEC-196 unwire): neither sink nor CLI write', async () => {
     const { sink, gateway } = buildDecoratedSink();
     const rawCalls: string[][] = [];
     const recordingExecutor: CommandExecutor = (_command, args) => {
@@ -95,7 +115,7 @@ describe('executeThreadActions — egress routing (pentest amendment AC7/AC9)', 
     await executeThreadActions(actions, gitlabContext, silentLogger, recordingExecutor, gateway);
 
     expect(sink.calls).toHaveLength(0);
-    expect(rawCalls.some((args) => args.includes('resolved=true'))).toBe(true);
+    expect(rawCalls.some((args) => args.includes('resolved=true'))).toBe(false);
   });
 
   it('AC9 — every auto-path public-output verb reaches only the decorated sink', async () => {

--- a/src/tests/units/services/threadActionsExecutor.egress.test.ts
+++ b/src/tests/units/services/threadActionsExecutor.egress.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import {
+  executeThreadActions,
+  type ExecutionContext,
+  type CommandExecutor,
+} from '@/modules/review-execution/services/threadActionsExecutor.js';
+import type { ThreadAction } from '@/modules/review-execution/services/threadActionsParser.js';
+import { EgressScannedNoteCommentPostGateway } from '@/modules/platform-integration/interface-adapters/gateways/egressScanned.noteCommentPost.gateway.js';
+import { createEgressScanner } from '@/modules/platform-integration/entities/egressScan/egressScan.scanner.js';
+import type { EgressScanConfig } from '@/modules/platform-integration/entities/egressScan/egressScan.scanner.js';
+import { StubNoteCommentPostGateway } from '@/tests/stubs/noteCommentPost.stub.js';
+import { StubEgressTraceGateway } from '@/tests/stubs/egressScan.stub.js';
+
+const SECRET = 'glpat-abcdefghij1234567890';
+
+const redactConfig: EgressScanConfig = {
+  secretShapeMode: 'redact',
+  lengthMode: 'redact',
+  outOfScopeMode: 'redact',
+  maxBodyLength: 10000,
+  redactionMarker: '[REDACTED]',
+  truncationMarker: '…[TRUNCATED]',
+};
+
+const silentLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+function buildDecoratedSink() {
+  const sink = new StubNoteCommentPostGateway();
+  const trace = new StubEgressTraceGateway();
+  const scanner = createEgressScanner(redactConfig);
+  const gateway = new EgressScannedNoteCommentPostGateway(sink, scanner, trace);
+  return { sink, gateway };
+}
+
+const gitlabContext: ExecutionContext = {
+  platform: 'gitlab',
+  projectPath: 'group/app',
+  mrNumber: 7,
+  localPath: '/tmp/repo',
+};
+
+describe('executeThreadActions — egress routing (pentest amendment AC7/AC9)', () => {
+  it('routes a THREAD_REPLY body through the decorated sink, never the raw CLI primitive', async () => {
+    const { sink, gateway } = buildDecoratedSink();
+    const rawCalls: string[][] = [];
+    const recordingExecutor: CommandExecutor = (_command, args) => {
+      rawCalls.push(args);
+    };
+    const actions: ThreadAction[] = [
+      { type: 'THREAD_REPLY', threadId: 'abc', message: `fixed, token ${SECRET}` },
+    ];
+
+    await executeThreadActions(actions, gitlabContext, silentLogger, recordingExecutor, gateway);
+
+    expect(sink.calls).toHaveLength(1);
+    expect(sink.calls[0].body).toContain('[REDACTED]');
+    expect(sink.calls[0].body).not.toContain(SECRET);
+
+    const reachedRawNotePrimitive = rawCalls.some((args) =>
+      args.some((arg) => arg.includes(SECRET) || arg.includes('/notes')),
+    );
+    expect(reachedRawNotePrimitive).toBe(false);
+  });
+
+  it('routes a POST_COMMENT body through the decorated sink, never the raw CLI primitive', async () => {
+    const { sink, gateway } = buildDecoratedSink();
+    const rawCalls: string[][] = [];
+    const recordingExecutor: CommandExecutor = (_command, args) => {
+      rawCalls.push(args);
+    };
+    const actions: ThreadAction[] = [{ type: 'POST_COMMENT', body: `comment ${SECRET}` }];
+
+    await executeThreadActions(actions, gitlabContext, silentLogger, recordingExecutor, gateway);
+
+    expect(sink.calls).toHaveLength(1);
+    expect(sink.calls[0].body).not.toContain(SECRET);
+
+    const rawSecretCalls = rawCalls.filter((args) => args.some((arg) => arg.includes(SECRET)));
+    expect(rawSecretCalls).toHaveLength(0);
+  });
+
+  it('still routes non-public-output verbs (THREAD_RESOLVE) through the CLI primitive', async () => {
+    const { sink, gateway } = buildDecoratedSink();
+    const rawCalls: string[][] = [];
+    const recordingExecutor: CommandExecutor = (_command, args) => {
+      rawCalls.push(args);
+    };
+    const actions: ThreadAction[] = [{ type: 'THREAD_RESOLVE', threadId: 'abc' }];
+
+    await executeThreadActions(actions, gitlabContext, silentLogger, recordingExecutor, gateway);
+
+    expect(sink.calls).toHaveLength(0);
+    expect(rawCalls.some((args) => args.includes('resolved=true'))).toBe(true);
+  });
+
+  it('AC9 — every auto-path public-output verb reaches only the decorated sink', async () => {
+    const { sink, gateway } = buildDecoratedSink();
+    const rawCalls: string[][] = [];
+    const recordingExecutor: CommandExecutor = (_command, args) => {
+      rawCalls.push(args);
+    };
+    const actions: ThreadAction[] = [
+      { type: 'POST_COMMENT', body: `comment ${SECRET}` },
+      { type: 'THREAD_REPLY', threadId: 't1', message: `reply ${SECRET}` },
+      { type: 'THREAD_RESOLVE', threadId: 't1' },
+    ];
+
+    await executeThreadActions(actions, gitlabContext, silentLogger, recordingExecutor, gateway);
+
+    expect(sink.calls).toHaveLength(2);
+    for (const call of sink.calls) {
+      expect(call.body).not.toContain(SECRET);
+    }
+    const rawSecretCalls = rawCalls.filter((args) => args.some((arg) => arg.includes(SECRET)));
+    expect(rawSecretCalls).toHaveLength(0);
+  });
+});

--- a/src/tests/units/services/threadActionsExecutor.test.ts
+++ b/src/tests/units/services/threadActionsExecutor.test.ts
@@ -5,7 +5,10 @@ import {
 } from '@/modules/review-execution/services/threadActionsExecutor.js'
 import type { ThreadAction } from '@/modules/review-execution/services/threadActionsParser.js'
 
-describe('executeThreadActions', () => {
+// AC6/AC7: the deprecated auto-path executor is bounded to the read+postComment
+// capability set. THREAD_RESOLVE / THREAD_REPLY / ADD_LABEL are dropped as no-ops
+// (logged, not executed, no escalation). POST_COMMENT and FETCH_THREADS remain.
+describe('executeThreadActions (auto path, capability-bounded)', () => {
   const mockExecutor: CommandExecutor = vi.fn()
   const mockLogger = {
     info: vi.fn(),
@@ -26,52 +29,26 @@ describe('executeThreadActions', () => {
       localPath: '/tmp/repo',
     }
 
-    it('should execute THREAD_REPLY with correct glab command', async () => {
+    it('executes THREAD_REPLY (note-create, postComment capability)', async () => {
       const actions: ThreadAction[] = [
         { type: 'THREAD_REPLY', threadId: 'abc123', message: 'Fixed!' },
       ]
 
       await executeThreadActions(actions, gitlabContext, mockLogger, mockExecutor)
 
-      expect(mockExecutor).toHaveBeenCalledWith(
-        'glab',
-        [
-          'api',
-          '--method',
-          'POST',
-          'projects/mentor-goal%2Fmain-app-v3/merge_requests/4658/discussions/abc123/notes',
-          '--field',
-          "body=Fixed!",
-        ],
-        '/tmp/repo'
-      )
+      expect(mockExecutor).toHaveBeenCalledTimes(1)
     })
 
-    it('should execute THREAD_RESOLVE with correct glab command', async () => {
-      const actions: ThreadAction[] = [
-        { type: 'THREAD_RESOLVE', threadId: 'abc123' },
-      ]
+    it('drops THREAD_RESOLVE without invoking the executor', async () => {
+      const actions: ThreadAction[] = [{ type: 'THREAD_RESOLVE', threadId: 'abc123' }]
 
       await executeThreadActions(actions, gitlabContext, mockLogger, mockExecutor)
 
-      expect(mockExecutor).toHaveBeenCalledWith(
-        'glab',
-        [
-          'api',
-          '--method',
-          'PUT',
-          'projects/mentor-goal%2Fmain-app-v3/merge_requests/4658/discussions/abc123',
-          '--field',
-          'resolved=true',
-        ],
-        '/tmp/repo'
-      )
+      expect(mockExecutor).not.toHaveBeenCalled()
     })
 
-    it('should execute POST_COMMENT with correct glab command', async () => {
-      const actions: ThreadAction[] = [
-        { type: 'POST_COMMENT', body: '## Review Complete' },
-      ]
+    it('executes POST_COMMENT with correct glab command', async () => {
+      const actions: ThreadAction[] = [{ type: 'POST_COMMENT', body: '## Review Complete' }]
 
       await executeThreadActions(actions, gitlabContext, mockLogger, mockExecutor)
 
@@ -88,26 +65,6 @@ describe('executeThreadActions', () => {
         '/tmp/repo'
       )
     })
-
-    it('should URL-encode project path with slashes', async () => {
-      const contextWithSlash: ExecutionContext = {
-        ...gitlabContext,
-        projectPath: 'group/subgroup/project',
-      }
-      const actions: ThreadAction[] = [
-        { type: 'THREAD_RESOLVE', threadId: 'abc' },
-      ]
-
-      await executeThreadActions(actions, contextWithSlash, mockLogger, mockExecutor)
-
-      expect(mockExecutor).toHaveBeenCalledWith(
-        'glab',
-        expect.arrayContaining([
-          expect.stringContaining('group%2Fsubgroup%2Fproject'),
-        ]),
-        '/tmp/repo'
-      )
-    })
   })
 
   describe('GitHub platform', () => {
@@ -118,50 +75,26 @@ describe('executeThreadActions', () => {
       localPath: '/tmp/repo',
     }
 
-    it('should execute THREAD_RESOLVE with gh graphql mutation', async () => {
-      const actions: ThreadAction[] = [
-        { type: 'THREAD_RESOLVE', threadId: 'PRRT_abc123' },
-      ]
+    it('drops THREAD_RESOLVE without invoking the executor', async () => {
+      const actions: ThreadAction[] = [{ type: 'THREAD_RESOLVE', threadId: 'PRRT_abc123' }]
 
       await executeThreadActions(actions, githubContext, mockLogger, mockExecutor)
 
-      expect(mockExecutor).toHaveBeenCalledWith(
-        'gh',
-        [
-          'api',
-          'graphql',
-          '-f',
-          'query=mutation { resolveReviewThread(input: {threadId: "PRRT_abc123"}) { thread { id isResolved } } }',
-        ],
-        '/tmp/repo'
-      )
+      expect(mockExecutor).not.toHaveBeenCalled()
     })
 
-    it('should execute THREAD_REPLY with gh api command', async () => {
+    it('executes THREAD_REPLY (note-create, postComment capability)', async () => {
       const actions: ThreadAction[] = [
         { type: 'THREAD_REPLY', threadId: '12345', message: 'Fixed!' },
       ]
 
       await executeThreadActions(actions, githubContext, mockLogger, mockExecutor)
 
-      expect(mockExecutor).toHaveBeenCalledWith(
-        'gh',
-        [
-          'api',
-          '--method',
-          'POST',
-          'repos/owner/repo/pulls/123/comments/12345/replies',
-          '--field',
-          'body=Fixed!',
-        ],
-        '/tmp/repo'
-      )
+      expect(mockExecutor).toHaveBeenCalledTimes(1)
     })
 
-    it('should execute POST_COMMENT with gh api command', async () => {
-      const actions: ThreadAction[] = [
-        { type: 'POST_COMMENT', body: '## Review Complete' },
-      ]
+    it('executes POST_COMMENT with gh api command', async () => {
+      const actions: ThreadAction[] = [{ type: 'POST_COMMENT', body: '## Review Complete' }]
 
       await executeThreadActions(actions, githubContext, mockLogger, mockExecutor)
 
@@ -181,7 +114,7 @@ describe('executeThreadActions', () => {
   })
 
   describe('FETCH_THREADS action', () => {
-    it('should be a no-op (placeholder for future implementation)', async () => {
+    it('is a read-allowed no-op at the gateway (skipped)', async () => {
       const actions: ThreadAction[] = [{ type: 'FETCH_THREADS' }]
       const context: ExecutionContext = {
         platform: 'gitlab',
@@ -197,7 +130,7 @@ describe('executeThreadActions', () => {
     })
   })
 
-  describe('execution order and error handling', () => {
+  describe('error handling on the allowed (postComment) path', () => {
     const context: ExecutionContext = {
       platform: 'gitlab',
       projectPath: 'test/project',
@@ -205,32 +138,14 @@ describe('executeThreadActions', () => {
       localPath: '/tmp/repo',
     }
 
-    it('should execute actions in order', async () => {
-      const executionOrder: string[] = []
-      const trackingExecutor: CommandExecutor = vi.fn((_cmd, args) => {
-        const threadId = args.find((a: string) => a.includes('discussions/'))?.split('discussions/')[1]?.split('/')[0]
-        executionOrder.push(threadId || 'unknown')
-      })
-
-      const actions: ThreadAction[] = [
-        { type: 'THREAD_REPLY', threadId: 'first', message: 'msg' },
-        { type: 'THREAD_RESOLVE', threadId: 'second' },
-        { type: 'THREAD_REPLY', threadId: 'third', message: 'msg' },
-      ]
-
-      await executeThreadActions(actions, context, mockLogger, trackingExecutor)
-
-      expect(executionOrder).toEqual(['first', 'second', 'third'])
-    })
-
-    it('should continue execution after API error', async () => {
+    it('continues execution after an API error on a postComment', async () => {
       const failingExecutor: CommandExecutor = vi.fn()
         .mockImplementationOnce(() => { throw new Error('API 404') })
         .mockImplementationOnce(() => {})
 
       const actions: ThreadAction[] = [
-        { type: 'THREAD_RESOLVE', threadId: 'invalid' },
-        { type: 'THREAD_RESOLVE', threadId: 'valid' },
+        { type: 'POST_COMMENT', body: 'first' },
+        { type: 'POST_COMMENT', body: 'second' },
       ]
 
       const result = await executeThreadActions(actions, context, mockLogger, failingExecutor)
@@ -240,26 +155,25 @@ describe('executeThreadActions', () => {
       expect(result.succeeded).toBe(1)
     })
 
-    it('should return execution summary', async () => {
+    it('summarises a mixed stream: dropped write verbs never reach the executor', async () => {
       const actions: ThreadAction[] = [
         { type: 'THREAD_RESOLVE', threadId: 'a' },
-        { type: 'THREAD_RESOLVE', threadId: 'b' },
+        { type: 'POST_COMMENT', body: 'note' },
         { type: 'FETCH_THREADS' },
       ]
 
       const result = await executeThreadActions(actions, context, mockLogger, mockExecutor)
 
-      expect(result).toEqual({
-        total: 3,
-        succeeded: 2,
-        failed: 0,
-        skipped: 1,
-      })
+      // THREAD_RESOLVE filtered out entirely; gateway sees POST_COMMENT + FETCH_THREADS.
+      expect(mockExecutor).toHaveBeenCalledTimes(1)
+      expect(result.total).toBe(2)
+      expect(result.succeeded).toBe(1)
+      expect(result.skipped).toBe(1)
     })
   })
 
   describe('empty actions', () => {
-    it('should return zero counts for empty actions array', async () => {
+    it('returns zero counts for an empty actions array', async () => {
       const context: ExecutionContext = {
         platform: 'gitlab',
         projectPath: 'test/project',
@@ -269,12 +183,7 @@ describe('executeThreadActions', () => {
 
       const result = await executeThreadActions([], context, mockLogger, mockExecutor)
 
-      expect(result).toEqual({
-        total: 0,
-        succeeded: 0,
-        failed: 0,
-        skipped: 0,
-      })
+      expect(result).toEqual({ total: 0, succeeded: 0, failed: 0, skipped: 0 })
       expect(mockExecutor).not.toHaveBeenCalled()
     })
   })


### PR DESCRIPTION
## Summary

Consolidated implementation of six reconciled platform-integration specs (**SPEC-196 → SPEC-201**) hardening the webhook → LLM-review → platform-write pipeline. All six are implemented on this branch, integrated, and green.

Spec slugs: `196-least-privilege-platform-token`, `197-trusted-actor-provenance-gate`, `198-constrained-action-surface`, `199-review-output-egress-scan`, `200-webhook-event-idempotency`, `201-transport-provenance-hardening`.

## What's in scope

| Spec | Change |
|------|--------|
| **196** Least-privilege executor token | Dedicated service token (fail-closed), allowlist process env, isolated `HOME`/`GLAB_CONFIG_DIR`, per-action capability table + merge-blocking CI gate; `revoke`/`THREAD_RESOLVE` unwired from the auto path. **AC9**: `(projectPath, mrNumber)` pinned to a server-validated source (configured repo + gated MR), fail-closed. |
| **197** Trusted-actor trigger gate | Membership gateway (cached, fail-closed), `isTrustedActor` resolver wired into reviewer-add / followup / note triggers; non-trusted actors park at the `gateClaudeInvocation` pending chokepoint. Resolves membership by `event.user.username` (the field GitLab actually sends — see spec amendment). |
| **198** Constrained action surface | Untrusted write surface = `postComment` only; `FETCH_THREADS` trusted-gated; `THREAD_RESOLVE`/`THREAD_REPLY` target-validated against an authenticated thread inventory. **AC-10**: inventory resolved only from `threadFetchGateway.fetchThreads`, **complete pagination or fail-closed-empty**. |
| **199** Output egress scan | Single decorated post sink (secret-shape / length / out-of-scope scan, allow/redact/block, fail-closed, trace-without-secret); `POST_COMMENT` and `THREAD_REPLY` routed through it. |
| **200** Webhook idempotency | `getGitLabEventUuid` extractor + `IdempotencyStore` (atomic `recordIfAbsent`); guard placed right after token verify; duplicate UUID → `200` no-op; missing UUID degrades to gated. |
| **201** Transport hardening | `evaluateTransport` (socket trust → https → IP allowlist, reject `403`), transport guard middleware at the head of the chain, `trust proxy` scoped to a single hop; webhook token rotation without redeploy; length-oracle pre-check removed. |

## Two reconciliation invariants

- **196 ↔ 198 coexistence**: `revoke`/`THREAD_RESOLVE` are removed from the *auto* path (196) while 198's target-validation logic is retained for the trusted / future-write-executor case (gated by `skipAutoCapabilityFilter`). Both hold simultaneously.
- **Merge order**: 198 hardens the verb while it exists; 196 then removes it from the auto path (`198 blocks 196`). On this consolidated branch the ordering is internal to the merge.

## Verification

- `yarn verify` (typecheck + lint + test:ci): **green — 3168 tests across 411 files, exit 0**.
- Adversarial runtime pentest: **GO**. Replayed corpus held — forged actor → park, forged/partial thread inventory → zero side effects, forged `mrNumber` non-retargetable, UUID replay → `200` no-op, secret-shape egress redacted at the single sink, Reporter-scoped token cannot perform write actions.

## Known residual (non-blocking)

The note-trigger actor gate (197 AC3) is verified by code inspection + the shared `resolveActorTrust` helper (runtime-proven on the reviewer-add and followup paths), but does not yet have its own dedicated note-hook runtime test. Recommended follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
