### PR TITLE
test: raise coverage to 80% + Stryker mutation pilot (insights)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ claude-review.desktop
 # VitePress
 docs/.vitepress/dist
 docs/.vitepress/cache
+
+# Stryker (mutation testing)
+.stryker-tmp/
+reports/mutation/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ DOMAIN LAYER (Entities, Business Rules)
 
 ### Coverage Requirements
 
-Branches 80%, Functions 40%, Lines 30%, Statements 30%
+Statements 80%, Branches 80%, Functions 80%, Lines 80% — enforced via `coverage.thresholds` in `vitest.config.ts` (`yarn coverage` fails below).
 
 ### Test Structure
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test:ui": "vitest --ui",
     "test:ci": "vitest --run",
     "coverage": "vitest --coverage",
+    "test:mutation": "stryker run",
     "lint": "biome check src/",
     "lint:fix": "biome check --write src/",
     "verify": "yarn typecheck && yarn lint && yarn test:ci",
@@ -69,6 +70,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",
+    "@stryker-mutator/core": "^9.6.1",
+    "@stryker-mutator/vitest-runner": "^9.6.1",
     "@types/node": "^20.0.0",
     "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^4.0.18",

--- a/src/tests/stubs/claudeSession.stub.ts
+++ b/src/tests/stubs/claudeSession.stub.ts
@@ -35,6 +35,10 @@ export class StubClaudeSessionGateway implements ClaudeSessionGateway {
   private usageValue: UsageReport = { usesApiPool: false, raw: 'subscription pool' };
   private scheduledAgentStatuses: ScheduledAgentStatus[] = [];
   private sessionUsageResult: SessionUsageSnapshot | null = null;
+  private stopResult: CleanupResult = { success: true, warning: null };
+  private removeResult: CleanupResult = { success: true, warning: null };
+  private stopError: unknown = null;
+  private removeError: unknown = null;
 
   setDispatchResult(result: DispatchResult): void {
     this.dispatchResult = result;
@@ -50,6 +54,22 @@ export class StubClaudeSessionGateway implements ClaudeSessionGateway {
 
   setSessionUsage(value: SessionUsageSnapshot | null): void {
     this.sessionUsageResult = value;
+  }
+
+  setStopResult(result: CleanupResult): void {
+    this.stopResult = result;
+  }
+
+  setRemoveResult(result: CleanupResult): void {
+    this.removeResult = result;
+  }
+
+  setStopError(error: unknown): void {
+    this.stopError = error;
+  }
+
+  setRemoveError(error: unknown): void {
+    this.removeError = error;
   }
 
   scheduleAgentCompletion(
@@ -71,12 +91,18 @@ export class StubClaudeSessionGateway implements ClaudeSessionGateway {
 
   async stop(sessionId: SessionId): Promise<CleanupResult> {
     this.stopCalls.push(sessionId);
-    return { success: true, warning: null };
+    if (this.stopError !== null) {
+      throw this.stopError;
+    }
+    return this.stopResult;
   }
 
   async remove(sessionId: SessionId): Promise<CleanupResult> {
     this.removeCalls.push(sessionId);
-    return { success: true, warning: null };
+    if (this.removeError !== null) {
+      throw this.removeError;
+    }
+    return this.removeResult;
   }
 
   async listAgents(): Promise<AgentStatusEntry[]> {

--- a/src/tests/units/entities/insight/teamInsight.guard.test.ts
+++ b/src/tests/units/entities/insight/teamInsight.guard.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseTeamInsight,
+  safeParseTeamInsight,
+  isValidTeamInsight,
+} from '@/modules/statistics-insights/entities/insight/teamInsight.guard.js';
+import { TeamInsightFactory } from '@/tests/factories/teamInsight.factory.js';
+
+describe('TeamInsight guard', () => {
+  describe('parseTeamInsight', () => {
+    it('should return the typed insight for a valid object', () => {
+      const valid = TeamInsightFactory.createValid();
+
+      const result = parseTeamInsight(valid);
+
+      expect(result.developerCount).toBe(3);
+      expect(result.averageLevels.quality).toBe(6);
+      expect(result.strengths).toEqual(['codeVolume']);
+    });
+
+    it('should throw with the instigator label for an invalid object', () => {
+      expect(() => parseTeamInsight({ developerCount: -1 })).toThrow(/teamInsight/);
+    });
+  });
+
+  describe('safeParseTeamInsight', () => {
+    it('should succeed for a valid object', () => {
+      const valid = TeamInsightFactory.createValid();
+
+      const result = safeParseTeamInsight(valid);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should fail when averageLevels is out of bounds', () => {
+      const invalid = TeamInsightFactory.create({
+        averageLevels: { quality: 11, responsiveness: 5, codeVolume: 7, iteration: 5 },
+      });
+
+      const result = safeParseTeamInsight(invalid);
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('isValidTeamInsight', () => {
+    it('should return true for a valid object', () => {
+      const valid = TeamInsightFactory.createValid();
+
+      expect(isValidTeamInsight(valid)).toBe(true);
+    });
+
+    it('should return false for an unknown strength category', () => {
+      const invalid = TeamInsightFactory.create({ strengths: ['unknownCategory'] });
+
+      expect(isValidTeamInsight(invalid)).toBe(false);
+    });
+
+    it('should return false for a non-object input', () => {
+      expect(isValidTeamInsight(null)).toBe(false);
+    });
+  });
+});

--- a/src/tests/units/interface-adapters/controllers/http/stats.routes.test.ts
+++ b/src/tests/units/interface-adapters/controllers/http/stats.routes.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import type { FastifyInstance } from 'fastify';
+import { statsRoutes } from '@/modules/statistics-insights/interface-adapters/controllers/http/stats.routes.js';
+import { InMemoryStatsGateway } from '@/tests/stubs/stats.stub.js';
+import { ProjectStatsFactory, ReviewStatsFactory } from '@/tests/factories/projectStats.factory.js';
+
+interface RepositoryInfo {
+  localPath: string;
+  name: string;
+  enabled: boolean;
+  platform?: string;
+}
+
+describe('stats routes', () => {
+  let app: FastifyInstance;
+  let statsGateway: InMemoryStatsGateway;
+  let repositories: RepositoryInfo[];
+
+  const register = async (extra: Record<string, unknown> = {}): Promise<void> => {
+    await app.register(statsRoutes, {
+      statsGateway,
+      getRepositories: () => repositories,
+      ...extra,
+    });
+    await app.ready();
+  };
+
+  beforeEach(() => {
+    app = Fastify();
+    statsGateway = new InMemoryStatsGateway();
+    repositories = [];
+  });
+
+  describe('GET /api/stats with explicit path', () => {
+    it('should reject a relative path', async () => {
+      await register();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/stats?path=relative/path',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ error: 'Invalid path' });
+    });
+
+    it('should reject a path containing directory traversal', async () => {
+      await register();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/stats?path=/etc/../passwd',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ error: 'Invalid path' });
+    });
+
+    it('should return null stats and summary when project has no stats', async () => {
+      await register();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/stats?path=/unknown/project',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ stats: null, summary: null });
+    });
+
+    it('should return stats and summary when project has stats', async () => {
+      const reviews = [
+        ReviewStatsFactory.create({ id: 'r1', mrNumber: 1, score: 8 }),
+      ];
+      statsGateway.saveProjectStats('/known/project', ProjectStatsFactory.withReviews(reviews));
+      await register();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/stats?path=/known/project',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.stats).not.toBeNull();
+      expect(body.stats.totalReviews).toBe(1);
+      expect(body.summary).not.toBeNull();
+    });
+
+    it('should treat a whitespace-only path as no path and list projects', async () => {
+      await register();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/stats?path=%20%20',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ projects: [] });
+    });
+  });
+
+  describe('GET /api/stats listing all repositories', () => {
+    it('should skip disabled repositories', async () => {
+      repositories = [
+        { localPath: '/disabled/project', name: 'Disabled', enabled: false },
+      ];
+      statsGateway.saveProjectStats('/disabled/project', ProjectStatsFactory.withReviews([]));
+      await register();
+
+      const response = await app.inject({ method: 'GET', url: '/api/stats' });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ projects: [] });
+    });
+
+    it('should skip enabled repositories without stats', async () => {
+      repositories = [
+        { localPath: '/enabled/no-stats', name: 'NoStats', enabled: true },
+      ];
+      await register();
+
+      const response = await app.inject({ method: 'GET', url: '/api/stats' });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ projects: [] });
+    });
+
+    it('should include enabled repositories with stats', async () => {
+      repositories = [
+        { localPath: '/enabled/with-stats', name: 'WithStats', enabled: true },
+      ];
+      const reviews = [ReviewStatsFactory.create({ id: 'r1', mrNumber: 1, score: 7 })];
+      statsGateway.saveProjectStats('/enabled/with-stats', ProjectStatsFactory.withReviews(reviews));
+      await register();
+
+      const response = await app.inject({ method: 'GET', url: '/api/stats' });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.projects).toHaveLength(1);
+      expect(body.projects[0].project).toBe('WithStats');
+      expect(body.projects[0].path).toBe('/enabled/with-stats');
+      expect(body.projects[0].summary).toBeDefined();
+    });
+  });
+
+  describe('POST /api/stats/recalculate', () => {
+    it('should return 400 when body is missing the path', async () => {
+      await register();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/stats/recalculate',
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json()).toEqual({ error: 'Chemin du projet requis' });
+    });
+
+    it('should return 400 when the body fails validation', async () => {
+      await register();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/stats/recalculate',
+        payload: { path: 123 },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json()).toEqual({ error: 'Chemin du projet requis' });
+    });
+
+    it('should return 400 when the path is only whitespace', async () => {
+      await register();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/stats/recalculate',
+        payload: { path: '   ' },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 404 when the project is not in the configuration', async () => {
+      repositories = [];
+      await register();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/stats/recalculate',
+        payload: { path: '/missing/project' },
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json()).toEqual({ error: 'Projet non trouvé dans la configuration' });
+    });
+
+    it('should return 404 when the matching repository is disabled', async () => {
+      repositories = [
+        { localPath: '/disabled/project', name: 'Disabled', enabled: false },
+      ];
+      await register();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/stats/recalculate',
+        payload: { path: '/disabled/project' },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should start recalculation for an enabled repository without optional dependencies', async () => {
+      repositories = [
+        { localPath: '/enabled/project', name: 'Enabled', enabled: true },
+      ];
+      statsGateway.saveProjectStats('/enabled/project', ProjectStatsFactory.withReviews([]));
+      await register();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/stats/recalculate',
+        payload: { path: '/enabled/project' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ status: 'started' });
+    });
+
+    it('should start recalculation and forward progress through broadcast and logger', async () => {
+      repositories = [
+        { localPath: '/enabled/project', name: 'Enabled', enabled: true, platform: 'github' },
+      ];
+      statsGateway.saveProjectStats('/enabled/project', ProjectStatsFactory.withReviews([]));
+
+      const progressEvents: unknown[] = [];
+      const warnings: string[] = [];
+      const errors: string[] = [];
+
+      await register({
+        broadcastBackfillProgress: (progress: unknown) => {
+          progressEvents.push(progress);
+        },
+        logger: {
+          warn: (message: string) => warnings.push(message),
+          info: (_message: string) => {},
+          error: (message: string) => errors.push(message),
+        },
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/stats/recalculate',
+        payload: { path: '/enabled/project', backfill: false },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ status: 'started' });
+    });
+  });
+});

--- a/src/tests/units/interface-adapters/controllers/mcp/addAction.handler.test.ts
+++ b/src/tests/units/interface-adapters/controllers/mcp/addAction.handler.test.ts
@@ -97,4 +97,115 @@ describe("addAction handler", () => {
 		expect(result.isError).toBe(true);
 		expect(result.content[0].text).toContain("threadId required");
 	});
+
+	it("should add THREAD_RESOLVE action with an optional message", () => {
+		const handler = createAddActionHandler({ jobContextGateway, reviewContextGateway });
+		const result = handler({
+			jobId,
+			type: "THREAD_RESOLVE",
+			threadId: "t1",
+			message: "Resolved by automation",
+		});
+
+		expect(result.isError).toBeUndefined();
+		const content = JSON.parse(result.content[0].text);
+		expect(content.success).toBe(true);
+		expect(content.actionType).toBe("THREAD_RESOLVE");
+	});
+
+	it("should add THREAD_REPLY action successfully", () => {
+		const handler = createAddActionHandler({ jobContextGateway, reviewContextGateway });
+		const result = handler({
+			jobId,
+			type: "THREAD_REPLY",
+			threadId: "t1",
+			message: "Thanks for the feedback.",
+		});
+
+		expect(result.isError).toBeUndefined();
+		const content = JSON.parse(result.content[0].text);
+		expect(content.success).toBe(true);
+		expect(content.actionType).toBe("THREAD_REPLY");
+	});
+
+	it("should return error when THREAD_REPLY missing threadId", () => {
+		const handler = createAddActionHandler({ jobContextGateway, reviewContextGateway });
+		const result = handler({ jobId, type: "THREAD_REPLY", message: "reply" });
+
+		expect(result.isError).toBe(true);
+		expect(result.content[0].text).toContain("threadId required");
+	});
+
+	it("should return error when THREAD_REPLY missing message", () => {
+		const handler = createAddActionHandler({ jobContextGateway, reviewContextGateway });
+		const result = handler({ jobId, type: "THREAD_REPLY", threadId: "t1" });
+
+		expect(result.isError).toBe(true);
+		expect(result.content[0].text).toContain("message required");
+	});
+
+	it("should return error when POST_COMMENT missing body", () => {
+		const handler = createAddActionHandler({ jobContextGateway, reviewContextGateway });
+		const result = handler({ jobId, type: "POST_COMMENT" });
+
+		expect(result.isError).toBe(true);
+		expect(result.content[0].text).toContain("body required");
+	});
+
+	it("should return error when POST_INLINE_COMMENT has a non-string filePath", () => {
+		const handler = createAddActionHandler({ jobContextGateway, reviewContextGateway });
+		const result = handler({
+			jobId,
+			type: "POST_INLINE_COMMENT",
+			line: 42,
+			body: "Extract this logic.",
+		});
+
+		expect(result.isError).toBe(true);
+		expect(result.content[0].text).toContain("filePath required");
+	});
+
+	it("should return error when POST_INLINE_COMMENT has a non-number line", () => {
+		const handler = createAddActionHandler({ jobContextGateway, reviewContextGateway });
+		const result = handler({
+			jobId,
+			type: "POST_INLINE_COMMENT",
+			filePath: "src/app.ts",
+			line: "42",
+			body: "Extract this logic.",
+		});
+
+		expect(result.isError).toBe(true);
+		expect(result.content[0].text).toContain("line must be > 0");
+	});
+
+	it("should return error when the job context is not found", () => {
+		const handler = createAddActionHandler({ jobContextGateway, reviewContextGateway });
+		const result = handler({
+			jobId: "gitlab:unknown/path:999",
+			type: "POST_COMMENT",
+			body: "Great job!",
+		});
+
+		expect(result.isError).toBe(true);
+		expect(result.content[0].text).toContain("Job context not found");
+	});
+
+	it("should return error when appending to the review context fails", () => {
+		const orphanJobId = "gitlab:orphan/path:7";
+		jobContextGateway.register(orphanJobId, {
+			localPath: tempDir,
+			mergeRequestId: "gitlab-orphan-path-7",
+		});
+
+		const handler = createAddActionHandler({ jobContextGateway, reviewContextGateway });
+		const result = handler({
+			jobId: orphanJobId,
+			type: "POST_COMMENT",
+			body: "Great job!",
+		});
+
+		expect(result.isError).toBe(true);
+		expect(result.content[0].text).toContain("Failed to append action to review context");
+	});
 });

--- a/src/tests/units/interface-adapters/controllers/webhook/github.controller.test.ts
+++ b/src/tests/units/interface-adapters/controllers/webhook/github.controller.test.ts
@@ -79,6 +79,8 @@ import { GitHubEventFactory } from '../../../../factories/gitHubEvent.factory.js
 import { createStubLogger } from '../../../../stubs/logger.stub.js';
 import { enqueueReview } from '../../../../../frameworks/queue/pQueueAdapter.js';
 import { invokeClaudeReview } from '../../../../../claude/invoker.js';
+import { verifyGitHubSignature, getGitHubEventType } from '../../../../../security/verifier.js';
+import { findRepositoryByRemoteUrl } from '../../../../../config/loader.js';
 import { TrackedMrFactory } from '../../../../factories/trackedMr.factory.js';
 import type { TrackedMr } from '@/modules/tracking/entities/tracking/trackedMr.js';
 
@@ -829,6 +831,443 @@ describe('handleGitHubWebhook', () => {
       expect(mockReply.status).toHaveBeenCalledWith(200);
       expect(mockReply.send).toHaveBeenCalledWith(
         expect.objectContaining({ status: 'cleaned' }),
+      );
+    });
+  });
+
+  describe('signature and event-type gating', () => {
+    afterEach(() => {
+      vi.mocked(verifyGitHubSignature).mockReturnValue({ valid: true });
+      vi.mocked(getGitHubEventType).mockReturnValue('pull_request');
+    });
+
+    it('responds 401 when signature verification fails', async () => {
+      vi.mocked(verifyGitHubSignature).mockReturnValue({
+        valid: false,
+        error: 'bad-signature',
+      });
+
+      const event = GitHubEventFactory.createReviewRequestedPr('claude-bot');
+      const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, mockDeps);
+
+      expect(mockReply.status).toHaveBeenCalledWith(401);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'bad-signature' });
+      expect(enqueueReview).not.toHaveBeenCalled();
+    });
+
+    it('ignores a non-PR event type', async () => {
+      vi.mocked(getGitHubEventType).mockReturnValue('ping');
+
+      const request = { body: {}, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, mockDeps);
+
+      expect(mockReply.status).toHaveBeenCalledWith(200);
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'ignored', reason: 'Not a PR event' }),
+      );
+      expect(enqueueReview).not.toHaveBeenCalled();
+    });
+
+    it('responds 400 when the pull_request payload is not parseable', async () => {
+      const request = {
+        body: { not: 'a valid PR payload' },
+        headers: {},
+      } as unknown as FastifyRequest;
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, mockDeps);
+
+      expect(mockReply.status).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ error: 'Invalid webhook payload' }),
+      );
+      expect(enqueueReview).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('repository configuration gating', () => {
+    afterEach(() => {
+      vi.mocked(findRepositoryByRemoteUrl).mockReturnValue(mockRepoConfig);
+    });
+
+    it('ignores a review request when the repository is not configured', async () => {
+      vi.mocked(findRepositoryByRemoteUrl).mockReturnValue(undefined);
+
+      const event = GitHubEventFactory.createReviewRequestedPr('claude-bot');
+      const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, mockDeps);
+
+      expect(mockReply.status).toHaveBeenCalledWith(200);
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'ignored', reason: 'Repository not configured' }),
+      );
+      expect(enqueueReview).not.toHaveBeenCalled();
+    });
+
+    it('acknowledges a closed PR when the repository is not configured', async () => {
+      vi.mocked(findRepositoryByRemoteUrl).mockReturnValue(undefined);
+
+      const event = GitHubEventFactory.createClosedPr();
+      const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, mockDeps);
+
+      expect(mockReply.status).toHaveBeenCalledWith(200);
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'ignored',
+          reason: 'PR closed, repo not configured',
+        }),
+      );
+    });
+  });
+
+  describe('deduplication on enqueue', () => {
+    it('responds 200 deduplicated when enqueueReview returns false', async () => {
+      vi.mocked(enqueueReview).mockResolvedValue(false);
+
+      const event = GitHubEventFactory.createReviewRequestedPr('claude-bot');
+      const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, mockDeps);
+
+      expect(mockReply.status).toHaveBeenCalledWith(200);
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'deduplicated' }),
+      );
+    });
+  });
+
+  describe('issue_comment hook', () => {
+    afterEach(() => {
+      vi.mocked(getGitHubEventType).mockReturnValue('pull_request');
+    });
+
+    function buildCommentRequest(body: string): FastifyRequest {
+      vi.mocked(getGitHubEventType).mockReturnValue('issue_comment');
+      return {
+        body: {
+          action: 'created',
+          issue: { number: 123, pull_request: { url: 'https://api/pr/123' } },
+          comment: { body, user: { login: 'commenter' } },
+          repository: {
+            full_name: 'test-owner/test-repo',
+            html_url: 'https://github.com/test-owner/test-repo',
+            clone_url: 'https://github.com/test-owner/test-repo.git',
+          },
+          sender: { login: 'commenter' },
+        },
+        headers: {},
+      } as unknown as FastifyRequest;
+    }
+
+    it('ignores an unparseable issue_comment payload', async () => {
+      vi.mocked(getGitHubEventType).mockReturnValue('issue_comment');
+      const request = { body: { action: 'created' }, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, mockDeps);
+
+      expect(mockReply.status).toHaveBeenCalledWith(200);
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'Comment payload not parseable' }),
+      );
+    });
+
+    it('ignores a comment for an unconfigured repository', async () => {
+      vi.mocked(findRepositoryByRemoteUrl).mockReturnValue(undefined);
+      const request = buildCommentRequest('/bypass: shipping hotfix');
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, mockDeps);
+
+      vi.mocked(findRepositoryByRemoteUrl).mockReturnValue(mockRepoConfig);
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'ignored', reason: 'Repository not configured' }),
+      );
+    });
+
+    it('posts a comment and responds bypass-rejected when a marker has no reason', async () => {
+      (mockDeps.recordBypass.execute as ReturnType<typeof vi.fn>).mockReturnValue({
+        kind: 'rejected-missing-reason',
+        message: 'Please provide a reason',
+      });
+      const request = buildCommentRequest('/bypass');
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, mockDeps);
+
+      expect(mockDeps.noteCommentPostGateway.postComment).toHaveBeenCalledWith(
+        expect.objectContaining({ body: 'Please provide a reason' }),
+      );
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'bypass-rejected', reason: 'missing-reason' }),
+      );
+    });
+
+    it('responds bypass-recorded when a valid bypass marker is recorded', async () => {
+      (mockDeps.recordBypass.execute as ReturnType<typeof vi.fn>).mockReturnValue({
+        kind: 'recorded',
+        bypass: { author: 'commenter', reason: 'hotfix', recordedAt: '2026-05-26T12:00:00.000Z' },
+      });
+      const request = buildCommentRequest('/bypass: hotfix');
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, mockDeps);
+
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'bypass-recorded' }),
+      );
+    });
+
+    it('ignores a bypass marker on an untracked PR', async () => {
+      (mockDeps.recordBypass.execute as ReturnType<typeof vi.fn>).mockReturnValue({
+        kind: 'mr-not-found',
+      });
+      const request = buildCommentRequest('/bypass: hotfix');
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, mockDeps);
+
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'ignored', reason: 'PR not tracked' }),
+      );
+    });
+
+    it('ignores a comment without a bypass marker', async () => {
+      (mockDeps.recordBypass.execute as ReturnType<typeof vi.fn>).mockReturnValue({
+        kind: 'no-marker',
+      });
+      const request = buildCommentRequest('just a normal comment');
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, mockDeps);
+
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'ignored', reason: 'No bypass marker' }),
+      );
+    });
+  });
+
+  describe('pull_request_review hook', () => {
+    afterEach(() => {
+      vi.mocked(getGitHubEventType).mockReturnValue('pull_request');
+    });
+
+    function buildApprovalRequest(): FastifyRequest {
+      vi.mocked(getGitHubEventType).mockReturnValue('pull_request_review');
+      return {
+        body: {
+          action: 'submitted',
+          review: { id: 55, state: 'approved', user: { login: 'approver' } },
+          pull_request: { number: 123, state: 'open' },
+          repository: {
+            full_name: 'test-owner/test-repo',
+            clone_url: 'https://github.com/test-owner/test-repo.git',
+          },
+          sender: { login: 'approver' },
+        },
+        headers: {},
+      } as unknown as FastifyRequest;
+    }
+
+    it('ignores an unparseable pull_request_review payload', async () => {
+      vi.mocked(getGitHubEventType).mockReturnValue('pull_request_review');
+      const request = { body: { action: 'submitted' }, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, mockDeps);
+
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'pull_request_review payload not parseable' }),
+      );
+    });
+
+    it('ignores a non-approval review', async () => {
+      vi.mocked(getGitHubEventType).mockReturnValue('pull_request_review');
+      const request = {
+        body: {
+          action: 'submitted',
+          review: { id: 55, state: 'commented', user: { login: 'approver' } },
+          pull_request: { number: 123, state: 'open' },
+          repository: {
+            full_name: 'test-owner/test-repo',
+            clone_url: 'https://github.com/test-owner/test-repo.git',
+          },
+          sender: { login: 'approver' },
+        },
+        headers: {},
+      } as unknown as FastifyRequest;
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, mockDeps);
+
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'ignored', reason: 'Review state is commented, not approved' }),
+      );
+    });
+
+    it('ignores an approval for an unconfigured repository', async () => {
+      vi.mocked(findRepositoryByRemoteUrl).mockReturnValue(undefined);
+      const request = buildApprovalRequest();
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, mockDeps);
+
+      vi.mocked(findRepositoryByRemoteUrl).mockReturnValue(mockRepoConfig);
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'ignored', reason: 'Repository not configured' }),
+      );
+    });
+
+    it('marks the PR approved when the state transition succeeds', async () => {
+      (mockDeps.transitionState.execute as ReturnType<typeof vi.fn>).mockReturnValue({ ok: true });
+      const request = buildApprovalRequest();
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, mockDeps);
+
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'approved', prNumber: 123 }),
+      );
+    });
+
+    it('revokes the approval and posts an FR comment when quality gate reverts it', async () => {
+      (mockDeps.transitionState.execute as ReturnType<typeof vi.fn>).mockReturnValue({
+        ok: false,
+        reason: 'quality-gate',
+        message: 'gate failed',
+      });
+      (mockDeps.handlePlatformApproval.execute as ReturnType<typeof vi.fn>).mockReturnValue({
+        kind: 'reverted',
+        reason: 'below-threshold',
+        message: 'Score trop bas',
+      });
+      const request = buildApprovalRequest();
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, mockDeps);
+
+      expect(mockDeps.approvalRevocationGateway.revoke).toHaveBeenCalledWith(
+        expect.objectContaining({ mrNumber: 123, reviewId: 55 }),
+      );
+      expect(mockDeps.noteCommentPostGateway.postComment).toHaveBeenCalledWith(
+        expect.objectContaining({ body: 'Score trop bas' }),
+      );
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'unapproved', prNumber: 123, reason: 'below-threshold' }),
+      );
+    });
+
+    it('keeps responding unapproved when the revocation gateway throws', async () => {
+      (mockDeps.transitionState.execute as ReturnType<typeof vi.fn>).mockReturnValue({
+        ok: false,
+        reason: 'quality-gate',
+        message: 'gate failed',
+      });
+      (mockDeps.handlePlatformApproval.execute as ReturnType<typeof vi.fn>).mockReturnValue({
+        kind: 'reverted',
+        reason: 'blockers-present',
+        message: 'Blocages restants',
+      });
+      (mockDeps.approvalRevocationGateway.revoke as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('GitHub API down'),
+      );
+      (mockDeps.noteCommentPostGateway.postComment as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('comment failed'),
+      );
+      const request = buildApprovalRequest();
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, mockDeps);
+
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'unapproved', reason: 'blockers-present' }),
+      );
+    });
+
+    it('ignores the approval when the quality gate verdict is not reverted', async () => {
+      (mockDeps.transitionState.execute as ReturnType<typeof vi.fn>).mockReturnValue({
+        ok: false,
+        reason: 'quality-gate',
+        message: 'gate failed',
+      });
+      (mockDeps.handlePlatformApproval.execute as ReturnType<typeof vi.fn>).mockReturnValue({
+        kind: 'bypass-active',
+      });
+      const request = buildApprovalRequest();
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, mockDeps);
+
+      expect(mockDeps.approvalRevocationGateway.revoke).not.toHaveBeenCalled();
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'ignored', prNumber: 123, reason: 'bypass-active' }),
+      );
+    });
+
+    it('ignores the approval when the transition fails for a non-quality-gate reason', async () => {
+      (mockDeps.transitionState.execute as ReturnType<typeof vi.fn>).mockReturnValue({
+        ok: false,
+        reason: 'not-found',
+      });
+      const request = buildApprovalRequest();
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, mockDeps);
+
+      expect(mockDeps.handlePlatformApproval.execute).not.toHaveBeenCalled();
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'ignored', prNumber: 123, reason: 'not-found' }),
+      );
+    });
+  });
+
+  describe('gated invocation (gateClaudeInvocation present)', () => {
+    it('responds 202 pending-confirmation when the gate parks the review', async () => {
+      const deps = {
+        ...mockDeps,
+        gateClaudeInvocation: {
+          execute: vi.fn(async () => ({ status: 'pending', pendingId: 'pending-1' })),
+        },
+      } as unknown as GitHubWebhookDependencies;
+
+      const event = GitHubEventFactory.createReviewRequestedPr('claude-bot');
+      const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, deps);
+
+      expect(enqueueReview).not.toHaveBeenCalled();
+      expect(mockReply.status).toHaveBeenCalledWith(202);
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'pending-confirmation', pendingId: 'pending-1', prNumber: 123 }),
+      );
+    });
+
+    it('responds 202 queued when the gate enqueues the review', async () => {
+      const deps = {
+        ...mockDeps,
+        gateClaudeInvocation: {
+          execute: vi.fn(async () => ({ status: 'enqueued' })),
+        },
+      } as unknown as GitHubWebhookDependencies;
+
+      const event = GitHubEventFactory.createReviewRequestedPr('claude-bot');
+      const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, deps);
+
+      expect(mockReply.status).toHaveBeenCalledWith(202);
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'queued', prNumber: 123 }),
+      );
+    });
+
+    it('responds 200 deduplicated when the gate deduplicates the review', async () => {
+      const deps = {
+        ...mockDeps,
+        gateClaudeInvocation: {
+          execute: vi.fn(async () => ({ status: 'deduplicated' })),
+        },
+      } as unknown as GitHubWebhookDependencies;
+
+      const event = GitHubEventFactory.createReviewRequestedPr('claude-bot');
+      const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitHubWebhook(request, mockReply, logger, mockGateway, deps);
+
+      expect(mockReply.status).toHaveBeenCalledWith(200);
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'deduplicated' }),
       );
     });
   });

--- a/src/tests/units/interface-adapters/controllers/webhook/gitlab.controller.test.ts
+++ b/src/tests/units/interface-adapters/controllers/webhook/gitlab.controller.test.ts
@@ -29,6 +29,7 @@ vi.mock('@/config/loader.js', () => ({
 vi.mock('@/security/verifier.js', () => ({
   verifyGitLabSignature: vi.fn(() => ({ valid: true })),
   getGitLabEventType: vi.fn(() => 'Merge Request Hook'),
+  getGitLabEventUuid: vi.fn(() => undefined),
 }));
 
 vi.mock('@/frameworks/queue/pQueueAdapter.js', () => ({
@@ -79,9 +80,15 @@ vi.mock('@/modules/platform-integration/interface-adapters/gateways/diffMetadata
 }));
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { handleGitLabWebhook } from '@/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.js';
+import {
+  handleGitLabWebhook,
+  extractBaseUrl,
+  buildGitLabReviewProcessor,
+} from '@/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.js';
 import { enqueueReview } from '@/frameworks/queue/pQueueAdapter.js';
 import { invokeClaudeReview } from '@/claude/invoker.js';
+import { verifyGitLabSignature, getGitLabEventType } from '@/security/verifier.js';
+import { findRepositoryByProjectPath } from '@/config/loader.js';
 import { GitLabEventFactory } from '@/tests/factories/gitLabEvent.factory.js';
 import { createStubLogger } from '@/tests/stubs/logger.stub.js';
 import { TrackedMrFactory } from '@/tests/factories/trackedMr.factory.js';
@@ -672,6 +679,481 @@ describe('handleGitLabWebhook', () => {
         expect(enqueueReview).not.toHaveBeenCalled();
         expect(pendingGateway.saveCount).toBe(1);
       });
+    });
+  });
+
+  describe('extractBaseUrl', () => {
+    it('returns protocol and host for an HTTPS remote', () => {
+      expect(extractBaseUrl('https://gitlab.example.com/group/project.git')).toBe(
+        'https://gitlab.example.com',
+      );
+    });
+
+    it('returns https host for an SSH remote', () => {
+      expect(extractBaseUrl('git@gitlab.example.com:group/project.git')).toBe(
+        'https://gitlab.example.com',
+      );
+    });
+
+    it('returns null for a remote that is neither http nor SSH-shaped', () => {
+      expect(extractBaseUrl('ftp-only-no-at-no-colon-pattern')).toBeNull();
+    });
+
+    it('returns null when the HTTPS URL is malformed', () => {
+      expect(extractBaseUrl('http://')).toBeNull();
+    });
+  });
+
+  describe('request gating before payload parsing', () => {
+    it('returns 401 when the GitLab signature is invalid', async () => {
+      vi.mocked(verifyGitLabSignature).mockReturnValueOnce({ valid: false, error: 'bad-token' });
+      const event = GitLabEventFactory.createWithReviewerAdded('claude-bot');
+      const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitLabWebhook(request, mockReply, logger, mockGateway, defaultDeps);
+
+      expect(mockReply.status).toHaveBeenCalledWith(401);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'bad-token' });
+      expect(enqueueReview).not.toHaveBeenCalled();
+    });
+
+    it('ignores events that are neither Note Hook nor Merge Request Hook', async () => {
+      vi.mocked(getGitLabEventType).mockReturnValueOnce('Pipeline Hook');
+      const event = GitLabEventFactory.createWithReviewerAdded('claude-bot');
+      const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitLabWebhook(request, mockReply, logger, mockGateway, defaultDeps);
+
+      expect(mockReply.status).toHaveBeenCalledWith(200);
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'ignored', reason: 'Not a MR event' }),
+      );
+    });
+
+    it('returns 400 when the merge request payload is not parseable', async () => {
+      const request = { body: { object_kind: 'merge_request' }, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitLabWebhook(request, mockReply, logger, mockGateway, defaultDeps);
+
+      expect(mockReply.status).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Invalid webhook payload' });
+    });
+  });
+
+  describe('Note Hook handling', () => {
+    function buildNoteEvent(note: string) {
+      return {
+        object_kind: 'note',
+        event_type: 'note',
+        user: { username: 'note-author', name: 'Note Author' },
+        project: {
+          id: 1,
+          name: 'test-project',
+          path_with_namespace: 'test-org/test-project',
+          web_url: 'https://gitlab.com/test-org/test-project',
+          git_http_url: 'https://gitlab.com/test-org/test-project.git',
+        },
+        object_attributes: {
+          id: 7,
+          note,
+          noteable_type: 'MergeRequest',
+          noteable_id: 99,
+        },
+        merge_request: {
+          iid: 42,
+          title: 'Test MR',
+          state: 'opened',
+          source_branch: 'feature/test',
+          target_branch: 'main',
+          url: 'https://gitlab.com/test-org/test-project/-/merge_requests/42',
+        },
+      };
+    }
+
+    beforeEach(() => {
+      vi.mocked(getGitLabEventType).mockReturnValue('Note Hook');
+    });
+
+    it('ignores a note payload that does not match the note schema', async () => {
+      const request = { body: { object_kind: 'note' }, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitLabWebhook(request, mockReply, logger, mockGateway, defaultDeps);
+
+      expect(mockReply.status).toHaveBeenCalledWith(200);
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'ignored', reason: 'Note payload not parseable' }),
+      );
+    });
+
+    it('ignores a note when the filter rejects it', async () => {
+      const body = buildNoteEvent('hello');
+      body.object_attributes.noteable_type = 'Issue';
+      const request = { body, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitLabWebhook(request, mockReply, logger, mockGateway, defaultDeps);
+
+      expect(mockReply.status).toHaveBeenCalledWith(200);
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'ignored' }),
+      );
+    });
+
+    it('ignores a note when the repository is not configured', async () => {
+      vi.mocked(findRepositoryByProjectPath).mockReturnValueOnce(undefined);
+      const request = { body: buildNoteEvent('hello'), headers: {} } as unknown as FastifyRequest;
+
+      await handleGitLabWebhook(request, mockReply, logger, mockGateway, defaultDeps);
+
+      expect(mockReply.status).toHaveBeenCalledWith(200);
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'ignored', reason: 'Repository not configured' }),
+      );
+    });
+
+    it('records a bypass when the note carries a valid bypass marker', async () => {
+      const request = {
+        body: buildNoteEvent('/bypass-quality "urgent hotfix"'),
+        headers: {},
+      } as unknown as FastifyRequest;
+
+      await handleGitLabWebhook(request, mockReply, logger, mockGateway, defaultDeps);
+
+      expect(mockGateway.update).toHaveBeenCalledWith(
+        '/home/user/projects/test-project',
+        'gitlab-test-org/test-project-42',
+        expect.objectContaining({ bypass: expect.objectContaining({ reason: 'urgent hotfix' }) }),
+      );
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'bypass-recorded' }),
+      );
+    });
+
+    it('rejects a bypass marker that has no reason and posts an explanation comment', async () => {
+      const noteCommentPostGateway = new StubNoteCommentPostGateway();
+      const deps = { ...defaultDeps, noteCommentPostGateway };
+      const request = {
+        body: buildNoteEvent('/bypass-quality'),
+        headers: {},
+      } as unknown as FastifyRequest;
+
+      await handleGitLabWebhook(request, mockReply, logger, mockGateway, deps);
+
+      expect(noteCommentPostGateway.calls).toHaveLength(1);
+      expect(noteCommentPostGateway.calls[0]).toEqual(
+        expect.objectContaining({ projectPath: 'test-org/test-project', mrNumber: 42 }),
+      );
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'bypass-rejected', reason: 'missing-reason' }),
+      );
+    });
+
+    it('ignores a bypass marker when the MR is not tracked', async () => {
+      mockGateway.getById.mockReturnValue(null);
+      const request = {
+        body: buildNoteEvent('/bypass-quality "reason here"'),
+        headers: {},
+      } as unknown as FastifyRequest;
+
+      await handleGitLabWebhook(request, mockReply, logger, mockGateway, defaultDeps);
+
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'ignored', reason: 'MR not tracked' }),
+      );
+    });
+
+    it('ignores a note that carries no bypass marker', async () => {
+      const request = {
+        body: buildNoteEvent('just a normal comment'),
+        headers: {},
+      } as unknown as FastifyRequest;
+
+      await handleGitLabWebhook(request, mockReply, logger, mockGateway, defaultDeps);
+
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'ignored', reason: 'No bypass marker' }),
+      );
+    });
+
+    it('parks a note trigger from a non-trusted actor (provenance gate)', async () => {
+      const memberAccess = new StubMemberAccessGateway();
+      memberAccess.setAccess('note-author', MEMBER_ACCESS_LEVELS.reporter);
+      const deps = { ...defaultDeps, isTrustedActor: new IsTrustedActorUseCase(memberAccess) };
+      const request = {
+        body: buildNoteEvent('/bypass-quality "reason here"'),
+        headers: {},
+      } as unknown as FastifyRequest;
+
+      await handleGitLabWebhook(request, mockReply, logger, mockGateway, deps);
+
+      expect(mockReply.status).toHaveBeenCalledWith(202);
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'pending-confirmation', reason: 'untrusted-actor' }),
+      );
+      expect(mockGateway.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('closed MR with unconfigured repository', () => {
+    it('acknowledges without cleanup when the repo is not configured', async () => {
+      vi.mocked(findRepositoryByProjectPath).mockReturnValueOnce(undefined);
+      const event = GitLabEventFactory.createClosedMr();
+      const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitLabWebhook(request, mockReply, logger, mockGateway, defaultDeps);
+
+      expect(mockReply.status).toHaveBeenCalledWith(200);
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'ignored', reason: 'MR closed, repo not configured' }),
+      );
+    });
+  });
+
+  describe('approval quality gate', () => {
+    function buildApprovedMr(overrides: Partial<TrackedMr> = {}): TrackedMr {
+      return TrackedMrFactory.create({
+        id: 'gitlab-test-org/test-project-42',
+        mrNumber: 42,
+        platform: 'gitlab',
+        project: 'test-org/test-project',
+        state: 'pending-review',
+        latestScore: 4,
+        openThreads: 0,
+        bypass: null,
+        ...overrides,
+      });
+    }
+
+    it('revokes the platform approval and posts an FR comment when the quality gate fails', async () => {
+      const trackedMr = buildApprovedMr();
+      mockGateway.getById.mockReturnValue(trackedMr);
+      const approvalRevocationGateway = new StubApprovalRevocationGateway();
+      const noteCommentPostGateway = new StubNoteCommentPostGateway();
+      const deps = {
+        ...defaultDeps,
+        approvalRevocationGateway,
+        noteCommentPostGateway,
+        getQualityThreshold: (): number | null => 8,
+      };
+
+      const event = GitLabEventFactory.createApprovedMr();
+      const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitLabWebhook(request, mockReply, logger, mockGateway, deps);
+
+      expect(approvalRevocationGateway.calls).toHaveLength(1);
+      expect(noteCommentPostGateway.calls).toHaveLength(1);
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'unapproved', mrNumber: 42 }),
+      );
+    });
+
+    it('continues to post the FR comment when revoking the approval throws', async () => {
+      const trackedMr = buildApprovedMr();
+      mockGateway.getById.mockReturnValue(trackedMr);
+      const approvalRevocationGateway = new StubApprovalRevocationGateway();
+      approvalRevocationGateway.shouldThrow = true;
+      const noteCommentPostGateway = new StubNoteCommentPostGateway();
+      const deps = {
+        ...defaultDeps,
+        approvalRevocationGateway,
+        noteCommentPostGateway,
+        getQualityThreshold: (): number | null => 8,
+      };
+
+      const event = GitLabEventFactory.createApprovedMr();
+      const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitLabWebhook(request, mockReply, logger, mockGateway, deps);
+
+      expect(noteCommentPostGateway.calls).toHaveLength(1);
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'unapproved', mrNumber: 42 }),
+      );
+    });
+
+    it('ignores the approval when the MR is not tracked', async () => {
+      mockGateway.getById.mockReturnValue(null);
+      const event = GitLabEventFactory.createApprovedMr();
+      const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitLabWebhook(request, mockReply, logger, mockGateway, defaultDeps);
+
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'ignored', reason: 'not-found', mrNumber: 42 }),
+      );
+    });
+  });
+
+  describe('followup budget gate', () => {
+    function buildFollowupMr(): TrackedMr {
+      return TrackedMrFactory.create({
+        id: 'gitlab-test-org/test-project-42',
+        mrNumber: 42,
+        platform: 'gitlab',
+        project: 'test-org/test-project',
+        state: 'pending-review',
+        openThreads: 3,
+        autoFollowup: true,
+        lastPushAt: '2026-05-26T12:00:00.000Z',
+        lastReviewAt: '2026-05-25T12:00:00.000Z',
+      });
+    }
+
+    it('rejects a followup and broadcasts when the budget is exceeded', async () => {
+      const followupMr = buildFollowupMr();
+      mockGateway.getById.mockReturnValue(followupMr);
+      mockGateway.getByNumber.mockReturnValue(followupMr);
+      mockGateway.recordPush.mockReturnValue(followupMr);
+      const enforceBudget = {
+        execute: vi.fn(async () => ({
+          accepted: false,
+          status: {
+            limitUsd: 200,
+            consumedUsd: 250,
+            remainingUsd: 0,
+            percentUsed: 125,
+            exceeded: true,
+            periodStart: '2026-05-01T00:00:00.000Z',
+          },
+        })),
+      };
+      const broadcastBudgetExceeded = vi.fn();
+      const deps = { ...defaultDeps, enforceBudget, broadcastBudgetExceeded };
+
+      const event = GitLabEventFactory.createMrUpdate();
+      const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitLabWebhook(request, mockReply, logger, mockGateway, deps);
+
+      expect(enqueueReview).not.toHaveBeenCalled();
+      expect(broadcastBudgetExceeded).toHaveBeenCalledWith(
+        expect.objectContaining({ mrNumber: 42, platform: 'gitlab' }),
+      );
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'rejected', reason: 'budget-exceeded' }),
+      );
+    });
+
+    it('skips the followup when auto-followup is disabled on the MR', async () => {
+      const followupMr = TrackedMrFactory.create({
+        id: 'gitlab-test-org/test-project-42',
+        mrNumber: 42,
+        platform: 'gitlab',
+        project: 'test-org/test-project',
+        state: 'pending-review',
+        openThreads: 3,
+        autoFollowup: false,
+        lastPushAt: '2026-05-26T12:00:00.000Z',
+        lastReviewAt: '2026-05-25T12:00:00.000Z',
+      });
+      mockGateway.getById.mockReturnValue(followupMr);
+      mockGateway.getByNumber.mockReturnValue(followupMr);
+      mockGateway.recordPush.mockReturnValue(followupMr);
+
+      const event = GitLabEventFactory.createMrUpdate();
+      const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitLabWebhook(request, mockReply, logger, mockGateway, defaultDeps);
+
+      expect(enqueueReview).not.toHaveBeenCalled();
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'ignored', reason: 'Auto-followup disabled' }),
+      );
+    });
+  });
+
+  describe('review processor build', () => {
+    it('throws when no repository is configured for the job projectPath', async () => {
+      vi.mocked(findRepositoryByProjectPath).mockReturnValueOnce(undefined);
+      const processor = buildGitLabReviewProcessor(defaultDeps, logger)({
+        id: 'gitlab-test-org/test-project-42',
+        platform: 'gitlab',
+        projectPath: 'test-org/test-project',
+        localPath: '/home/user/projects/test-project',
+        mrNumber: 42,
+        skill: 'review-front',
+        mrUrl: 'https://gitlab.com/test-org/test-project/-/merge_requests/42',
+        sourceBranch: 'feature/test',
+        targetBranch: 'main',
+        jobType: 'review',
+      });
+
+      await expect(processor(
+        {
+          id: 'gitlab-test-org/test-project-42',
+          platform: 'gitlab',
+          projectPath: 'test-org/test-project',
+          localPath: '/home/user/projects/test-project',
+          mrNumber: 42,
+          skill: 'review-front',
+          mrUrl: 'https://gitlab.com/test-org/test-project/-/merge_requests/42',
+          sourceBranch: 'feature/test',
+          targetBranch: 'main',
+          jobType: 'review',
+        },
+        new AbortController().signal,
+      )).rejects.toThrow(/No GitLab repository configured/);
+    });
+
+    it('records completion stats on a successful review run', async () => {
+      mockGateway.getById.mockReturnValue(null);
+      const recordCompletion = new RecordReviewCompletionUseCase(mockGateway);
+      const recordSpy = vi.spyOn(recordCompletion, 'execute');
+      const diffStatsFetchGateway = { fetchDiffStats: vi.fn(() => null) };
+      const deps = { ...defaultDeps, recordCompletion, diffStatsFetchGateway };
+
+      vi.mocked(invokeClaudeReview).mockResolvedValue({
+        success: true,
+        cancelled: false,
+        stdout: 'Score: 9/10',
+        stderr: '',
+        exitCode: 0,
+        durationMs: 1200,
+      });
+      vi.mocked(enqueueReview).mockImplementation(async (job, callback) => {
+        await callback(job, new AbortController().signal);
+        return true;
+      });
+
+      const event = GitLabEventFactory.createWithReviewerAdded('claude-bot');
+      const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitLabWebhook(request, mockReply, logger, mockGateway, deps);
+
+      expect(recordSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mrId: 'gitlab-test-org/test-project-42',
+          reviewData: expect.objectContaining({ type: 'review' }),
+        }),
+      );
+    });
+
+    it('throws when a non-cancelled review run fails', async () => {
+      mockGateway.getById.mockReturnValue(null);
+      vi.mocked(invokeClaudeReview).mockResolvedValue({
+        success: false,
+        cancelled: false,
+        stdout: '',
+        stderr: 'boom',
+        exitCode: 1,
+        durationMs: 50,
+      });
+      const capturedMessages: string[] = [];
+      vi.mocked(enqueueReview).mockImplementation(async (job, callback) => {
+        try {
+          await callback(job, new AbortController().signal);
+        } catch (error) {
+          capturedMessages.push(error instanceof Error ? error.message : String(error));
+        }
+        return true;
+      });
+
+      const event = GitLabEventFactory.createWithReviewerAdded('claude-bot');
+      const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitLabWebhook(request, mockReply, logger, mockGateway, defaultDeps);
+
+      expect(capturedMessages).toEqual(['boom']);
     });
   });
 });

--- a/src/tests/units/modules/claude-invocation/usecases/awaitSessionCompletion.usecase.test.ts
+++ b/src/tests/units/modules/claude-invocation/usecases/awaitSessionCompletion.usecase.test.ts
@@ -4,6 +4,10 @@ import { StubMcpCompletionBridge } from '@/tests/stubs/mcpCompletion.stub.js';
 import { StubClaudeSessionGateway } from '@/tests/stubs/claudeSession.stub.js';
 import { ClaudeSessionFactory } from '@/tests/factories/claudeSession.factory.js';
 import { parseSessionId } from '@/modules/claude-invocation/entities/claudeSession/claudeSession.schema.js';
+import type {
+  AgentStatusEntry,
+  AgentStatusValue,
+} from '@/modules/claude-invocation/entities/claudeSession/claudeSession.gateway.js';
 
 describe('awaitSessionCompletion use case', () => {
   beforeEach(() => {
@@ -43,6 +47,96 @@ describe('awaitSessionCompletion use case', () => {
       { sessionGateway, completionBridge: bridge, now: () => new Date('2026-05-22T10:00:00Z') },
     );
     await vi.advanceTimersByTimeAsync(30_000);
+    const completion = await promise;
+
+    expect(completion.source).toBe('polling');
+    expect(completion.outcome).toBe('completed');
+  });
+
+  it('maps a stopped agent status to a stopped polling outcome', async () => {
+    const session = ClaudeSessionFactory.create({ sessionId: parseSessionId('stop0003') });
+    const bridge = new StubMcpCompletionBridge();
+    const sessionGateway = new StubClaudeSessionGateway();
+    sessionGateway.scheduleAgentCompletion('stop0003', 'stopped', 1);
+
+    const promise = awaitSessionCompletion(
+      { session, timeoutMs: 60_000, pollIntervalMs: 30_000 },
+      { sessionGateway, completionBridge: bridge, now: () => new Date('2026-05-22T10:00:00Z') },
+    );
+    await vi.advanceTimersByTimeAsync(30_000);
+    const completion = await promise;
+
+    expect(completion.source).toBe('polling');
+    expect(completion.outcome).toBe('stopped');
+    expect(completion.reason).toBeNull();
+  });
+
+  it('maps a failed agent status to a failed polling outcome', async () => {
+    const session = ClaudeSessionFactory.create({ sessionId: parseSessionId('fail0004') });
+    const bridge = new StubMcpCompletionBridge();
+    const sessionGateway = new StubClaudeSessionGateway();
+    sessionGateway.scheduleAgentCompletion('fail0004', 'failed', 1);
+
+    const promise = awaitSessionCompletion(
+      { session, timeoutMs: 60_000, pollIntervalMs: 30_000 },
+      { sessionGateway, completionBridge: bridge, now: () => new Date('2026-05-22T10:00:00Z') },
+    );
+    await vi.advanceTimersByTimeAsync(30_000);
+    const completion = await promise;
+
+    expect(completion.source).toBe('polling');
+    expect(completion.outcome).toBe('failed');
+    expect(completion.reason).toBeNull();
+  });
+
+  it('keeps polling while the agent is still running, then settles when it completes', async () => {
+    const session = ClaudeSessionFactory.create({ sessionId: parseSessionId('run00005') });
+    const bridge = new StubMcpCompletionBridge();
+    class RunningThenDoneSessionGateway extends StubClaudeSessionGateway {
+      override async listAgents(): Promise<AgentStatusEntry[]> {
+        const call = this.listAgentsCallCount + 1;
+        await super.listAgents();
+        const status: AgentStatusValue = call === 1 ? 'running' : 'completed';
+        return [{ sessionId: session.sessionId, status }];
+      }
+    }
+    const sessionGateway = new RunningThenDoneSessionGateway();
+
+    const promise = awaitSessionCompletion(
+      { session, timeoutMs: 60_000, pollIntervalMs: 10_000 },
+      { sessionGateway, completionBridge: bridge, now: () => new Date('2026-05-22T10:00:00Z') },
+    );
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(sessionGateway.listAgentsCallCount).toBe(1);
+    await vi.advanceTimersByTimeAsync(10_000);
+    const completion = await promise;
+
+    expect(completion.source).toBe('polling');
+    expect(completion.outcome).toBe('completed');
+  });
+
+  it('treats a listAgents error as non-fatal and retries on the next tick', async () => {
+    const session = ClaudeSessionFactory.create({ sessionId: parseSessionId('errr0006') });
+    const bridge = new StubMcpCompletionBridge();
+    class ThrowOnceSessionGateway extends StubClaudeSessionGateway {
+      private hasThrown = false;
+      override async listAgents() {
+        if (!this.hasThrown) {
+          this.hasThrown = true;
+          throw new Error('daemon unreachable');
+        }
+        return super.listAgents();
+      }
+    }
+    const sessionGateway = new ThrowOnceSessionGateway();
+    sessionGateway.scheduleAgentCompletion('errr0006', 'completed', 1);
+
+    const promise = awaitSessionCompletion(
+      { session, timeoutMs: 60_000, pollIntervalMs: 10_000 },
+      { sessionGateway, completionBridge: bridge, now: () => new Date('2026-05-22T10:00:00Z') },
+    );
+    await vi.advanceTimersByTimeAsync(10_000);
+    await vi.advanceTimersByTimeAsync(10_000);
     const completion = await promise;
 
     expect(completion.source).toBe('polling');

--- a/src/tests/units/modules/claude-invocation/usecases/cleanupClaudeSession.usecase.test.ts
+++ b/src/tests/units/modules/claude-invocation/usecases/cleanupClaudeSession.usecase.test.ts
@@ -16,4 +16,84 @@ describe('cleanupClaudeSession use case', () => {
     expect(sessionGateway.stopCalls).toContain(sessionId);
     expect(sessionGateway.removeCalls).toContain(sessionId);
   });
+
+  it('records a stop warning when stop fails with a warning', async () => {
+    const sessionGateway = new StubClaudeSessionGateway();
+    sessionGateway.setStopResult({ success: false, warning: 'not running' });
+    const sessionId = parseSessionId('clean002');
+
+    const result = await cleanupClaudeSession({ sessionId }, { sessionGateway });
+
+    expect(result.stopped).toBe(false);
+    expect(result.removed).toBe(true);
+    expect(result.warnings).toEqual(['stop: not running']);
+  });
+
+  it('records a remove warning when remove fails with a warning', async () => {
+    const sessionGateway = new StubClaudeSessionGateway();
+    sessionGateway.setRemoveResult({ success: false, warning: 'still present' });
+    const sessionId = parseSessionId('clean003');
+
+    const result = await cleanupClaudeSession({ sessionId }, { sessionGateway });
+
+    expect(result.stopped).toBe(true);
+    expect(result.removed).toBe(false);
+    expect(result.warnings).toEqual(['remove: still present']);
+  });
+
+  it('does not record a warning when a step fails without a warning message', async () => {
+    const sessionGateway = new StubClaudeSessionGateway();
+    sessionGateway.setStopResult({ success: false, warning: null });
+    const sessionId = parseSessionId('clean004');
+
+    const result = await cleanupClaudeSession({ sessionId }, { sessionGateway });
+
+    expect(result.stopped).toBe(false);
+    expect(result.removed).toBe(true);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('captures the message when stop throws an Error', async () => {
+    const sessionGateway = new StubClaudeSessionGateway();
+    sessionGateway.setStopError(new Error('daemon unreachable'));
+    const sessionId = parseSessionId('clean005');
+
+    const result = await cleanupClaudeSession({ sessionId }, { sessionGateway });
+
+    expect(result.stopped).toBe(false);
+    expect(result.removed).toBe(true);
+    expect(result.warnings).toEqual([
+      'stop failed: daemon unreachable',
+      'stop: daemon unreachable',
+    ]);
+  });
+
+  it('stringifies the value when remove throws a non-Error', async () => {
+    const sessionGateway = new StubClaudeSessionGateway();
+    sessionGateway.setRemoveError('boom');
+    const sessionId = parseSessionId('clean006');
+
+    const result = await cleanupClaudeSession({ sessionId }, { sessionGateway });
+
+    expect(result.stopped).toBe(true);
+    expect(result.removed).toBe(false);
+    expect(result.warnings).toEqual(['remove failed: boom', 'remove: boom']);
+  });
+
+  it('accumulates warnings from both stop and remove failures', async () => {
+    const sessionGateway = new StubClaudeSessionGateway();
+    sessionGateway.setStopError(new Error('stop blew up'));
+    sessionGateway.setRemoveResult({ success: false, warning: 'cannot delete' });
+    const sessionId = parseSessionId('clean007');
+
+    const result = await cleanupClaudeSession({ sessionId }, { sessionGateway });
+
+    expect(result.stopped).toBe(false);
+    expect(result.removed).toBe(false);
+    expect(result.warnings).toEqual([
+      'stop failed: stop blew up',
+      'stop: stop blew up',
+      'remove: cannot delete',
+    ]);
+  });
 });

--- a/src/tests/units/modules/cli-configuration/interface-adapters/controllers/http/cliStatus.routes.test.ts
+++ b/src/tests/units/modules/cli-configuration/interface-adapters/controllers/http/cliStatus.routes.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import Fastify from 'fastify';
+import type { FastifyInstance } from 'fastify';
+
+class FakeChildProcess extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+
+  emitStdout(data: string): void {
+    this.stdout.emit('data', Buffer.from(data));
+  }
+
+  emitStderr(data: string): void {
+    this.stderr.emit('data', Buffer.from(data));
+  }
+}
+
+let currentChild: FakeChildProcess;
+let lastCommand: string;
+
+vi.mock('node:child_process', () => ({
+  spawn: (command: string) => {
+    lastCommand = command;
+    return currentChild;
+  },
+}));
+
+vi.mock('@/shared/services/claudePathResolver.js', () => ({
+  resolveClaudePath: () => '/usr/bin/claude',
+}));
+
+const { cliStatusRoutes } = await import(
+  '@/modules/cli-configuration/interface-adapters/controllers/http/cliStatus.routes.js'
+);
+
+describe('cliStatus routes', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = Fastify();
+    await app.register(cliStatusRoutes);
+    await app.ready();
+    currentChild = new FakeChildProcess();
+  });
+
+  function injectAfter(
+    url: string,
+    drive: (child: FakeChildProcess) => void,
+  ): Promise<ReturnType<FastifyInstance['inject']> extends Promise<infer R> ? R : never> {
+    const responsePromise = app.inject({ method: 'GET', url });
+    setImmediate(() => drive(currentChild));
+    return responsePromise;
+  }
+
+  describe('GET /api/claude/status', () => {
+    it('should report available when version is returned with exit code 0', async () => {
+      const response = await injectAfter('/api/claude/status', (child) => {
+        child.emitStdout('1.2.3');
+        child.emit('close', 0);
+      });
+
+      expect(lastCommand).toBe('/usr/bin/claude');
+      const body = response.json();
+      expect(body.available).toBe(true);
+      expect(body.version).toBe('1.2.3');
+      expect(body.message).toBe('Claude CLI operational');
+      expect(typeof body.duration).toBe('number');
+    });
+
+    it('should report unavailable with the error message on spawn error', async () => {
+      const response = await injectAfter('/api/claude/status', (child) => {
+        child.emit('error', new Error('spawn ENOENT'));
+      });
+
+      const body = response.json();
+      expect(body.available).toBe(false);
+      expect(body.error).toBe('spawn ENOENT');
+      expect(body.message).toBe('Claude CLI not installed or not accessible');
+    });
+
+    it('should report authentication message when stderr mentions not logged in', async () => {
+      const response = await injectAfter('/api/claude/status', (child) => {
+        child.emitStderr('error: not logged in');
+        child.emit('close', 1);
+      });
+
+      const body = response.json();
+      expect(body.available).toBe(false);
+      expect(body.exitCode).toBe(1);
+      expect(body.stderr).toBe('error: not logged in');
+      expect(body.message).toBe('Not authenticated - run "claude login"');
+    });
+
+    it('should report generic CLI error when exit code is non-zero without auth hint', async () => {
+      const response = await injectAfter('/api/claude/status', (child) => {
+        child.emitStderr('boom');
+        child.emit('close', 2);
+      });
+
+      const body = response.json();
+      expect(body.available).toBe(false);
+      expect(body.exitCode).toBe(2);
+      expect(body.message).toBe('Claude CLI error');
+    });
+
+    it('should report error when exit code is 0 but stdout is empty', async () => {
+      const response = await injectAfter('/api/claude/status', (child) => {
+        child.emit('close', 0);
+      });
+
+      const body = response.json();
+      expect(body.available).toBe(false);
+      expect(body.message).toBe('Claude CLI error');
+    });
+  });
+
+  describe('GET /api/gitlab/status', () => {
+    it('should spawn glab and report authenticated with valid JSON user', async () => {
+      const response = await injectAfter('/api/gitlab/status', (child) => {
+        child.emitStdout(JSON.stringify({ username: 'octocat' }));
+        child.emit('close', 0);
+      });
+
+      expect(lastCommand).toBe('glab');
+      const body = response.json();
+      expect(body.available).toBe(true);
+      expect(body.authenticated).toBe(true);
+      expect(body.username).toBe('octocat');
+      expect(body.message).toBe('GitLab CLI operational');
+    });
+
+    it('should report invalid response when stdout is not valid JSON', async () => {
+      const response = await injectAfter('/api/gitlab/status', (child) => {
+        child.emitStdout('not-json');
+        child.emit('close', 0);
+      });
+
+      const body = response.json();
+      expect(body.available).toBe(true);
+      expect(body.authenticated).toBe(false);
+      expect(body.message).toBe('Invalid GitLab response');
+    });
+
+    it('should report not installed on spawn error', async () => {
+      const response = await injectAfter('/api/gitlab/status', (child) => {
+        child.emit('error', new Error('glab missing'));
+      });
+
+      const body = response.json();
+      expect(body.available).toBe(false);
+      expect(body.authenticated).toBe(false);
+      expect(body.error).toBe('glab missing');
+      expect(body.message).toBe('GitLab CLI (glab) not installed');
+      expect(body.command).toBe('sudo apt install glab');
+    });
+
+    it('should report not authenticated when exit code is non-zero', async () => {
+      const response = await injectAfter('/api/gitlab/status', (child) => {
+        child.emitStderr('unauthorized');
+        child.emit('close', 1);
+      });
+
+      const body = response.json();
+      expect(body.available).toBe(true);
+      expect(body.authenticated).toBe(false);
+      expect(body.message).toBe('Not authenticated to GitLab');
+    });
+  });
+
+  describe('GET /api/github/status', () => {
+    it('should spawn gh and report authenticated with valid JSON user', async () => {
+      const response = await injectAfter('/api/github/status', (child) => {
+        child.emitStdout(JSON.stringify({ login: 'monalisa' }));
+        child.emit('close', 0);
+      });
+
+      expect(lastCommand).toBe('gh');
+      const body = response.json();
+      expect(body.available).toBe(true);
+      expect(body.authenticated).toBe(true);
+      expect(body.username).toBe('monalisa');
+      expect(body.message).toBe('GitHub CLI operational');
+    });
+
+    it('should report invalid response when stdout is not valid JSON', async () => {
+      const response = await injectAfter('/api/github/status', (child) => {
+        child.emitStdout('}{');
+        child.emit('close', 0);
+      });
+
+      const body = response.json();
+      expect(body.available).toBe(true);
+      expect(body.authenticated).toBe(false);
+      expect(body.message).toBe('Invalid GitHub response');
+    });
+
+    it('should report not installed on spawn error', async () => {
+      const response = await injectAfter('/api/github/status', (child) => {
+        child.emit('error', new Error('gh missing'));
+      });
+
+      const body = response.json();
+      expect(body.available).toBe(false);
+      expect(body.authenticated).toBe(false);
+      expect(body.error).toBe('gh missing');
+      expect(body.message).toBe('GitHub CLI (gh) not installed');
+      expect(body.command).toBe('sudo apt install gh');
+    });
+
+    it('should report not authenticated when exit code is non-zero', async () => {
+      const response = await injectAfter('/api/github/status', (child) => {
+        child.emitStderr('bad creds');
+        child.emit('close', 1);
+      });
+
+      const body = response.json();
+      expect(body.available).toBe(true);
+      expect(body.authenticated).toBe(false);
+      expect(body.message).toBe('Not authenticated - run: gh auth login');
+    });
+  });
+});

--- a/src/tests/units/modules/cli-configuration/interface-adapters/controllers/http/projectConfig.routes.test.ts
+++ b/src/tests/units/modules/cli-configuration/interface-adapters/controllers/http/projectConfig.routes.test.ts
@@ -176,6 +176,174 @@ describe('projectConfigRoutes — GET /api/project-config', () => {
     expect(payload.error).toMatch(/review-back/);
     await app.close();
   });
+
+  it('returns 400 when the path query parameter is missing', async () => {
+    const app = await buildApp();
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/project-config',
+    });
+
+    expect(response.statusCode).toBe(400);
+    const payload = response.json();
+    expect(payload.success).toBe(false);
+    expect(payload.error).toBe('Project path required');
+    await app.close();
+  });
+
+  it('returns 400 when the path is not absolute', async () => {
+    const app = await buildApp();
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/project-config?path=relative/path',
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error).toBe('Invalid path (must be absolute without ..)');
+    await app.close();
+  });
+
+  it('reports missing base required fields when they are absent', async () => {
+    vi.mocked(fsPromises.readFile).mockResolvedValue(
+      jsonResponse({ reviewSkill: 'review-front' }),
+    );
+
+    const app = await buildApp();
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/project-config?path=/fake/project',
+    });
+
+    const payload = response.json();
+    expect(payload.success).toBe(false);
+    expect(payload.error).toMatch(/Missing fields:/);
+    expect(payload.error).toMatch(/github/);
+    await app.close();
+  });
+
+  it('resolves the reviewSkill SKILL.md when reviewSkill is explicitly set', async () => {
+    vi.mocked(fsPromises.readFile).mockResolvedValue(
+      jsonResponse(ProjectConfigFactory.create({ reviewSkill: 'review-front' })),
+    );
+    const statMock = vi.mocked(fsPromises.stat);
+    statMock.mockResolvedValue(fakeStats());
+
+    const app = await buildApp();
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/project-config?path=/fake/project',
+    });
+
+    expect(response.json().success).toBe(true);
+    const checkedPaths = statMock.mock.calls.map((call) => String(call[0]));
+    expect(
+      checkedPaths.some((checkedPath) => checkedPath.includes('review-front/SKILL.md')),
+    ).toBe(true);
+    await app.close();
+  });
+
+  it('rejects a config whose agents field is not an array', async () => {
+    const config = { ...ProjectConfigFactory.create(), agents: 'not-an-array' };
+    vi.mocked(fsPromises.readFile).mockResolvedValue(jsonResponse(config));
+    vi.mocked(fsPromises.stat).mockResolvedValue(fakeStats());
+
+    const app = await buildApp();
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/project-config?path=/fake/project',
+    });
+
+    const payload = response.json();
+    expect(payload.success).toBe(false);
+    expect(payload.error).toBe('Field "agents" must be an array');
+    await app.close();
+  });
+
+  it('rejects a config whose agents entries are malformed', async () => {
+    const config = {
+      ...ProjectConfigFactory.create(),
+      agents: [{ name: '', displayName: '' }],
+    };
+    vi.mocked(fsPromises.readFile).mockResolvedValue(jsonResponse(config));
+    vi.mocked(fsPromises.stat).mockResolvedValue(fakeStats());
+
+    const app = await buildApp();
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/project-config?path=/fake/project',
+    });
+
+    const payload = response.json();
+    expect(payload.success).toBe(false);
+    expect(payload.error).toMatch(/Invalid agents format/);
+    await app.close();
+  });
+
+  it('accepts a config with a well-formed agents array', async () => {
+    vi.mocked(fsPromises.readFile).mockResolvedValue(
+      jsonResponse(
+        ProjectConfigFactory.create({
+          agents: [{ name: 'security', displayName: 'Security Auditor' }],
+        }),
+      ),
+    );
+    vi.mocked(fsPromises.stat).mockResolvedValue(fakeStats());
+
+    const app = await buildApp();
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/project-config?path=/fake/project',
+    });
+
+    expect(response.json().success).toBe(true);
+    await app.close();
+  });
+
+  it('returns the ENOENT message when config.json is missing', async () => {
+    const enoentError = Object.assign(new Error('no such file'), { code: 'ENOENT' });
+    vi.mocked(fsPromises.readFile).mockRejectedValue(enoentError);
+
+    const app = await buildApp();
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/project-config?path=/fake/project',
+    });
+
+    const payload = response.json();
+    expect(payload.success).toBe(false);
+    expect(payload.error).toBe('config.json file not found in .claude/reviews/');
+    await app.close();
+  });
+
+  it('returns a read error when the config file is not valid JSON', async () => {
+    vi.mocked(fsPromises.readFile).mockResolvedValue('not-json{');
+
+    const app = await buildApp();
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/project-config?path=/fake/project',
+    });
+
+    const payload = response.json();
+    expect(payload.success).toBe(false);
+    expect(payload.error).toMatch(/^Read error: /);
+    await app.close();
+  });
+
+  it('stringifies a non-Error thrown value in the read error message', async () => {
+    vi.mocked(fsPromises.readFile).mockRejectedValue('boom');
+
+    const app = await buildApp();
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/project-config?path=/fake/project',
+    });
+
+    const payload = response.json();
+    expect(payload.success).toBe(false);
+    expect(payload.error).toBe('Read error: boom');
+    await app.close();
+  });
 });
 
 function baseConfig(overrides: Partial<ProjectConfig> = {}): ProjectConfig {
@@ -466,6 +634,122 @@ describe('projectConfigRoutes — PATCH /api/project-config', () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.json().config.maxConcurrentReviews).toBeUndefined();
+    await app.close();
+  });
+
+  it('returns 501 when the PATCH use case is not configured', async () => {
+    const app = Fastify();
+    await app.register(projectConfigRoutes);
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/project-config?path=' + encodeURIComponent('/repo/A'),
+      payload: { language: 'en' },
+    });
+
+    expect(response.statusCode).toBe(501);
+    expect(response.json().error).toBe('PATCH not configured');
+    await app.close();
+  });
+
+  it('returns 400 when the body is not a JSON object', async () => {
+    const gateway = new StubProjectConfigGateway();
+    gateway.set('/repo/A', baseConfig());
+    const app = await buildAppWithPatch(gateway);
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/project-config?path=' + encodeURIComponent('/repo/A'),
+      headers: { 'content-type': 'application/json' },
+      payload: JSON.stringify(['not', 'an', 'object']),
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error).toBe('Body must be a JSON object');
+    await app.close();
+  });
+
+  it('applies a valid defaultModel from the patch body', async () => {
+    const gateway = new StubProjectConfigGateway();
+    gateway.set('/repo/A', baseConfig({ defaultModel: 'sonnet' }));
+    const app = await buildAppWithPatch(gateway);
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/project-config?path=' + encodeURIComponent('/repo/A'),
+      payload: { defaultModel: 'opus' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().config.defaultModel).toBe('opus');
+    await app.close();
+  });
+
+  it('treats an empty-string qualityThreshold as a clear request', async () => {
+    const gateway = new StubProjectConfigGateway();
+    gateway.set('/repo/A', baseConfig({ qualityThreshold: 7 }));
+    const app = await buildAppWithPatch(gateway);
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/project-config?path=' + encodeURIComponent('/repo/A'),
+      payload: { qualityThreshold: '' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().config.qualityThreshold).toBeUndefined();
+    await app.close();
+  });
+
+  it('keeps a boolean maxConcurrentReviews to surface a validation error', async () => {
+    const gateway = new StubProjectConfigGateway();
+    gateway.set('/repo/A', baseConfig());
+    const app = await buildAppWithPatch(gateway);
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/project-config?path=' + encodeURIComponent('/repo/A'),
+      payload: { maxConcurrentReviews: true },
+    });
+
+    expect(response.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it('applies reviewSkill and reviewFollowupSkill string values from the patch', async () => {
+    const gateway = new StubProjectConfigGateway();
+    gateway.set('/repo/A', baseConfig());
+    const app = await buildAppWithPatch(gateway);
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/project-config?path=' + encodeURIComponent('/repo/A'),
+      payload: { reviewSkill: 'review-back', reviewFollowupSkill: 'review-followup-v2' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.config.reviewSkill).toBe('review-back');
+    expect(body.config.reviewFollowupSkill).toBe('review-followup-v2');
+    await app.close();
+  });
+
+  it('invokes the onSaved callback after a successful update', async () => {
+    const gateway = new StubProjectConfigGateway();
+    gateway.set('/repo/A', baseConfig());
+    const updateProjectConfig = new UpdateProjectConfigUseCase(gateway);
+    const onSaved = vi.fn();
+    const app = Fastify();
+    await app.register(projectConfigRoutes, { updateProjectConfig, onSaved });
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/project-config?path=' + encodeURIComponent('/repo/A'),
+      payload: { language: 'en' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(onSaved).toHaveBeenCalledWith('/repo/A');
     await app.close();
   });
 });

--- a/src/tests/units/modules/ember-chat/gateways/emberAnswerTransport.claude.gateway.test.ts
+++ b/src/tests/units/modules/ember-chat/gateways/emberAnswerTransport.claude.gateway.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { EmberAnswerTransportClaudeGateway } from '@/modules/ember-chat/interface-adapters/gateways/emberAnswerTransport.claude.gateway.js';
+import type {
+  EmberAnswerStartOptions,
+  EmberAnswerSubscriber,
+} from '@/modules/ember-chat/entities/emberAnswer/emberAnswerTransport.gateway.js';
+import { StubClaudeSessionGateway } from '@/tests/stubs/claudeSession.stub.js';
+
+interface CollectedSubscriber extends EmberAnswerSubscriber {
+  chunks: string[];
+  done: boolean;
+  error: string | null;
+}
+
+function collectingSubscriber(resolve: () => void): CollectedSubscriber {
+  const subscriber: CollectedSubscriber = {
+    chunks: [],
+    done: false,
+    error: null,
+    onChunk(text: string): void {
+      subscriber.chunks.push(text);
+    },
+    onDone(): void {
+      subscriber.done = true;
+      resolve();
+    },
+    onError(message: string): void {
+      subscriber.error = message;
+      resolve();
+    },
+  };
+  return subscriber;
+}
+
+function settled(): {
+  subscriber: CollectedSubscriber;
+  finished: Promise<void>;
+} {
+  let resolve: () => void = () => undefined;
+  const finished = new Promise<void>((res) => {
+    resolve = res;
+  });
+  const subscriber = collectingSubscriber(resolve);
+  return { subscriber, finished };
+}
+
+function projectDirFor(projectPath: string, homeDir: string): string {
+  const slug = projectPath.replace(/\//g, '-');
+  const dir = join(homeDir, '.claude', 'projects', slug);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+const FAST_OPTIONS = (homeDir: string) => ({
+  homeDir,
+  pollIntervalMs: 1,
+});
+
+describe('EmberAnswerTransportClaudeGateway (integration with real filesystem)', () => {
+  let homeDir: string;
+  let sessionGateway: StubClaudeSessionGateway;
+
+  beforeEach(() => {
+    homeDir = mkdtempSync(join(tmpdir(), 'ember-answer-'));
+    sessionGateway = new StubClaudeSessionGateway();
+  });
+
+  afterEach(() => {
+    rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  function startOptions(): EmberAnswerStartOptions {
+    return {
+      question: 'what is the review velocity?',
+      systemPrompt: 'You are Ember.',
+      projectPath: homeDir,
+    };
+  }
+
+  it('dispatches --bg with read-only flags and streams transcript chunks until turn-complete', async () => {
+    const dir = projectDirFor(homeDir, homeDir);
+    const lines = [
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'Hello ' }] } }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'world' }], stop_reason: 'end_turn' },
+      }),
+    ];
+    writeFileSync(join(dir, 'stub-session-full-uuid.jsonl'), lines.join('\n') + '\n');
+
+    const gateway = new EmberAnswerTransportClaudeGateway(sessionGateway, FAST_OPTIONS(homeDir));
+    const { subscriber, finished } = settled();
+
+    const result = gateway.start(startOptions(), subscriber);
+    expect(result.status).toBe('started');
+
+    await finished;
+
+    expect(subscriber.chunks).toEqual(['Hello ', 'world']);
+    expect(subscriber.done).toBe(true);
+    expect(subscriber.error).toBeNull();
+
+    const dispatch = sessionGateway.dispatchCalls[0];
+    expect(dispatch.jobType).toBe('ember-chat');
+    expect(dispatch.flags.allowedTools).toBe('Read,Glob,Grep');
+    expect(dispatch.flags.disallowedTools).toBe('Edit,Write,Bash,Task');
+    expect(dispatch.flags.mcpConfigJson).toBe('{"mcpServers":{}}');
+    expect(dispatch.flags.permissionMode).toBe('auto');
+    expect(sessionGateway.stopCalls).toEqual(['stub-session']);
+  });
+
+  it('reports ember-answer-dispatch-failed and never stops a session when dispatch fails', async () => {
+    sessionGateway.setDispatchResult({ status: 'failed', rawStderr: 'not logged in' });
+
+    const gateway = new EmberAnswerTransportClaudeGateway(sessionGateway, FAST_OPTIONS(homeDir));
+    const { subscriber, finished } = settled();
+
+    gateway.start(startOptions(), subscriber);
+    await finished;
+
+    expect(subscriber.error).toBe('ember-answer-dispatch-failed');
+    expect(subscriber.done).toBe(false);
+    expect(subscriber.chunks).toEqual([]);
+    expect(sessionGateway.stopCalls).toEqual([]);
+  });
+
+  it('completes on a system turn_duration marker even without assistant stop_reason', async () => {
+    const dir = projectDirFor(homeDir, homeDir);
+    const lines = [
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'partial answer' }] } }),
+      JSON.stringify({ type: 'system', subtype: 'turn_duration' }),
+    ];
+    writeFileSync(join(dir, 'stub-session-x.jsonl'), lines.join('\n') + '\n');
+
+    const gateway = new EmberAnswerTransportClaudeGateway(sessionGateway, FAST_OPTIONS(homeDir));
+    const { subscriber, finished } = settled();
+
+    gateway.start(startOptions(), subscriber);
+    await finished;
+
+    expect(subscriber.chunks).toEqual(['partial answer']);
+    expect(subscriber.done).toBe(true);
+    expect(sessionGateway.stopCalls).toEqual(['stub-session']);
+  });
+
+  it('skips blank and unparseable transcript lines while still finishing the turn', async () => {
+    const dir = projectDirFor(homeDir, homeDir);
+    const lines = [
+      '',
+      '   ',
+      'not-json-at-all',
+      JSON.stringify({ type: 'system', subtype: 'init' }),
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'real' }] } }),
+      JSON.stringify({ type: 'result' }),
+    ];
+    writeFileSync(join(dir, 'stub-session-noise.jsonl'), lines.join('\n') + '\n');
+
+    const gateway = new EmberAnswerTransportClaudeGateway(sessionGateway, FAST_OPTIONS(homeDir));
+    const { subscriber, finished } = settled();
+
+    gateway.start(startOptions(), subscriber);
+    await finished;
+
+    expect(subscriber.chunks).toEqual(['real']);
+    expect(subscriber.done).toBe(true);
+  });
+
+  it('times out and stops the session when no transcript ever turn-completes', async () => {
+    const dir = projectDirFor(homeDir, homeDir);
+    writeFileSync(
+      join(dir, 'stub-session-stuck.jsonl'),
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'thinking' }] } }) + '\n',
+    );
+
+    const gateway = new EmberAnswerTransportClaudeGateway(sessionGateway, {
+      homeDir,
+      pollIntervalMs: 1,
+    });
+    const { subscriber, finished } = settled();
+
+    gateway.start(startOptions(), subscriber);
+    await finished;
+
+    expect(subscriber.error).toBe('ember-answer-timeout');
+    expect(subscriber.done).toBe(false);
+    expect(sessionGateway.stopCalls).toEqual(['stub-session']);
+  });
+
+  it('does not emit done or error after the run is cancelled', async () => {
+    const gateway = new EmberAnswerTransportClaudeGateway(sessionGateway, FAST_OPTIONS(homeDir));
+    const subscriber: CollectedSubscriber = {
+      chunks: [],
+      done: false,
+      error: null,
+      onChunk(text) {
+        subscriber.chunks.push(text);
+      },
+      onDone() {
+        subscriber.done = true;
+      },
+      onError(message) {
+        subscriber.error = message;
+      },
+    };
+
+    const result = gateway.start(startOptions(), subscriber);
+    expect(result.status).toBe('started');
+    if (result.status === 'started') {
+      result.run.cancel();
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(subscriber.done).toBe(false);
+    expect(subscriber.error).toBeNull();
+  });
+});

--- a/src/tests/units/modules/platform-integration/entities/transport/cidr.test.ts
+++ b/src/tests/units/modules/platform-integration/entities/transport/cidr.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { isIpInCidr } from '@/modules/platform-integration/entities/transport/cidr.js';
+
+describe('isIpInCidr', () => {
+  describe('happy path', () => {
+    it('matches an ip inside the range', () => {
+      expect(isIpInCidr('192.168.1.42', '192.168.1.0/24')).toBe(true);
+    });
+
+    it('rejects an ip outside the range', () => {
+      expect(isIpInCidr('192.168.2.42', '192.168.1.0/24')).toBe(false);
+    });
+  });
+
+  describe('prefix boundaries', () => {
+    it('matches everything when prefix is 0', () => {
+      expect(isIpInCidr('8.8.8.8', '0.0.0.0/0')).toBe(true);
+    });
+
+    it('matches only the exact ip when prefix is 32', () => {
+      expect(isIpInCidr('10.0.0.1', '10.0.0.1/32')).toBe(true);
+      expect(isIpInCidr('10.0.0.2', '10.0.0.1/32')).toBe(false);
+    });
+
+    it('returns false when prefix is not an integer', () => {
+      expect(isIpInCidr('192.168.1.1', '192.168.1.0/abc')).toBe(false);
+    });
+
+    it('returns false when prefix is negative', () => {
+      expect(isIpInCidr('192.168.1.1', '192.168.1.0/-1')).toBe(false);
+    });
+
+    it('returns false when prefix is greater than 32', () => {
+      expect(isIpInCidr('192.168.1.1', '192.168.1.0/33')).toBe(false);
+    });
+
+    it('returns false when prefix is missing', () => {
+      expect(isIpInCidr('192.168.1.1', '192.168.1.0')).toBe(false);
+    });
+  });
+
+  describe('invalid ip parsing', () => {
+    it('returns false when the ip has fewer than four octets', () => {
+      expect(isIpInCidr('192.168.1', '192.168.1.0/24')).toBe(false);
+    });
+
+    it('returns false when the ip has more than four octets', () => {
+      expect(isIpInCidr('192.168.1.1.1', '192.168.1.0/24')).toBe(false);
+    });
+
+    it('returns false when an octet is non-numeric', () => {
+      expect(isIpInCidr('192.168.1.x', '192.168.1.0/24')).toBe(false);
+    });
+
+    it('returns false when an octet exceeds 255', () => {
+      expect(isIpInCidr('192.168.1.256', '192.168.1.0/24')).toBe(false);
+    });
+
+    it('returns false when the range ip is malformed', () => {
+      expect(isIpInCidr('192.168.1.1', '999.168.1.0/24')).toBe(false);
+    });
+  });
+});

--- a/src/tests/units/modules/review-execution/entities/reviewRequest/reviewRequest.guard.test.ts
+++ b/src/tests/units/modules/review-execution/entities/reviewRequest/reviewRequest.guard.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseReviewRequest,
+  safeParseReviewRequest,
+  isValidReviewRequest,
+} from '@/modules/review-execution/entities/reviewRequest/reviewRequest.guard.js';
+
+const validReviewRequest = {
+  platform: 'gitlab',
+  projectPath: 'group/project',
+  reviewRequestNumber: 42,
+  title: 'Add feature',
+  sourceBranch: 'feat/x',
+  targetBranch: 'main',
+  state: 'open',
+  isDraft: false,
+  author: 'alice',
+  webUrl: 'https://gitlab.example.com/group/project/-/merge_requests/42',
+  createdAt: '2026-05-30T10:00:00Z',
+  updatedAt: '2026-05-30T11:00:00Z',
+};
+
+describe('reviewRequest.guard', () => {
+  it('parses a valid review request', () => {
+    const result = parseReviewRequest(validReviewRequest);
+    expect(result.reviewRequestNumber).toBe(42);
+  });
+
+  it('throws when parsing an invalid review request', () => {
+    expect(() => parseReviewRequest({ ...validReviewRequest, reviewRequestNumber: -1 })).toThrow();
+  });
+
+  it('safeParse succeeds on a valid request and fails on a bad url', () => {
+    expect(safeParseReviewRequest(validReviewRequest).success).toBe(true);
+    expect(safeParseReviewRequest({ ...validReviewRequest, webUrl: 'not-a-url' }).success).toBe(false);
+  });
+
+  it('isValid reflects validity', () => {
+    expect(isValidReviewRequest(validReviewRequest)).toBe(true);
+    expect(isValidReviewRequest({ platform: 'bitbucket' })).toBe(false);
+  });
+});

--- a/src/tests/units/modules/review-execution/interface-adapters/controllers/http/reviews.routes.test.ts
+++ b/src/tests/units/modules/review-execution/interface-adapters/controllers/http/reviews.routes.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { reviewRoutes } from '@/modules/review-execution/interface-adapters/controllers/http/reviews.routes.js';
+import { InMemoryReviewFileGateway } from '@/tests/stubs/reviewFile.stub.js';
+import { InMemoryReviewRequestTrackingGateway } from '@/tests/stubs/reviewRequestTracking.stub.js';
+import { StubReviewQueuePort } from '@/tests/stubs/reviewQueue.stub.js';
+import { createStubLogger } from '@/tests/stubs/logger.stub.js';
+import { TrackedMrFactory } from '@/tests/factories/trackedMr.factory.js';
+
+type Repository = { localPath: string; enabled: boolean };
+
+describe('reviewRoutes', () => {
+  let app: FastifyInstance;
+  let reviewFileGateway: InMemoryReviewFileGateway;
+  let reviewRequestTrackingGateway: InMemoryReviewRequestTrackingGateway;
+  let queuePort: StubReviewQueuePort;
+  let repositories: Repository[];
+
+  beforeEach(async () => {
+    app = Fastify();
+    reviewFileGateway = new InMemoryReviewFileGateway();
+    reviewRequestTrackingGateway = new InMemoryReviewRequestTrackingGateway();
+    queuePort = new StubReviewQueuePort();
+    repositories = [];
+
+    await app.register(reviewRoutes, {
+      reviewFileGateway,
+      reviewRequestTrackingGateway,
+      getRepositories: () => repositories,
+      queuePort,
+      logger: createStubLogger(),
+    });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('GET /api/reviews', () => {
+    it('returns reviews for an explicit valid path', async () => {
+      reviewFileGateway.addReview('/repo/a', '2026-05-01-MR-12-front.md', '# Code Review - MR #12 (login)');
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/reviews?path=/repo/a',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.count).toBe(1);
+      expect(body.reviews[0].filename).toBe('2026-05-01-MR-12-front.md');
+    });
+
+    it('rejects a path without a leading slash', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/reviews?path=relative/path',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.error).toBe('Invalid path');
+      expect(body.reviews).toEqual([]);
+      expect(body.count).toBe(0);
+    });
+
+    it('rejects a path containing directory traversal', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/reviews?path=/repo/../etc',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.error).toBe('Invalid path');
+    });
+
+    it('aggregates enabled repositories and skips disabled ones when no path is given', async () => {
+      reviewFileGateway.addReview('/repo/a', '2026-05-01-MR-1-front.md', '# Code Review - MR #1 (a)');
+      reviewFileGateway.addReview('/repo/b', '2026-05-02-MR-2-front.md', '# Code Review - MR #2 (b)');
+      repositories = [
+        { localPath: '/repo/a', enabled: true },
+        { localPath: '/repo/b', enabled: false },
+      ];
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/reviews',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.count).toBe(1);
+      expect(body.reviews[0].filename).toBe('2026-05-01-MR-1-front.md');
+    });
+
+    it('returns an empty aggregate when no repositories are configured', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/reviews',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.reviews).toEqual([]);
+      expect(body.count).toBe(0);
+    });
+  });
+
+  describe('GET /api/reviews/:filename', () => {
+    it('returns 400 for an invalid filename format', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/reviews/not-a-valid-name',
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toBe('Invalid filename format');
+    });
+
+    it('returns the review content from an enabled repository', async () => {
+      reviewFileGateway.addReview('/repo/a', '2026-05-01-MR-12-front.md', 'CONTENT');
+      repositories = [{ localPath: '/repo/a', enabled: true }];
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/reviews/2026-05-01-MR-12-front.md',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.filename).toBe('2026-05-01-MR-12-front.md');
+      expect(body.content).toBe('CONTENT');
+    });
+
+    it('skips disabled repositories and returns 404 when not found anywhere', async () => {
+      reviewFileGateway.addReview('/repo/a', '2026-05-01-MR-12-front.md', 'CONTENT');
+      repositories = [{ localPath: '/repo/a', enabled: false }];
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/reviews/2026-05-01-MR-12-front.md',
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json().error).toBe('Review not found');
+    });
+  });
+
+  describe('DELETE /api/reviews/:filename', () => {
+    it('returns 400 for an invalid filename format', async () => {
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/api/reviews/invalid',
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = response.json();
+      expect(body.success).toBe(false);
+      expect(body.error).toBe('Invalid filename format');
+    });
+
+    it('deletes an existing review in an enabled repository', async () => {
+      reviewFileGateway.addReview('/repo/a', '2026-05-01-MR-12-front.md', 'CONTENT');
+      repositories = [{ localPath: '/repo/a', enabled: true }];
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/api/reviews/2026-05-01-MR-12-front.md',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().success).toBe(true);
+      expect(await reviewFileGateway.reviewExists('/repo/a', '2026-05-01-MR-12-front.md')).toBe(false);
+    });
+
+    it('skips disabled repositories and returns 404 when nothing is deleted', async () => {
+      reviewFileGateway.addReview('/repo/a', '2026-05-01-MR-12-front.md', 'CONTENT');
+      repositories = [{ localPath: '/repo/a', enabled: false }];
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/api/reviews/2026-05-01-MR-12-front.md',
+      });
+
+      expect(response.statusCode).toBe(404);
+      const body = response.json();
+      expect(body.success).toBe(false);
+      expect(body.error).toBe('Review not found');
+    });
+  });
+
+  describe('POST /api/reviews/cancel/:jobId', () => {
+    it('cancels a running job without tracking removal when body is empty', async () => {
+      queuePort.setJobStatus('job-1', 'running');
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/reviews/cancel/job-1',
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.success).toBe(true);
+      expect(body.message).toBe('Job job-1 cancelled');
+      expect(queuePort.cancelledJobs).toContain('job-1');
+    });
+
+    it('cancels a job and removes tracking when projectPath and mrId are provided', async () => {
+      queuePort.setJobStatus('job-2', 'queued');
+      reviewRequestTrackingGateway.create(
+        '/repo/a',
+        TrackedMrFactory.create({ id: 'mr-99', mrNumber: 99 }),
+      );
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/reviews/cancel/job-2',
+        payload: { projectPath: '/repo/a', mrId: 'mr-99' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().success).toBe(true);
+      expect(reviewRequestTrackingGateway.getById('/repo/a', 'mr-99')).toBeNull();
+    });
+
+    it('returns already-completed status when the job is finished', async () => {
+      queuePort.setJobStatus('job-3', 'completed');
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/reviews/cancel/job-3',
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.success).toBe(false);
+      expect(body.status).toBe('already-completed');
+    });
+
+    it('returns 404 when the job does not exist', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/reviews/cancel/unknown-job',
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(404);
+      const body = response.json();
+      expect(body.success).toBe(false);
+      expect(body.error).toBe('Job non trouvé');
+    });
+  });
+});

--- a/src/tests/units/modules/review-execution/interface-adapters/gateways/fileSystem/reviewFile.fileSystem.test.ts
+++ b/src/tests/units/modules/review-execution/interface-adapters/gateways/fileSystem/reviewFile.fileSystem.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { FileSystemReviewFileGateway } from '@/modules/review-execution/interface-adapters/gateways/fileSystem/reviewFile.fileSystem.js';
+
+function reviewsDir(projectPath: string): string {
+  const dir = join(projectPath, '.claude', 'reviews');
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe('FileSystemReviewFileGateway (integration with real filesystem)', () => {
+  let projectPath: string;
+  let gateway: FileSystemReviewFileGateway;
+
+  beforeEach(() => {
+    projectPath = mkdtempSync(join(tmpdir(), 'review-file-'));
+    gateway = new FileSystemReviewFileGateway();
+  });
+
+  afterEach(() => {
+    rmSync(projectPath, { recursive: true, force: true });
+  });
+
+  describe('getReviewsDirectory', () => {
+    it('returns the .claude/reviews directory under the project path', () => {
+      expect(gateway.getReviewsDirectory('/my/project')).toBe('/my/project/.claude/reviews');
+    });
+  });
+
+  describe('listReviews', () => {
+    it('returns an empty array when the reviews directory does not exist', async () => {
+      const result = await gateway.listReviews(projectPath);
+
+      expect(result).toEqual([]);
+    });
+
+    it('parses metadata and title for MR and PR review files, sorted by mtime desc', async () => {
+      const dir = reviewsDir(projectPath);
+      writeFileSync(
+        join(dir, '2024-01-15-MR-42-review.md'),
+        '# Code Review - MR !42 (fix: resolve bug)\n\nbody',
+      );
+      writeFileSync(
+        join(dir, '2024-01-16-PR-123-review.md'),
+        '# Code Review - PR #123 (feat: add feature)\n\nbody',
+      );
+
+      const result = await gateway.listReviews(projectPath);
+
+      expect(result).toHaveLength(2);
+      const byNumber = new Map(result.map(review => [review.mrNumber, review]));
+      const mrReview = byNumber.get('42');
+      const prReview = byNumber.get('123');
+      expect(mrReview?.date).toBe('2024-01-15');
+      expect(mrReview?.type).toBe('review');
+      expect(mrReview?.title).toBe('fix: resolve bug');
+      expect(mrReview?.size).toBeGreaterThan(0);
+      expect(mrReview?.path).toBe(join(dir, '2024-01-15-MR-42-review.md'));
+      expect(prReview?.title).toBe('feat: add feature');
+      expect(typeof prReview?.mtime).toBe('string');
+    });
+
+    it('leaves the title absent when the first line does not match the title format', async () => {
+      const dir = reviewsDir(projectPath);
+      writeFileSync(join(dir, '2024-01-15-PR-7-review.md'), '# Some other heading\n\nbody');
+
+      const result = await gateway.listReviews(projectPath);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].title).toBeUndefined();
+    });
+
+    it('ignores non-markdown files and markdown files not matching the review pattern', async () => {
+      const dir = reviewsDir(projectPath);
+      writeFileSync(join(dir, '2024-01-15-MR-42-review.md'), '# Code Review - MR !42 (ok)\n');
+      writeFileSync(join(dir, 'notes.txt'), 'plain text');
+      writeFileSync(join(dir, 'random.md'), '# not a review');
+
+      const result = await gateway.listReviews(projectPath);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].mrNumber).toBe('42');
+    });
+  });
+
+  describe('readReview', () => {
+    it('returns the file content when the review exists', async () => {
+      const dir = reviewsDir(projectPath);
+      writeFileSync(join(dir, '2024-01-15-MR-42-review.md'), '# Review\n\nContent here');
+
+      const result = await gateway.readReview(projectPath, '2024-01-15-MR-42-review.md');
+
+      expect(result).toBe('# Review\n\nContent here');
+    });
+
+    it('returns null when the review file is missing', async () => {
+      const result = await gateway.readReview(projectPath, 'missing.md');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('reviewExists', () => {
+    it('returns true when the review file exists', async () => {
+      const dir = reviewsDir(projectPath);
+      writeFileSync(join(dir, '2024-01-15-MR-42-review.md'), 'Content');
+
+      const result = await gateway.reviewExists(projectPath, '2024-01-15-MR-42-review.md');
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when the review file is missing', async () => {
+      const result = await gateway.reviewExists(projectPath, 'missing.md');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('deleteReview', () => {
+    it('deletes an existing review and returns true', async () => {
+      const dir = reviewsDir(projectPath);
+      writeFileSync(join(dir, '2024-01-15-MR-42-review.md'), 'Content');
+
+      const result = await gateway.deleteReview(projectPath, '2024-01-15-MR-42-review.md');
+
+      expect(result).toBe(true);
+      expect(await gateway.reviewExists(projectPath, '2024-01-15-MR-42-review.md')).toBe(false);
+    });
+
+    it('returns false when the review file is missing', async () => {
+      const result = await gateway.deleteReview(projectPath, 'missing.md');
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/tests/units/modules/setup-wizard/gateways/serverConfig.fileSystem.gateway.test.ts
+++ b/src/tests/units/modules/setup-wizard/gateways/serverConfig.fileSystem.gateway.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ServerConfigFileSystemGateway } from '@/modules/setup-wizard/interface-adapters/gateways/serverConfig.fileSystem.gateway.js';
+import type { ServerConfigEntry } from '@/modules/setup-wizard/entities/serverConfig/serverConfig.gateway.js';
+
+const makeEntry = (overrides: Partial<ServerConfigEntry> = {}): ServerConfigEntry => ({
+  name: 'main-app',
+  localPath: '/repos/main-app',
+  enabled: true,
+  ...overrides,
+});
+
+describe('ServerConfigFileSystemGateway (integration with real filesystem)', () => {
+  let baseDir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    baseDir = mkdtempSync(join(tmpdir(), 'server-config-'));
+    configPath = join(baseDir, 'config', 'config.json');
+  });
+
+  afterEach(() => {
+    rmSync(baseDir, { recursive: true, force: true });
+  });
+
+  describe('hasProject', () => {
+    it('returns false when the config file is missing', () => {
+      const gateway = new ServerConfigFileSystemGateway({ configPath });
+
+      expect(gateway.hasProject('/repos/main-app')).toBe(false);
+    });
+
+    it('returns false when the config content is malformed JSON', () => {
+      writeFileSync(configPath.replace('/config/config.json', '/malformed.json'), 'not json');
+      const malformedPath = join(baseDir, 'malformed.json');
+      const gateway = new ServerConfigFileSystemGateway({ configPath: malformedPath });
+
+      expect(gateway.hasProject('/repos/main-app')).toBe(false);
+    });
+
+    it('returns false when repositories is not an array', () => {
+      const path = join(baseDir, 'shape.json');
+      writeFileSync(path, JSON.stringify({ repositories: 'oops' }));
+      const gateway = new ServerConfigFileSystemGateway({ configPath: path });
+
+      expect(gateway.hasProject('/repos/main-app')).toBe(false);
+    });
+
+    it('returns true when a repository with the given localPath exists', () => {
+      const path = join(baseDir, 'valid.json');
+      writeFileSync(
+        path,
+        JSON.stringify({ repositories: [{ name: 'main-app', localPath: '/repos/main-app', enabled: true }] }),
+      );
+      const gateway = new ServerConfigFileSystemGateway({ configPath: path });
+
+      expect(gateway.hasProject('/repos/main-app')).toBe(true);
+      expect(gateway.hasProject('/repos/other')).toBe(false);
+    });
+  });
+
+  describe('addProject', () => {
+    it('creates the config file and directory when none exists', () => {
+      const gateway = new ServerConfigFileSystemGateway({ configPath });
+      const entry = makeEntry();
+
+      gateway.addProject(entry);
+
+      expect(existsSync(configPath)).toBe(true);
+      const written: unknown = JSON.parse(readFileSync(configPath, 'utf-8'));
+      expect(written).toEqual({
+        repositories: [{ name: 'main-app', localPath: '/repos/main-app', enabled: true }],
+      });
+      expect(gateway.hasProject('/repos/main-app')).toBe(true);
+    });
+
+    it('appends to existing repositories on a valid round-trip', () => {
+      const gateway = new ServerConfigFileSystemGateway({ configPath });
+      gateway.addProject(makeEntry({ name: 'first', localPath: '/repos/first' }));
+      gateway.addProject(makeEntry({ name: 'second', localPath: '/repos/second', enabled: false }));
+
+      expect(gateway.hasProject('/repos/first')).toBe(true);
+      expect(gateway.hasProject('/repos/second')).toBe(true);
+      const written: unknown = JSON.parse(readFileSync(configPath, 'utf-8'));
+      expect(written).toEqual({
+        repositories: [
+          { name: 'first', localPath: '/repos/first', enabled: true },
+          { name: 'second', localPath: '/repos/second', enabled: false },
+        ],
+      });
+    });
+
+    it('is idempotent and does not duplicate an existing localPath', () => {
+      const gateway = new ServerConfigFileSystemGateway({ configPath });
+      const entry = makeEntry();
+
+      gateway.addProject(entry);
+      gateway.addProject(makeEntry({ name: 'renamed' }));
+
+      const written = readFileSync(configPath, 'utf-8');
+      const parsed: unknown = JSON.parse(written);
+      expect(parsed).toEqual({
+        repositories: [{ name: 'main-app', localPath: '/repos/main-app', enabled: true }],
+      });
+    });
+
+    it('preserves unknown top-level keys from an existing loose config', () => {
+      const path = join(baseDir, 'loose.json');
+      writeFileSync(path, JSON.stringify({ repositories: [], version: 2, custom: { a: 1 } }));
+      const gateway = new ServerConfigFileSystemGateway({ configPath: path });
+
+      gateway.addProject(makeEntry());
+
+      const parsed: unknown = JSON.parse(readFileSync(path, 'utf-8'));
+      expect(parsed).toEqual({
+        repositories: [{ name: 'main-app', localPath: '/repos/main-app', enabled: true }],
+        version: 2,
+        custom: { a: 1 },
+      });
+    });
+  });
+});

--- a/src/tests/units/modules/setup-wizard/interface-adapters/gateways/skillTemplate.fileSystem.gateway.test.ts
+++ b/src/tests/units/modules/setup-wizard/interface-adapters/gateways/skillTemplate.fileSystem.gateway.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SkillTemplateFileSystemGateway } from '@/modules/setup-wizard/interface-adapters/gateways/skillTemplate.fileSystem.gateway.js';
+
+const MCP_SERVER_PATH = '/opt/reviewflow/dist/mcpServer.js';
+
+describe('SkillTemplateFileSystemGateway (integration with real filesystem)', () => {
+  let projectPath: string;
+  let gateway: SkillTemplateFileSystemGateway;
+
+  beforeEach(() => {
+    projectPath = mkdtempSync(join(tmpdir(), 'skill-template-'));
+    gateway = new SkillTemplateFileSystemGateway({ mcpServerPath: MCP_SERVER_PATH });
+  });
+
+  afterEach(() => {
+    rmSync(projectPath, { recursive: true, force: true });
+  });
+
+  it('writes a rendered SKILL.md under .claude/skills for the given language', () => {
+    gateway.writeSkill(projectPath, 'review-back', 'en');
+
+    const skillPath = join(projectPath, '.claude', 'skills', 'review-back', 'SKILL.md');
+    expect(existsSync(skillPath)).toBe(true);
+    expect(readFileSync(skillPath, 'utf-8')).toContain('# Skill: review-back');
+    expect(readFileSync(skillPath, 'utf-8')).toContain('# Goal');
+  });
+
+  it('does not overwrite an existing SKILL.md', () => {
+    const skillPath = join(projectPath, '.claude', 'skills', 'review-back', 'SKILL.md');
+    mkdirSync(join(projectPath, '.claude', 'skills', 'review-back'), { recursive: true });
+    writeFileSync(skillPath, 'PRESERVED', 'utf-8');
+
+    gateway.writeSkill(projectPath, 'review-back', 'fr');
+
+    expect(readFileSync(skillPath, 'utf-8')).toBe('PRESERVED');
+  });
+
+  it('writes the .mcp.json wiring the review-progress server to the mcp server path', () => {
+    gateway.writeMcpJson(projectPath);
+
+    const mcpPath = join(projectPath, '.mcp.json');
+    expect(existsSync(mcpPath)).toBe(true);
+    expect(JSON.parse(readFileSync(mcpPath, 'utf-8'))).toEqual({
+      mcpServers: {
+        'review-progress': {
+          command: 'node',
+          args: [MCP_SERVER_PATH],
+        },
+      },
+    });
+  });
+
+  it('does not overwrite an existing .mcp.json', () => {
+    const mcpPath = join(projectPath, '.mcp.json');
+    writeFileSync(mcpPath, '{"keep":true}', 'utf-8');
+
+    gateway.writeMcpJson(projectPath);
+
+    expect(readFileSync(mcpPath, 'utf-8')).toBe('{"keep":true}');
+  });
+});

--- a/src/tests/units/modules/setup-wizard/interface-adapters/gateways/validation.adapter.gateway.test.ts
+++ b/src/tests/units/modules/setup-wizard/interface-adapters/gateways/validation.adapter.gateway.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ValidationAdapterGateway } from '@/modules/setup-wizard/interface-adapters/gateways/validation.adapter.gateway.js';
+
+const VALID_CONFIG = {
+  server: { port: 3000 },
+  user: { name: 'reviewer' },
+  queue: { concurrency: 1 },
+};
+
+function writeJson(path: string, value: unknown): void {
+  writeFileSync(path, JSON.stringify(value));
+}
+
+describe('ValidationAdapterGateway (integration with real filesystem)', () => {
+  let rootDir: string;
+  let projectPath: string;
+  let fallbackConfigPath: string;
+  let envPath: string;
+
+  beforeEach(() => {
+    rootDir = mkdtempSync(join(tmpdir(), 'reviewflow-validation-adapter-'));
+    projectPath = join(rootDir, 'project');
+    mkdirSync(projectPath, { recursive: true });
+    fallbackConfigPath = join(rootDir, 'fallback-config.json');
+    envPath = join(rootDir, '.env');
+  });
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  it('reports valid when the project config and env file are present and correct', () => {
+    const projectConfigPath = join(projectPath, '.claude', 'reviews', 'config.json');
+    mkdirSync(join(projectPath, '.claude', 'reviews'), { recursive: true });
+    writeJson(projectConfigPath, VALID_CONFIG);
+    writeFileSync(envPath, 'TOKEN=value\n');
+
+    const gateway = new ValidationAdapterGateway({ configPath: fallbackConfigPath, envPath });
+    const report = gateway.validate(projectPath);
+
+    expect(report.status).toBe('valid');
+    expect(report.issues).toEqual([]);
+  });
+
+  it('falls back to the dependency config path when the project config is absent', () => {
+    writeJson(fallbackConfigPath, VALID_CONFIG);
+    writeFileSync(envPath, 'TOKEN=value\n');
+
+    const gateway = new ValidationAdapterGateway({ configPath: fallbackConfigPath, envPath });
+    const report = gateway.validate(projectPath);
+
+    expect(report.status).toBe('valid');
+    expect(report.issues).toEqual([]);
+  });
+
+  it('reports not-found when neither project nor fallback config exists', () => {
+    const gateway = new ValidationAdapterGateway({ configPath: fallbackConfigPath, envPath });
+    const report = gateway.validate(projectPath);
+
+    expect(report.status).toBe('not-found');
+    expect(report.issues).toEqual([]);
+  });
+
+  it('maps each validation issue field, message and severity', () => {
+    writeJson(fallbackConfigPath, { server: { port: 70000 } });
+
+    const gateway = new ValidationAdapterGateway({ configPath: fallbackConfigPath, envPath });
+    const report = gateway.validate(projectPath);
+
+    expect(report.status).toBe('invalid');
+    expect(report.issues).toContainEqual({
+      field: 'server.port',
+      message: 'Port must be between 1 and 65535',
+      severity: 'error',
+    });
+    expect(report.issues).toContainEqual({
+      field: '.env',
+      message: 'Missing .env file',
+      severity: 'error',
+    });
+  });
+});

--- a/src/tests/units/modules/statistics-insights/entities/insight/developerInsight.guard.test.ts
+++ b/src/tests/units/modules/statistics-insights/entities/insight/developerInsight.guard.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseDeveloperInsight,
+  safeParseDeveloperInsight,
+  isValidDeveloperInsight,
+} from '@/modules/statistics-insights/entities/insight/developerInsight.guard.js';
+import { DeveloperInsightFactory } from '@/tests/factories/developerInsight.factory.js';
+
+describe('parseDeveloperInsight', () => {
+  it('returns the parsed insight for valid data', () => {
+    const valid = DeveloperInsightFactory.createValid();
+
+    const result = parseDeveloperInsight(valid);
+
+    expect(result).toEqual(valid);
+  });
+
+  it('throws for invalid data', () => {
+    const invalid = DeveloperInsightFactory.create({ developerName: '' });
+
+    expect(() => parseDeveloperInsight(invalid)).toThrow('[developerInsight]');
+  });
+});
+
+describe('safeParseDeveloperInsight', () => {
+  it('succeeds for valid data', () => {
+    const valid = DeveloperInsightFactory.createValid();
+
+    const result = safeParseDeveloperInsight(valid);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('fails for an out-of-range overallLevel', () => {
+    const invalid = DeveloperInsightFactory.create({ overallLevel: 11 });
+
+    const result = safeParseDeveloperInsight(invalid);
+
+    expect(result.success).toBe(false);
+  });
+
+  it('fails when a required field is missing', () => {
+    const result = safeParseDeveloperInsight({ developerName: 'alice' });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('isValidDeveloperInsight', () => {
+  it('returns true for valid data', () => {
+    const valid = DeveloperInsightFactory.createValid();
+
+    expect(isValidDeveloperInsight(valid)).toBe(true);
+  });
+
+  it('returns true when topPriority is null', () => {
+    const valid = DeveloperInsightFactory.createValid({ topPriority: null });
+
+    expect(isValidDeveloperInsight(valid)).toBe(true);
+  });
+
+  it('returns false for a non-object', () => {
+    expect(isValidDeveloperInsight(null)).toBe(false);
+    expect(isValidDeveloperInsight('alice')).toBe(false);
+  });
+
+  it('returns false for a negative reviewCount', () => {
+    const invalid = DeveloperInsightFactory.create({ reviewCount: -1 });
+
+    expect(isValidDeveloperInsight(invalid)).toBe(false);
+  });
+});

--- a/src/tests/units/modules/statistics-insights/entities/insight/persistedInsightsData.guard.test.ts
+++ b/src/tests/units/modules/statistics-insights/entities/insight/persistedInsightsData.guard.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parsePersistedInsightsData,
+  safeParsePersistedInsightsData,
+  isValidPersistedInsightsData,
+} from '@/modules/statistics-insights/entities/insight/persistedInsightsData.guard.js';
+
+const validData = {
+  developers: [],
+  processedReviewIds: ['r1'],
+  lastUpdated: '2026-03-15T10:00:00Z',
+  aiInsights: null,
+  reviewCountAtAiGeneration: 0,
+};
+
+describe('persistedInsightsData.guard', () => {
+  it('parses a valid persisted-insights object', () => {
+    const result = parsePersistedInsightsData(validData);
+    expect(result.processedReviewIds).toEqual(['r1']);
+  });
+
+  it('throws when parsing an invalid object', () => {
+    expect(() => parsePersistedInsightsData({ developers: 'nope' })).toThrow();
+  });
+
+  it('safeParse succeeds on a valid object', () => {
+    expect(safeParsePersistedInsightsData(validData).success).toBe(true);
+  });
+
+  it('safeParse fails on an invalid object', () => {
+    expect(safeParsePersistedInsightsData(null).success).toBe(false);
+  });
+
+  it('isValid returns true for a valid object and false otherwise', () => {
+    expect(isValidPersistedInsightsData(validData)).toBe(true);
+    expect(isValidPersistedInsightsData({})).toBe(false);
+  });
+});

--- a/src/tests/units/modules/statistics-insights/gateways/aiInsightsSession.claude.gateway.test.ts
+++ b/src/tests/units/modules/statistics-insights/gateways/aiInsightsSession.claude.gateway.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AiInsightsSessionClaudeGateway } from '@/modules/statistics-insights/interface-adapters/gateways/aiInsightsSession.claude.gateway.js';
+import { StubClaudeSessionGateway } from '@/tests/stubs/claudeSession.stub.js';
+
+const FAST_OPTIONS = (homeDir: string) => ({
+  homeDir,
+  model: 'sonnet',
+  pollIntervalMs: 1,
+  maxAttempts: 20,
+});
+
+function transcriptDir(homeDir: string): string {
+  const slug = homeDir.replace(/\//g, '-');
+  const dir = join(homeDir, '.claude', 'projects', slug);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe('AiInsightsSessionClaudeGateway (integration with real filesystem)', () => {
+  let homeDir: string;
+  let sessionGateway: StubClaudeSessionGateway;
+
+  beforeEach(() => {
+    homeDir = mkdtempSync(join(tmpdir(), 'insights-session-'));
+    sessionGateway = new StubClaudeSessionGateway();
+  });
+
+  afterEach(() => {
+    rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it('dispatches --bg, accumulates the transcript answer, and cleans up the session', async () => {
+    const dir = transcriptDir(homeDir);
+    const lines = [
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: '{"part":' }] } }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: '1}' }], stop_reason: 'end_turn' },
+      }),
+    ];
+    writeFileSync(join(dir, 'stub-session-abc.jsonl'), lines.join('\n') + '\n');
+
+    const gateway = new AiInsightsSessionClaudeGateway(sessionGateway, FAST_OPTIONS(homeDir));
+    const result = await gateway.run('insights prompt');
+
+    expect(result).toEqual({ status: 'completed', answer: '{"part":1}' });
+    expect(sessionGateway.dispatchCalls[0].jobType).toBe('insights');
+    expect(sessionGateway.dispatchCalls[0].flags.mcpConfigJson).toBe('{"mcpServers":{}}');
+    expect(sessionGateway.stopCalls).toEqual(['stub-session']);
+    expect(sessionGateway.removeCalls).toEqual(['stub-session']);
+  });
+
+  it('returns unavailable without cleanup when the dispatch fails', async () => {
+    sessionGateway.setDispatchResult({ status: 'failed', rawStderr: 'not logged in' });
+
+    const gateway = new AiInsightsSessionClaudeGateway(sessionGateway, FAST_OPTIONS(homeDir));
+    const result = await gateway.run('insights prompt');
+
+    expect(result).toEqual({ status: 'unavailable', reason: 'failed' });
+    expect(sessionGateway.stopCalls).toEqual([]);
+    expect(sessionGateway.removeCalls).toEqual([]);
+  });
+
+  it('times out and still cleans up when no transcript turn completes', async () => {
+    const gateway = new AiInsightsSessionClaudeGateway(sessionGateway, FAST_OPTIONS(homeDir));
+    const result = await gateway.run('insights prompt');
+
+    expect(result).toEqual({ status: 'timed-out' });
+    expect(sessionGateway.stopCalls).toEqual(['stub-session']);
+    expect(sessionGateway.removeCalls).toEqual(['stub-session']);
+  });
+});

--- a/src/tests/units/modules/statistics-insights/gateways/stats.fileSystem.test.ts
+++ b/src/tests/units/modules/statistics-insights/gateways/stats.fileSystem.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { FileSystemStatsGateway } from '@/modules/statistics-insights/interface-adapters/gateways/fileSystem/stats.fileSystem.js';
+import { ProjectStatsFactory, ReviewStatsFactory } from '@/tests/factories/projectStats.factory.js';
+
+function statsPath(projectPath: string): string {
+  return join(projectPath, '.claude', 'reviews', 'stats.json');
+}
+
+function writeStatsFile(projectPath: string, content: string): void {
+  const path = statsPath(projectPath);
+  mkdirSync(join(projectPath, '.claude', 'reviews'), { recursive: true });
+  writeFileSync(path, content, 'utf-8');
+}
+
+describe('FileSystemStatsGateway (integration with real filesystem)', () => {
+  let projectPath: string;
+  let gateway: FileSystemStatsGateway;
+
+  beforeEach(() => {
+    projectPath = mkdtempSync(join(tmpdir(), 'stats-fs-'));
+    gateway = new FileSystemStatsGateway();
+  });
+
+  afterEach(() => {
+    rmSync(projectPath, { recursive: true, force: true });
+  });
+
+  describe('loadProjectStats', () => {
+    it('returns null when the stats file does not exist', () => {
+      expect(gateway.loadProjectStats(projectPath)).toBeNull();
+    });
+
+    it('returns the parsed stats when the file is valid', () => {
+      const stats = ProjectStatsFactory.withReviews([ReviewStatsFactory.create()]);
+      writeStatsFile(projectPath, JSON.stringify(stats));
+
+      const loaded = gateway.loadProjectStats(projectPath);
+
+      expect(loaded).not.toBeNull();
+      expect(loaded?.totalReviews).toBe(1);
+      expect(loaded?.reviews).toHaveLength(1);
+    });
+
+    it('normalizes a missing reviews array to an empty array', () => {
+      writeStatsFile(projectPath, JSON.stringify({ totalReviews: 0 }));
+
+      const loaded = gateway.loadProjectStats(projectPath);
+
+      expect(loaded?.reviews).toEqual([]);
+    });
+
+    it('returns null when the file content is malformed JSON', () => {
+      writeStatsFile(projectPath, '{ not valid json');
+
+      expect(gateway.loadProjectStats(projectPath)).toBeNull();
+    });
+  });
+
+  describe('saveProjectStats', () => {
+    it('creates the directory and writes the stats with a fresh lastUpdated', () => {
+      const stats = ProjectStatsFactory.create({ lastUpdated: 'stale' });
+
+      gateway.saveProjectStats(projectPath, stats);
+
+      expect(existsSync(statsPath(projectPath))).toBe(true);
+      const written = gateway.loadProjectStats(projectPath);
+      expect(written?.lastUpdated).not.toBe('stale');
+    });
+
+    it('writes into an already-existing directory', () => {
+      mkdirSync(join(projectPath, '.claude', 'reviews'), { recursive: true });
+      const stats = ProjectStatsFactory.withReviews([ReviewStatsFactory.create()]);
+
+      gateway.saveProjectStats(projectPath, stats);
+
+      const content = readFileSync(statsPath(projectPath), 'utf-8');
+      expect(JSON.parse(content).totalReviews).toBe(1);
+    });
+  });
+
+  describe('statsFileExists', () => {
+    it('returns false when no stats file is present', () => {
+      expect(gateway.statsFileExists(projectPath)).toBe(false);
+    });
+
+    it('returns true once a stats file has been saved', () => {
+      gateway.saveProjectStats(projectPath, ProjectStatsFactory.create());
+
+      expect(gateway.statsFileExists(projectPath)).toBe(true);
+    });
+  });
+});

--- a/src/tests/units/modules/statistics-insights/interface-adapters/presenters/overview.presenter.test.ts
+++ b/src/tests/units/modules/statistics-insights/interface-adapters/presenters/overview.presenter.test.ts
@@ -141,6 +141,51 @@ describe('OverviewPresenter', () => {
 
       expect(viewModel.activeReviews.items[0]?.elapsedLabel).toBe('—');
     });
+
+    it('falls back to "—" elapsedLabel when startedAt is an unparseable date string', () => {
+      const presenter = new OverviewPresenter({ now: () => NOW });
+
+      const viewModel = presenter.present({
+        repositories: [RepositoryConfigFactory.create({ name: 'frontend', localPath: '/repos/frontend' })],
+        activeJobs: [
+          {
+            id: 'broken-date-job',
+            mrNumber: 9,
+            project: '/repos/frontend',
+            mrUrl: 'https://example.com/9',
+            status: 'running',
+            startedAt: 'not-a-date',
+          },
+        ],
+        projectStats: [],
+        recentReviews: [],
+      });
+
+      expect(viewModel.activeReviews.items[0]?.elapsedLabel).toBe('—');
+    });
+
+    it('falls back to "—" projectName when the job localPath matches no repository', () => {
+      const presenter = new OverviewPresenter({ now: () => NOW });
+
+      const viewModel = presenter.present({
+        repositories: [],
+        activeJobs: [
+          {
+            id: 'orphan-job',
+            mrNumber: 7,
+            project: '/repos/unknown',
+            mrUrl: 'https://example.com/7',
+            status: 'running',
+            startedAt: new Date(NOW.getTime() - 60_000).toISOString(),
+          },
+        ],
+        projectStats: [],
+        recentReviews: [],
+      });
+
+      expect(viewModel.activeReviews.items[0]?.projectName).toBe('—');
+      expect(viewModel.activeReviews.items[0]?.mrPrefix).toBe('MR');
+    });
   });
 
   describe('project cards', () => {
@@ -423,6 +468,75 @@ describe('OverviewPresenter', () => {
       });
 
       expect(viewModel.projectCards.items[0]?.externalLink).toBeUndefined();
+    });
+
+    it('forwards externalLink into a card that has a stats entry with history', () => {
+      const presenter = new OverviewPresenter({ now: () => NOW });
+
+      const viewModel = presenter.present({
+        repositories: [
+          RepositoryConfigFactory.create({ name: 'frontend', localPath: '/repos/frontend', platform: 'gitlab' }),
+        ],
+        activeJobs: [],
+        projectStats: [
+          ProjectStatsApiResponseFactory.create({
+            project: 'frontend',
+            path: '/repos/frontend',
+            totalReviews: 1,
+            averageScore: 8,
+            reviews: [ReviewStatsFactory.create({ id: 'r1', timestamp: '2026-05-25T11:59:00.000Z', score: 8 })],
+          }),
+        ],
+        recentReviews: [],
+        projectConfigs: {
+          '/repos/frontend': { externalLink: 'https://notion.so/team/frontend' },
+        },
+      });
+
+      const card = viewModel.projectCards.items[0];
+      expect(card?.totalReviews).toBe(1);
+      expect(card?.isEmptyHistory).toBe(false);
+      expect(card?.externalLink).toBe('https://notion.so/team/frontend');
+    });
+
+    it('omits externalLink when the projectConfigs entry holds an empty string', () => {
+      const presenter = new OverviewPresenter({ now: () => NOW });
+
+      const viewModel = presenter.present({
+        repositories: [
+          RepositoryConfigFactory.create({ name: 'frontend', localPath: '/repos/frontend', platform: 'gitlab' }),
+        ],
+        activeJobs: [],
+        projectStats: [],
+        recentReviews: [],
+        projectConfigs: {
+          '/repos/frontend': { externalLink: '' },
+        },
+      });
+
+      expect(viewModel.projectCards.items[0]?.externalLink).toBeUndefined();
+    });
+  });
+
+  describe('recent review title fallback', () => {
+    it('falls back to an empty title when the review file has no title', () => {
+      const presenter = new OverviewPresenter({ now: () => NOW });
+
+      const viewModel = presenter.present({
+        repositories: [RepositoryConfigFactory.create({ name: 'frontend', localPath: '/repos/frontend' })],
+        activeJobs: [],
+        projectStats: [],
+        recentReviews: [
+          RecentReviewFileFactory.create({
+            path: '/repos/frontend/.claude/reviews/2026-05-25-MR-1.md',
+            mrNumber: '1',
+            mtime: '2026-05-25T11:59:00.000Z',
+            title: undefined,
+          }),
+        ],
+      });
+
+      expect(viewModel.recentReviewsFeed.items[0]?.title).toBe('');
     });
   });
 });

--- a/src/tests/units/modules/supervisor-management/gateways/supervisorLock.fileSystem.gateway.test.ts
+++ b/src/tests/units/modules/supervisor-management/gateways/supervisorLock.fileSystem.gateway.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir, homedir } from 'node:os';
+import { join } from 'node:path';
 import {
   SupervisorLockFileSystemGateway,
+  createDefaultSupervisorLockFileSystem,
+  getDefaultSupervisorLockFilePath,
   type SupervisorLockFileSystem,
 } from '@/modules/supervisor-management/interface-adapters/gateways/supervisorLock.fileSystem.gateway.js';
 
@@ -122,5 +127,82 @@ describe('SupervisorLockFileSystemGateway', () => {
     await gateway.release();
 
     expect(fileSystem.files.get('/lock')).toBe('5555');
+  });
+
+  it('is a no-op on release when no lock file exists', async () => {
+    const gateway = new SupervisorLockFileSystemGateway({
+      lockFilePath: '/lock',
+      currentPid: 1000,
+      fileSystem,
+    });
+
+    await gateway.release();
+
+    expect(fileSystem.files.has('/lock')).toBe(false);
+  });
+});
+
+describe('getDefaultSupervisorLockFilePath', () => {
+  it('points at the reviewflow supervisor lock under the home directory', () => {
+    expect(getDefaultSupervisorLockFilePath()).toBe(
+      join(homedir(), '.reviewflow', 'supervisor.lock'),
+    );
+  });
+});
+
+describe('createDefaultSupervisorLockFileSystem (integration with real filesystem)', () => {
+  let baseDir: string;
+
+  beforeEach(() => {
+    baseDir = mkdtempSync(join(tmpdir(), 'supervisor-lock-'));
+  });
+
+  afterEach(() => {
+    rmSync(baseDir, { recursive: true, force: true });
+  });
+
+  it('returns null when reading a file that does not exist', () => {
+    const fileSystem = createDefaultSupervisorLockFileSystem();
+
+    expect(fileSystem.readFile(join(baseDir, 'missing.lock'))).toBe(null);
+  });
+
+  it('writes a file creating parent directories, then reads it back', () => {
+    const fileSystem = createDefaultSupervisorLockFileSystem();
+    const lockPath = join(baseDir, 'nested', 'supervisor.lock');
+
+    fileSystem.writeFile(lockPath, '4242');
+
+    expect(fileSystem.readFile(lockPath)).toBe('4242');
+    expect(readFileSync(lockPath, 'utf-8')).toBe('4242');
+  });
+
+  it('ensures a directory exists', () => {
+    const fileSystem = createDefaultSupervisorLockFileSystem();
+    const dirPath = join(baseDir, 'ensured');
+
+    fileSystem.ensureDirectory(dirPath);
+
+    fileSystem.writeFile(join(dirPath, 'child.lock'), 'ok');
+    expect(fileSystem.readFile(join(dirPath, 'child.lock'))).toBe('ok');
+  });
+
+  it('deletes an existing file and is a no-op on a missing one', () => {
+    const fileSystem = createDefaultSupervisorLockFileSystem();
+    const lockPath = join(baseDir, 'to-delete.lock');
+    writeFileSync(lockPath, '1');
+
+    fileSystem.deleteFile(lockPath);
+    expect(fileSystem.readFile(lockPath)).toBe(null);
+
+    fileSystem.deleteFile(lockPath);
+    expect(fileSystem.readFile(lockPath)).toBe(null);
+  });
+
+  it('reports the current process as alive and a fabricated pid as dead', () => {
+    const fileSystem = createDefaultSupervisorLockFileSystem();
+
+    expect(fileSystem.isProcessAlive(process.pid)).toBe(true);
+    expect(fileSystem.isProcessAlive(2_147_483_646)).toBe(false);
   });
 });

--- a/src/tests/units/modules/tracking/interface-adapters/controllers/http/mrTrackingAdvanced.routes.test.ts
+++ b/src/tests/units/modules/tracking/interface-adapters/controllers/http/mrTrackingAdvanced.routes.test.ts
@@ -30,14 +30,51 @@ import Fastify, { type FastifyInstance } from 'fastify';
 import { mrTrackingAdvancedRoutes } from '@/modules/tracking/interface-adapters/controllers/http/mrTrackingAdvanced.routes.js';
 import { enqueueReview } from '@/frameworks/queue/pQueueAdapter.js';
 import { createStubLogger } from '@/tests/stubs/logger.stub.js';
-import { TrackedMrFactory } from '@/tests/factories/trackedMr.factory.js';
+import { TrackedMrFactory, MrTrackingDataFactory } from '@/tests/factories/trackedMr.factory.js';
 import type { TrackedMr } from '@/modules/tracking/entities/tracking/trackedMr.js';
+
+interface RepoStub {
+  name: string;
+  platform: 'gitlab' | 'github';
+  localPath: string;
+  remoteUrl: string;
+  skill: string;
+  enabled: boolean;
+}
+
+const DEFAULT_REPO: RepoStub = {
+  name: 'test',
+  platform: 'gitlab',
+  localPath: '/home/user/projects/test',
+  remoteUrl: 'https://gitlab.com/test-org/test-project.git',
+  skill: 'review',
+  enabled: true,
+};
+
+interface TrackingGatewayOverrides {
+  getById?: ReturnType<typeof vi.fn>;
+  update?: ReturnType<typeof vi.fn>;
+  getByState?: ReturnType<typeof vi.fn>;
+  getActiveMrs?: ReturnType<typeof vi.fn>;
+  loadTracking?: ReturnType<typeof vi.fn>;
+}
+
+interface GateResult {
+  status: 'enqueued' | 'pending' | 'rejected';
+  jobId?: string;
+  pendingId?: string;
+  reason?: string;
+}
 
 interface BuildAppOptions {
   enforceBudgetAccepted: boolean;
   consumedUsd?: number;
   limitUsd?: number;
   trackedMr?: TrackedMr | null;
+  repositories?: RepoStub[];
+  tracking?: TrackingGatewayOverrides;
+  createSyncThreadsExecute?: ReturnType<typeof vi.fn>;
+  gateResult?: GateResult | null;
 }
 
 interface AppBundle {
@@ -45,6 +82,8 @@ interface AppBundle {
   broadcastBudgetExceeded: ReturnType<typeof vi.fn>;
   enforceBudgetExecute: ReturnType<typeof vi.fn>;
   getByNumber: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  gateExecute: ReturnType<typeof vi.fn>;
 }
 
 async function buildApp(options: BuildAppOptions): Promise<AppBundle> {
@@ -65,45 +104,42 @@ async function buildApp(options: BuildAppOptions): Promise<AppBundle> {
 
   const trackedMrValue = options.trackedMr === undefined ? null : options.trackedMr;
   const getByNumber = vi.fn(() => trackedMrValue);
+  const tracking = options.tracking ?? {};
+  const update = tracking.update ?? vi.fn();
+  const gateExecute = vi.fn(async () => options.gateResult);
+  const createSyncThreadsExecute = options.createSyncThreadsExecute ?? vi.fn();
 
   const app = Fastify();
   await app.register(mrTrackingAdvancedRoutes, {
-    getRepositories: () => [
-      {
-        name: 'test',
-        platform: 'gitlab',
-        localPath: '/home/user/projects/test',
-        remoteUrl: 'https://gitlab.com/test-org/test-project.git',
-        skill: 'review',
-        enabled: true,
-      },
-    ],
+    getRepositories: () => options.repositories ?? [DEFAULT_REPO],
     reviewRequestTrackingGateway: {
-      getById: vi.fn(() => null),
+      getById: tracking.getById ?? vi.fn(() => null),
       getByNumber,
       create: vi.fn(),
-      update: vi.fn(),
-      getByState: vi.fn(() => []),
-      getActiveMrs: vi.fn(() => []),
+      update,
+      getByState: tracking.getByState ?? vi.fn(() => []),
+      getActiveMrs: tracking.getActiveMrs ?? vi.fn(() => []),
       remove: vi.fn(() => true),
       archive: vi.fn(() => true),
       recordReviewEvent: vi.fn(),
       recordPush: vi.fn(() => null),
-      loadTracking: vi.fn(() => null),
+      loadTracking: tracking.loadTracking ?? vi.fn(() => null),
       saveTracking: vi.fn(),
     } as never,
     reviewContextGateway: { create: vi.fn(), read: vi.fn(() => null), updateProgress: vi.fn() } as never,
     threadFetchGatewayFactory: () => ({ fetchThreads: vi.fn(() => []) }) as never,
     diffMetadataFetchGatewayFactory: () => ({ fetchDiffMetadata: vi.fn(() => undefined) }) as never,
     diffStatsFetchGatewayFactory: () => ({ fetchDiffStats: vi.fn(() => null) }) as never,
-    createSyncThreadsUseCase: () => ({ execute: vi.fn() }) as never,
+    createSyncThreadsUseCase: () => ({ execute: createSyncThreadsExecute }) as never,
     recordReviewCompletion: { execute: vi.fn() } as never,
     enforceBudget: { execute: enforceBudgetExecute } as never,
     broadcastBudgetExceeded,
+    gateClaudeInvocation:
+      options.gateResult == null ? undefined : ({ execute: gateExecute } as never),
     logger: createStubLogger(),
   });
 
-  return { app, broadcastBudgetExceeded, enforceBudgetExecute, getByNumber };
+  return { app, broadcastBudgetExceeded, enforceBudgetExecute, getByNumber, update, gateExecute };
 }
 
 describe('mrTrackingAdvancedRoutes POST /api/mr-tracking/followup', () => {
@@ -205,6 +241,602 @@ describe('mrTrackingAdvancedRoutes POST /api/mr-tracking/followup', () => {
     expect(response.json()).toEqual({ success: false, error: 'MR not tracked' });
     expect(enforceBudgetExecute).not.toHaveBeenCalled();
     expect(enqueueReview).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 400 when mrId is missing', async () => {
+    const { app, enforceBudgetExecute } = await buildApp({ enforceBudgetAccepted: true });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/followup',
+      payload: { projectPath: '/home/user/projects/test' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toEqual({ success: false, error: 'mrId required' });
+    expect(enforceBudgetExecute).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 400 when projectPath is missing', async () => {
+    const { app } = await buildApp({ enforceBudgetAccepted: true });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/followup',
+      payload: { mrId: 'gitlab-test-org/test-project-42' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toEqual({ success: false, error: 'projectPath required' });
+
+    await app.close();
+  });
+
+  it('returns 400 when projectPath is not absolute', async () => {
+    const { app } = await buildApp({ enforceBudgetAccepted: true });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/followup',
+      payload: { mrId: 'gitlab-test-org/test-project-42', projectPath: 'relative/path' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toEqual({ success: false, error: 'Invalid path' });
+
+    await app.close();
+  });
+
+  it('returns 400 when projectPath contains directory traversal', async () => {
+    const { app } = await buildApp({ enforceBudgetAccepted: true });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/followup',
+      payload: { mrId: 'gitlab-test-org/test-project-42', projectPath: '/home/../etc' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toEqual({ success: false, error: 'Invalid path' });
+
+    await app.close();
+  });
+
+  it('returns 400 when mrId does not match the expected format', async () => {
+    const { app } = await buildApp({ enforceBudgetAccepted: true });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/followup',
+      payload: { mrId: 'not-a-valid-id', projectPath: '/home/user/projects/test' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toEqual({ success: false, error: 'Invalid mrId format' });
+
+    await app.close();
+  });
+
+  it('returns 404 when no enabled repository matches the projectPath', async () => {
+    const { app } = await buildApp({
+      enforceBudgetAccepted: true,
+      repositories: [{ ...DEFAULT_REPO, enabled: false }],
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/followup',
+      payload: { mrId: 'gitlab-test-org/test-project-42', projectPath: '/home/user/projects/test' },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toEqual({ success: false, error: 'Repository not configured' });
+
+    await app.close();
+  });
+
+  it('returns success=false when enqueueReview reports the review is already running', async () => {
+    (enqueueReview as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(false);
+    const { app } = await buildApp({
+      enforceBudgetAccepted: true,
+      trackedMr: TrackedMrFactory.create({ id: 'gitlab-test-org/test-project-42', mrNumber: 42 }),
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/followup',
+      payload: { mrId: 'gitlab-test-org/test-project-42', projectPath: '/home/user/projects/test' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      success: false,
+      error: 'Review already in progress or recently performed',
+    });
+
+    await app.close();
+  });
+
+  it('returns pending-confirmation when gateClaudeInvocation parks the job', async () => {
+    const { app, gateExecute } = await buildApp({
+      enforceBudgetAccepted: true,
+      trackedMr: TrackedMrFactory.create({ id: 'gitlab-test-org/test-project-42', mrNumber: 42 }),
+      gateResult: { status: 'pending', pendingId: 'pending-1' },
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/followup',
+      payload: { mrId: 'gitlab-test-org/test-project-42', projectPath: '/home/user/projects/test' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      success: true,
+      status: 'pending-confirmation',
+      pendingId: 'pending-1',
+    });
+    expect(gateExecute).toHaveBeenCalledTimes(1);
+    expect(enqueueReview).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns success=false when gateClaudeInvocation rejects the job', async () => {
+    const { app } = await buildApp({
+      enforceBudgetAccepted: true,
+      trackedMr: TrackedMrFactory.create({ id: 'gitlab-test-org/test-project-42', mrNumber: 42 }),
+      gateResult: { status: 'rejected', reason: 'duplicate' },
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/followup',
+      payload: { mrId: 'gitlab-test-org/test-project-42', projectPath: '/home/user/projects/test' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      success: false,
+      error: 'Review already in progress or recently performed',
+    });
+
+    await app.close();
+  });
+
+  it('returns success with jobId when gateClaudeInvocation enqueues the job', async () => {
+    const { app } = await buildApp({
+      enforceBudgetAccepted: true,
+      trackedMr: TrackedMrFactory.create({ id: 'gitlab-test-org/test-project-42', mrNumber: 42 }),
+      gateResult: { status: 'enqueued', jobId: 'job-1' },
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/followup',
+      payload: { mrId: 'gitlab-test-org/test-project-42', projectPath: '/home/user/projects/test' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      success: true,
+      message: 'Followup review in progress',
+    });
+
+    await app.close();
+  });
+
+  it('resolves the github platform from the mrId prefix', async () => {
+    const { app, getByNumber } = await buildApp({
+      enforceBudgetAccepted: true,
+      repositories: [
+        {
+          ...DEFAULT_REPO,
+          platform: 'github',
+          remoteUrl: 'https://github.com/test-org/test-project.git',
+        },
+      ],
+      trackedMr: TrackedMrFactory.create({
+        id: 'github-test-org/test-project-7',
+        mrNumber: 7,
+        platform: 'github',
+      }),
+    });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/followup',
+      payload: { mrId: 'github-test-org/test-project-7', projectPath: '/home/user/projects/test' },
+    });
+
+    expect(getByNumber).toHaveBeenCalledWith('/home/user/projects/test', 7, 'github');
+    const enqueuedJob = (enqueueReview as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(enqueuedJob.platform).toBe('github');
+    expect(enqueuedJob.mrUrl).toContain('/pull/7');
+
+    await app.close();
+  });
+});
+
+describe('mrTrackingAdvancedRoutes POST /api/mr-tracking/auto-followup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 400 when mrId is missing', async () => {
+    const { app } = await buildApp({ enforceBudgetAccepted: true });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/auto-followup',
+      payload: { projectPath: '/home/user/projects/test', enabled: true },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toEqual({ success: false, error: 'mrId requis' });
+
+    await app.close();
+  });
+
+  it('returns 400 when enabled is not a boolean', async () => {
+    const { app } = await buildApp({ enforceBudgetAccepted: true });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/auto-followup',
+      payload: { mrId: 'gitlab-test-org/test-project-42', projectPath: '/home/user/projects/test' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toEqual({ success: false, error: 'enabled (boolean) requis' });
+
+    await app.close();
+  });
+
+  it('returns 400 when projectPath is invalid', async () => {
+    const { app } = await buildApp({ enforceBudgetAccepted: true });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/auto-followup',
+      payload: { mrId: 'gitlab-test-org/test-project-42', projectPath: 'relative', enabled: true },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toEqual({ success: false, error: 'Invalid path' });
+
+    await app.close();
+  });
+
+  it('returns 404 when the MR is not found after update', async () => {
+    const update = vi.fn();
+    const { app } = await buildApp({
+      enforceBudgetAccepted: true,
+      tracking: { update, getById: vi.fn(() => null) },
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/auto-followup',
+      payload: { mrId: 'gitlab-test-org/test-project-42', projectPath: '/home/user/projects/test', enabled: true },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toEqual({ success: false, error: 'MR non trouvée' });
+    expect(update).toHaveBeenCalledWith('/home/user/projects/test', 'gitlab-test-org/test-project-42', {
+      autoFollowup: true,
+    });
+
+    await app.close();
+  });
+
+  it('returns success with the updated MR when toggling auto-followup', async () => {
+    const mr = TrackedMrFactory.create({ id: 'gitlab-test-org/test-project-42', autoFollowup: false });
+    const { app, update } = await buildApp({
+      enforceBudgetAccepted: true,
+      tracking: { update: vi.fn(), getById: vi.fn(() => mr) },
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/auto-followup',
+      payload: { mrId: 'gitlab-test-org/test-project-42', projectPath: '/home/user/projects/test', enabled: false },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.success).toBe(true);
+    expect(body.mr.id).toBe('gitlab-test-org/test-project-42');
+    expect(update).toHaveBeenCalledWith('/home/user/projects/test', 'gitlab-test-org/test-project-42', {
+      autoFollowup: false,
+    });
+
+    await app.close();
+  });
+});
+
+describe('mrTrackingAdvancedRoutes POST /api/mr-tracking/followup-importants', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 400 when an explicit projectPath is invalid', async () => {
+    const { app } = await buildApp({ enforceBudgetAccepted: true });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/followup-importants',
+      payload: { projectPath: 'relative' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toEqual({ success: false, error: 'Invalid path' });
+
+    await app.close();
+  });
+
+  it('returns 404 when the explicit projectPath has no enabled repository', async () => {
+    const { app } = await buildApp({
+      enforceBudgetAccepted: true,
+      repositories: [{ ...DEFAULT_REPO, enabled: false }],
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/followup-importants',
+      payload: { projectPath: '/home/user/projects/test' },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toEqual({ success: false, error: 'Repository not configured' });
+
+    await app.close();
+  });
+
+  it('returns triggered=0 with empty arrays when no pending-approval MR has warnings', async () => {
+    const noWarnings = TrackedMrFactory.create({ id: 'gitlab-test-org/test-project-1', totalWarnings: 0 });
+    const { app } = await buildApp({
+      enforceBudgetAccepted: true,
+      tracking: { getByState: vi.fn(() => [noWarnings]) },
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/followup-importants',
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ success: true, triggered: 0, candidates: [], failed: [] });
+
+    await app.close();
+  });
+
+  it('triggers candidates with warnings and reports successes via the internal followup route', async () => {
+    const candidate = TrackedMrFactory.create({
+      id: 'gitlab-test-org/test-project-42',
+      mrNumber: 42,
+      title: 'Important MR',
+      totalWarnings: 3,
+    });
+    const { app } = await buildApp({
+      enforceBudgetAccepted: true,
+      tracking: { getByState: vi.fn(() => [candidate]) },
+      trackedMr: candidate,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/followup-importants',
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.success).toBe(true);
+    expect(body.triggered).toBe(1);
+    expect(body.candidates).toEqual([{ mrId: 'gitlab-test-org/test-project-42', mrNumber: 42, title: 'Important MR' }]);
+    expect(body.failed).toEqual([]);
+
+    await app.close();
+  });
+
+  it('collects failures when the internal followup route reports success=false', async () => {
+    const candidate = TrackedMrFactory.create({
+      id: 'gitlab-test-org/test-project-42',
+      mrNumber: 42,
+      totalWarnings: 2,
+    });
+    const { app } = await buildApp({
+      enforceBudgetAccepted: true,
+      tracking: { getByState: vi.fn(() => [candidate]) },
+      trackedMr: null,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/followup-importants',
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.triggered).toBe(0);
+    expect(body.failed).toEqual([{ mrId: 'gitlab-test-org/test-project-42', error: 'MR not tracked' }]);
+
+    await app.close();
+  });
+});
+
+describe('mrTrackingAdvancedRoutes POST /api/mr-tracking/sync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 400 when projectPath is invalid', async () => {
+    const { app } = await buildApp({ enforceBudgetAccepted: true });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/sync',
+      payload: { projectPath: 'relative' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toEqual({ success: false, error: 'Invalid path' });
+
+    await app.close();
+  });
+
+  it('returns 404 when syncing a specific mrId that is not tracked', async () => {
+    const { app } = await buildApp({
+      enforceBudgetAccepted: true,
+      tracking: { getById: vi.fn(() => null) },
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/sync',
+      payload: { projectPath: '/home/user/projects/test', mrId: 'gitlab-test-org/test-project-42' },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toEqual({ success: false, error: 'MR/PR not found' });
+
+    await app.close();
+  });
+
+  it('returns the synced MR when a specific mrId resolves', async () => {
+    const tracked = TrackedMrFactory.create({ id: 'gitlab-test-org/test-project-42' });
+    const synced = TrackedMrFactory.create({ id: 'gitlab-test-org/test-project-42', openThreads: 2, state: 'pending-approval' });
+    const { app } = await buildApp({
+      enforceBudgetAccepted: true,
+      tracking: { getById: vi.fn(() => tracked) },
+      createSyncThreadsExecute: vi.fn(() => synced),
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/sync',
+      payload: { projectPath: '/home/user/projects/test', mrId: 'gitlab-test-org/test-project-42' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.success).toBe(true);
+    expect(body.mr.openThreads).toBe(2);
+
+    await app.close();
+  });
+
+  it('returns 404 when a specific mrId is tracked but the sync use case returns null', async () => {
+    const tracked = TrackedMrFactory.create({ id: 'gitlab-test-org/test-project-42' });
+    const { app } = await buildApp({
+      enforceBudgetAccepted: true,
+      tracking: { getById: vi.fn(() => tracked) },
+      createSyncThreadsExecute: vi.fn(() => null),
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/sync',
+      payload: { projectPath: '/home/user/projects/test', mrId: 'gitlab-test-org/test-project-42' },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toEqual({ success: false, error: 'MR/PR not found' });
+
+    await app.close();
+  });
+
+  it('syncs all active MRs and returns the loaded tracking list', async () => {
+    const activeMr = TrackedMrFactory.create({ id: 'gitlab-test-org/test-project-1' });
+    const trackingList = MrTrackingDataFactory.withMrs([activeMr]);
+    const { app } = await buildApp({
+      enforceBudgetAccepted: true,
+      tracking: {
+        getActiveMrs: vi.fn(() => [activeMr]),
+        loadTracking: vi.fn(() => trackingList),
+      },
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/sync',
+      payload: { projectPath: '/home/user/projects/test' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.success).toBe(true);
+    expect(body.mrs).toHaveLength(1);
+
+    await app.close();
+  });
+
+  it('defaults to an empty list when loadTracking returns null', async () => {
+    const { app } = await buildApp({
+      enforceBudgetAccepted: true,
+      tracking: { getActiveMrs: vi.fn(() => []), loadTracking: vi.fn(() => null) },
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/sync',
+      payload: { projectPath: '/home/user/projects/test' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ success: true, mrs: [] });
+
+    await app.close();
+  });
+
+  it('ignores individual MR sync failures while syncing all active MRs', async () => {
+    const activeMr = TrackedMrFactory.create({ id: 'gitlab-test-org/test-project-1' });
+    const failingSync = vi.fn(() => {
+      throw new Error('sync boom');
+    });
+    const { app } = await buildApp({
+      enforceBudgetAccepted: true,
+      tracking: { getActiveMrs: vi.fn(() => [activeMr]), loadTracking: vi.fn(() => null) },
+      createSyncThreadsExecute: failingSync,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/sync',
+      payload: { projectPath: '/home/user/projects/test' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ success: true, mrs: [] });
+
+    await app.close();
+  });
+
+  it('returns 500 when getById throws while syncing a specific mrId', async () => {
+    const { app } = await buildApp({
+      enforceBudgetAccepted: true,
+      tracking: {
+        getById: vi.fn(() => {
+          throw new Error('storage failure');
+        }),
+      },
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/mr-tracking/sync',
+      payload: { projectPath: '/home/user/projects/test', mrId: 'gitlab-test-org/test-project-42' },
+    });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.json()).toEqual({ success: false, error: 'storage failure' });
 
     await app.close();
   });

--- a/src/tests/units/modules/tracking/interface-adapters/gateways/fileSystem/reviewRequestTracking.fileSystem.test.ts
+++ b/src/tests/units/modules/tracking/interface-adapters/gateways/fileSystem/reviewRequestTracking.fileSystem.test.ts
@@ -1,0 +1,359 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { FileSystemReviewRequestTrackingGateway } from '@/modules/tracking/interface-adapters/gateways/fileSystem/reviewRequestTracking.fileSystem.js';
+import { ProjectStatsCalculator } from '@/modules/statistics-insights/interface-adapters/presenters/projectStats.calculator.js';
+import {
+  TrackedMrFactory,
+  MrTrackingDataFactory,
+} from '@/tests/factories/trackedMr.factory.js';
+
+function trackingFilePath(projectPath: string): string {
+  return join(projectPath, '.claude', 'reviews', 'mr-tracking.json');
+}
+
+function writeRaw(projectPath: string, content: string): void {
+  const filePath = trackingFilePath(projectPath);
+  mkdirSync(join(projectPath, '.claude', 'reviews'), { recursive: true });
+  writeFileSync(filePath, content, 'utf-8');
+}
+
+describe('FileSystemReviewRequestTrackingGateway', () => {
+  let projectPath: string;
+  let gateway: FileSystemReviewRequestTrackingGateway;
+
+  beforeEach(() => {
+    projectPath = mkdtempSync(join(tmpdir(), 'reviewflow-tracking-fs-'));
+    gateway = new FileSystemReviewRequestTrackingGateway(new ProjectStatsCalculator());
+  });
+
+  afterEach(() => {
+    rmSync(projectPath, { recursive: true, force: true });
+  });
+
+  describe('loadTracking', () => {
+    it('returns null when the tracking file does not exist', () => {
+      expect(gateway.loadTracking(projectPath)).toBeNull();
+    });
+
+    it('returns null when the tracking file contains malformed JSON', () => {
+      writeRaw(projectPath, '{ not valid json');
+
+      expect(gateway.loadTracking(projectPath)).toBeNull();
+    });
+
+    it('resets mrs to an empty array when persisted mrs is not an array', () => {
+      writeRaw(
+        projectPath,
+        JSON.stringify({ mrs: 'corrupted', lastUpdated: '2024-01-01T00:00:00Z', stats: null })
+      );
+
+      const result = gateway.loadTracking(projectPath);
+
+      expect(result).not.toBeNull();
+      expect(result?.mrs).toEqual([]);
+    });
+
+    it('fills empty stats when persisted stats is missing', () => {
+      writeRaw(projectPath, JSON.stringify({ mrs: [], lastUpdated: '2024-01-01T00:00:00Z' }));
+
+      const result = gateway.loadTracking(projectPath);
+
+      expect(result?.stats).toEqual({
+        totalMrs: 0,
+        totalReviews: 0,
+        totalFollowups: 0,
+        averageReviewsPerMr: 0,
+        averageTimeToApproval: null,
+        topAssigners: [],
+      });
+    });
+
+    it('round-trips data written through saveTracking', () => {
+      const trackedMr = TrackedMrFactory.create({ id: 'mr-roundtrip' });
+      const data = MrTrackingDataFactory.withMrs([trackedMr]);
+
+      gateway.saveTracking(projectPath, data);
+      const result = gateway.loadTracking(projectPath);
+
+      expect(result).not.toBeNull();
+      expect(result?.mrs).toHaveLength(1);
+      expect(result?.mrs[0].id).toBe('mr-roundtrip');
+    });
+  });
+
+  describe('saveTracking', () => {
+    it('creates the .claude/reviews directory when it is missing', () => {
+      const data = MrTrackingDataFactory.create();
+
+      gateway.saveTracking(projectPath, data);
+
+      expect(existsSync(trackingFilePath(projectPath))).toBe(true);
+    });
+
+    it('recomputes stats from the persisted MRs', () => {
+      const reviewed = TrackedMrFactory.create({ id: 'mr-1', totalReviews: 2, totalFollowups: 1 });
+      const data = MrTrackingDataFactory.withMrs([reviewed]);
+
+      gateway.saveTracking(projectPath, data);
+      const result = gateway.loadTracking(projectPath);
+
+      expect(result?.stats.totalMrs).toBe(1);
+      expect(result?.stats.totalReviews).toBe(2);
+      expect(result?.stats.totalFollowups).toBe(1);
+    });
+  });
+
+  describe('getById', () => {
+    it('returns null when no tracking file exists', () => {
+      expect(gateway.getById(projectPath, 'mr-1')).toBeNull();
+    });
+
+    it('returns null when the id is not found', () => {
+      gateway.create(projectPath, TrackedMrFactory.create({ id: 'mr-known' }));
+
+      expect(gateway.getById(projectPath, 'mr-unknown')).toBeNull();
+    });
+
+    it('returns the matching MR', () => {
+      gateway.create(projectPath, TrackedMrFactory.create({ id: 'mr-found' }));
+
+      expect(gateway.getById(projectPath, 'mr-found')?.id).toBe('mr-found');
+    });
+  });
+
+  describe('getByNumber', () => {
+    it('returns null when no tracking file exists', () => {
+      expect(gateway.getByNumber(projectPath, 42, 'gitlab')).toBeNull();
+    });
+
+    it('returns null when number matches but platform differs', () => {
+      gateway.create(projectPath, TrackedMrFactory.create({ mrNumber: 42, platform: 'gitlab' }));
+
+      expect(gateway.getByNumber(projectPath, 42, 'github')).toBeNull();
+    });
+
+    it('returns the matching MR by number and platform', () => {
+      gateway.create(projectPath, TrackedMrFactory.create({ mrNumber: 42, platform: 'gitlab' }));
+
+      expect(gateway.getByNumber(projectPath, 42, 'gitlab')?.mrNumber).toBe(42);
+    });
+  });
+
+  describe('create', () => {
+    it('initializes tracking data when none exists yet', () => {
+      gateway.create(projectPath, TrackedMrFactory.create({ id: 'first' }));
+
+      const result = gateway.loadTracking(projectPath);
+      expect(result?.mrs).toHaveLength(1);
+      expect(result?.stats.totalMrs).toBe(1);
+    });
+
+    it('appends to existing tracking data', () => {
+      gateway.create(projectPath, TrackedMrFactory.create({ id: 'first' }));
+      gateway.create(projectPath, TrackedMrFactory.create({ id: 'second' }));
+
+      const result = gateway.loadTracking(projectPath);
+      expect(result?.mrs).toHaveLength(2);
+    });
+  });
+
+  describe('update', () => {
+    it('does nothing when no tracking file exists', () => {
+      gateway.update(projectPath, 'mr-1', { state: 'merged' });
+
+      expect(gateway.loadTracking(projectPath)).toBeNull();
+    });
+
+    it('does nothing when the id is not found', () => {
+      gateway.create(projectPath, TrackedMrFactory.create({ id: 'mr-known', state: 'pending-review' }));
+
+      gateway.update(projectPath, 'mr-missing', { state: 'merged' });
+
+      expect(gateway.getById(projectPath, 'mr-known')?.state).toBe('pending-review');
+    });
+
+    it('updates the matching MR fields', () => {
+      gateway.create(projectPath, TrackedMrFactory.create({ id: 'mr-1', state: 'pending-review' }));
+
+      gateway.update(projectPath, 'mr-1', { state: 'pending-fix' });
+
+      expect(gateway.getById(projectPath, 'mr-1')?.state).toBe('pending-fix');
+    });
+  });
+
+  describe('getByState', () => {
+    it('returns empty array when no tracking file exists', () => {
+      expect(gateway.getByState(projectPath, 'pending-fix')).toEqual([]);
+    });
+
+    it('returns MRs matching the state', () => {
+      gateway.create(projectPath, TrackedMrFactory.create({ id: 'mr-1', state: 'pending-fix' }));
+      gateway.create(projectPath, TrackedMrFactory.create({ id: 'mr-2', state: 'pending-review' }));
+
+      const result = gateway.getByState(projectPath, 'pending-fix');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('mr-1');
+    });
+  });
+
+  describe('getActiveMrs', () => {
+    it('returns empty array when no tracking file exists', () => {
+      expect(gateway.getActiveMrs(projectPath)).toEqual([]);
+    });
+
+    it('excludes merged and closed MRs', () => {
+      gateway.create(projectPath, TrackedMrFactory.create({ id: 'active', state: 'pending-fix' }));
+      gateway.create(projectPath, TrackedMrFactory.create({ id: 'merged', state: 'merged' }));
+      gateway.create(projectPath, TrackedMrFactory.create({ id: 'closed', state: 'closed' }));
+
+      const result = gateway.getActiveMrs(projectPath);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('active');
+    });
+  });
+
+  describe('remove', () => {
+    it('returns false when no tracking file exists', () => {
+      expect(gateway.remove(projectPath, 'mr-1')).toBe(false);
+    });
+
+    it('returns false when the id is not found', () => {
+      gateway.create(projectPath, TrackedMrFactory.create({ id: 'mr-known' }));
+
+      expect(gateway.remove(projectPath, 'mr-unknown')).toBe(false);
+    });
+
+    it('removes the matching MR and returns true', () => {
+      gateway.create(projectPath, TrackedMrFactory.create({ id: 'mr-remove' }));
+
+      expect(gateway.remove(projectPath, 'mr-remove')).toBe(true);
+      expect(gateway.getById(projectPath, 'mr-remove')).toBeNull();
+    });
+  });
+
+  describe('archive', () => {
+    it('delegates to remove and returns false for unknown id', () => {
+      expect(gateway.archive(projectPath, 'mr-unknown')).toBe(false);
+    });
+
+    it('removes the matching MR and returns true', () => {
+      gateway.create(projectPath, TrackedMrFactory.create({ id: 'mr-archive' }));
+
+      expect(gateway.archive(projectPath, 'mr-archive')).toBe(true);
+      expect(gateway.getById(projectPath, 'mr-archive')).toBeNull();
+    });
+  });
+
+  describe('recordReviewEvent', () => {
+    it('does nothing when no tracking file exists', () => {
+      gateway.recordReviewEvent(projectPath, 'mr-1', {
+        type: 'review',
+        timestamp: '2024-01-15T12:00:00Z',
+        durationMs: 1000,
+        score: 8,
+        blocking: 1,
+        warnings: 2,
+        suggestions: 3,
+        threadsClosed: 0,
+        threadsOpened: 3,
+        diffStats: null,
+      });
+
+      expect(gateway.loadTracking(projectPath)).toBeNull();
+    });
+
+    it('does nothing when the MR id is not found', () => {
+      gateway.create(projectPath, TrackedMrFactory.create({ id: 'mr-known' }));
+
+      gateway.recordReviewEvent(projectPath, 'mr-missing', {
+        type: 'review',
+        timestamp: '2024-01-15T12:00:00Z',
+        durationMs: 1000,
+        score: 8,
+        blocking: 1,
+        warnings: 2,
+        suggestions: 3,
+        threadsClosed: 0,
+        threadsOpened: 3,
+        diffStats: null,
+      });
+
+      expect(gateway.getById(projectPath, 'mr-known')?.reviews).toHaveLength(0);
+    });
+
+    it('records a review event and increments review counters', () => {
+      gateway.create(projectPath, TrackedMrFactory.create({ id: 'mr-1' }));
+
+      gateway.recordReviewEvent(projectPath, 'mr-1', {
+        type: 'review',
+        timestamp: '2024-01-15T12:00:00Z',
+        durationMs: 60000,
+        score: 8,
+        blocking: 1,
+        warnings: 2,
+        suggestions: 3,
+        threadsClosed: 0,
+        threadsOpened: 3,
+        diffStats: null,
+      });
+
+      const result = gateway.getById(projectPath, 'mr-1');
+      expect(result?.totalReviews).toBe(1);
+      expect(result?.totalFollowups).toBe(0);
+      expect(result?.totalBlocking).toBe(1);
+      expect(result?.totalWarnings).toBe(2);
+      expect(result?.totalSuggestions).toBe(3);
+      expect(result?.totalDurationMs).toBe(60000);
+      expect(result?.lastReviewAt).toBe('2024-01-15T12:00:00Z');
+    });
+
+    it('records a followup event and increments followup counters', () => {
+      gateway.create(projectPath, TrackedMrFactory.create({ id: 'mr-1' }));
+
+      gateway.recordReviewEvent(projectPath, 'mr-1', {
+        type: 'followup',
+        timestamp: '2024-01-16T12:00:00Z',
+        durationMs: 30000,
+        score: 9,
+        blocking: 0,
+        warnings: 1,
+        suggestions: 0,
+        threadsClosed: 2,
+        threadsOpened: 0,
+        diffStats: null,
+      });
+
+      const result = gateway.getById(projectPath, 'mr-1');
+      expect(result?.totalFollowups).toBe(1);
+      expect(result?.totalReviews).toBe(0);
+    });
+  });
+
+  describe('recordPush', () => {
+    it('returns null when no tracking file exists', () => {
+      expect(gateway.recordPush(projectPath, 42, 'gitlab')).toBeNull();
+    });
+
+    it('returns null when the MR is not found', () => {
+      gateway.create(projectPath, TrackedMrFactory.create({ mrNumber: 42, platform: 'gitlab' }));
+
+      expect(gateway.recordPush(projectPath, 999, 'gitlab')).toBeNull();
+    });
+
+    it('updates lastPushAt and returns the MR', () => {
+      gateway.create(
+        projectPath,
+        TrackedMrFactory.create({ mrNumber: 42, platform: 'gitlab', lastPushAt: null })
+      );
+
+      const result = gateway.recordPush(projectPath, 42, 'gitlab');
+
+      expect(result).not.toBeNull();
+      expect(result?.lastPushAt).not.toBeNull();
+    });
+  });
+});

--- a/src/tests/units/modules/worktree-management/entities/worktree/worktree.test.ts
+++ b/src/tests/units/modules/worktree-management/entities/worktree/worktree.test.ts
@@ -2,12 +2,76 @@ import { describe, it, expect } from 'vitest';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import {
+  createWorktreePath,
   deriveWorktreeSlug,
+  deriveWorktreeDirectoryName,
   deriveWorktreePath,
   deriveFetchRef,
+  parseWorktreeDirectoryName,
 } from '@/modules/worktree-management/entities/worktree/worktree.js';
 
 describe('worktree entity helpers', () => {
+  describe('createWorktreePath', () => {
+    it('returns the value for a valid absolute path', () => {
+      const path = createWorktreePath('/home/damien/.reviewflow/worktrees/gitlab-x-1');
+      expect(path).toBe('/home/damien/.reviewflow/worktrees/gitlab-x-1');
+    });
+
+    it('throws on an empty string', () => {
+      expect(() => createWorktreePath('')).toThrow(
+        'Invalid worktree path (must be absolute, non-empty): ',
+      );
+    });
+
+    it('throws on a relative (non-absolute) path', () => {
+      expect(() => createWorktreePath('relative/path')).toThrow(
+        'Invalid worktree path (must be absolute, non-empty): relative/path',
+      );
+    });
+  });
+
+  describe('deriveWorktreeDirectoryName', () => {
+    it('joins platform, slugged project path, and mr number', () => {
+      expect(
+        deriveWorktreeDirectoryName({
+          platform: 'gitlab',
+          projectPath: 'group/project',
+          mrNumber: 42,
+        }),
+      ).toBe('gitlab-group-project-42');
+    });
+  });
+
+  describe('parseWorktreeDirectoryName', () => {
+    it('parses a gitlab directory name', () => {
+      expect(parseWorktreeDirectoryName('gitlab-group-project-42')).toEqual({
+        platform: 'gitlab',
+        projectPath: 'group-project',
+        mrNumber: 42,
+      });
+    });
+
+    it('parses a github directory name', () => {
+      expect(parseWorktreeDirectoryName('github-owner-repo-17')).toEqual({
+        platform: 'github',
+        projectPath: 'owner-repo',
+        mrNumber: 17,
+      });
+    });
+
+    it('returns null when the name does not match the pattern', () => {
+      expect(parseWorktreeDirectoryName('bitbucket-owner-repo-17')).toBeNull();
+    });
+
+    it('returns null when there is no trailing mr number', () => {
+      expect(parseWorktreeDirectoryName('gitlab-project')).toBeNull();
+    });
+
+    it('returns null when the mr number is zero', () => {
+      expect(parseWorktreeDirectoryName('gitlab-project-0')).toBeNull();
+    });
+  });
+
   describe('deriveWorktreeSlug', () => {
     it('replaces slashes with dashes', () => {
       expect(deriveWorktreeSlug('group/project')).toBe('group-project');

--- a/src/tests/units/modules/worktree-management/usecases/sweepStaleWorktrees.usecase.test.ts
+++ b/src/tests/units/modules/worktree-management/usecases/sweepStaleWorktrees.usecase.test.ts
@@ -167,4 +167,122 @@ describe('sweepStaleWorktrees use case', () => {
 
     expect(removed).toEqual([]);
   });
+
+  it('returns a zero summary when there are no entries to scan', async () => {
+    const summary = await sweepStaleWorktrees({
+      listEntries: async () => [],
+      removeWorktree: async identity => {
+        removed.push(identity);
+        return { status: 'removed' };
+      },
+      trackingGateway: { getById: (projectPath, mrId) => fakeTracking.getById(projectPath, mrId) },
+      getRepositories: () => [repository],
+      now: () => now,
+    });
+
+    expect(summary).toEqual({ scanned: 0, removed: 0, failures: 0 });
+    expect(removed).toEqual([]);
+  });
+
+  it('removes worktree when matching MR is closed with no mergedAt timestamp', async () => {
+    const identity: WorktreeIdentity = { platform: 'gitlab', projectPath: 'group-project', mrNumber: 6 };
+    const entry = buildEntry(identity, new Date('2026-05-23T11:00:00Z'));
+    trackingFor(identity, buildTrackedMr({
+      id: 'gitlab-group-project-6',
+      mrNumber: 6,
+      state: 'closed',
+      mergedAt: null,
+    }));
+
+    await runSweep([entry]);
+
+    expect(removed).toEqual([identity]);
+  });
+
+  it('removes worktree when mergedAt is not a parseable date', async () => {
+    const identity: WorktreeIdentity = { platform: 'gitlab', projectPath: 'group-project', mrNumber: 7 };
+    const entry = buildEntry(identity, new Date('2026-05-23T11:00:00Z'));
+    trackingFor(identity, buildTrackedMr({
+      id: 'gitlab-group-project-7',
+      mrNumber: 7,
+      state: 'merged',
+      mergedAt: 'not-a-date',
+    }));
+
+    await runSweep([entry]);
+
+    expect(removed).toEqual([identity]);
+  });
+
+  it('skips disabled repositories when resolving the tracked MR', async () => {
+    const identity: WorktreeIdentity = { platform: 'gitlab', projectPath: 'group-project', mrNumber: 8 };
+    const sixDaysAgo = new Date(now.getTime() - 6 * 24 * 60 * 60 * 1000);
+    const entry = buildEntry(identity, sixDaysAgo);
+    trackingFor(identity, buildTrackedMr({
+      id: 'gitlab-group-project-8',
+      mrNumber: 8,
+      state: 'pending-review',
+    }));
+
+    const summary = await sweepStaleWorktrees({
+      listEntries: async () => [entry],
+      removeWorktree: async removeIdentity => {
+        removed.push(removeIdentity);
+        return { status: 'removed' };
+      },
+      trackingGateway: { getById: (projectPath, mrId) => fakeTracking.getById(projectPath, mrId) },
+      getRepositories: () => [{ localPath: repository.localPath, enabled: false }],
+      now: () => now,
+    });
+
+    expect(removed).toEqual([identity]);
+    expect(summary).toEqual({ scanned: 1, removed: 1, failures: 0 });
+  });
+
+  it('counts a failure when removeWorktree reports a failed status', async () => {
+    const identity: WorktreeIdentity = { platform: 'gitlab', projectPath: 'group-project', mrNumber: 9 };
+    const entry = buildEntry(identity, new Date('2026-05-23T11:00:00Z'));
+
+    const summary = await sweepStaleWorktrees({
+      listEntries: async () => [entry],
+      removeWorktree: async () => ({ status: 'failed', warning: 'boom' }),
+      trackingGateway: { getById: (projectPath, mrId) => fakeTracking.getById(projectPath, mrId) },
+      getRepositories: () => [repository],
+      now: () => now,
+    });
+
+    expect(summary).toEqual({ scanned: 1, removed: 0, failures: 1 });
+  });
+
+  it('counts a failure when removeWorktree throws', async () => {
+    const identity: WorktreeIdentity = { platform: 'gitlab', projectPath: 'group-project', mrNumber: 10 };
+    const entry = buildEntry(identity, new Date('2026-05-23T11:00:00Z'));
+
+    const summary = await sweepStaleWorktrees({
+      listEntries: async () => [entry],
+      removeWorktree: async () => {
+        throw new Error('remove failed');
+      },
+      trackingGateway: { getById: (projectPath, mrId) => fakeTracking.getById(projectPath, mrId) },
+      getRepositories: () => [repository],
+      now: () => now,
+    });
+
+    expect(summary).toEqual({ scanned: 1, removed: 0, failures: 1 });
+  });
+
+  it('treats an absent removal result as neither removed nor failed', async () => {
+    const identity: WorktreeIdentity = { platform: 'gitlab', projectPath: 'group-project', mrNumber: 11 };
+    const entry = buildEntry(identity, new Date('2026-05-23T11:00:00Z'));
+
+    const summary = await sweepStaleWorktrees({
+      listEntries: async () => [entry],
+      removeWorktree: async () => ({ status: 'absent' }),
+      trackingGateway: { getById: (projectPath, mrId) => fakeTracking.getById(projectPath, mrId) },
+      getRepositories: () => [repository],
+      now: () => now,
+    });
+
+    expect(summary).toEqual({ scanned: 1, removed: 0, failures: 0 });
+  });
 });

--- a/src/tests/units/services/statsService.branches.test.ts
+++ b/src/tests/units/services/statsService.branches.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, existsSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  loadProjectStats,
+  saveProjectStats,
+  parseReviewOutput,
+  addReviewStats,
+  getStatsSummary,
+} from '@/modules/statistics-insights/services/statsService.js';
+import { ProjectStatsFactory, ReviewStatsFactory } from '@/tests/factories/projectStats.factory.js';
+import { DiffStatsFactory } from '@/tests/factories/diffStats.factory.js';
+
+const STATS_RELATIVE_PATH = join('.claude', 'reviews', 'stats.json');
+
+describe('loadProjectStats edge branches', () => {
+  let projectPath: string;
+
+  beforeEach(() => {
+    projectPath = join(tmpdir(), `reviewflow-load-${Date.now()}-${Math.random()}`);
+  });
+
+  afterEach(() => {
+    if (existsSync(projectPath)) {
+      rmSync(projectPath, { recursive: true, force: true });
+    }
+  });
+
+  it('returns empty stats when the stats file does not exist', () => {
+    const stats = loadProjectStats(projectPath);
+
+    expect(stats.totalReviews).toBe(0);
+    expect(stats.averageScore).toBeNull();
+    expect(stats.reviews).toEqual([]);
+  });
+
+  it('returns empty stats when the file content is not valid JSON', () => {
+    mkdirSync(join(projectPath, '.claude', 'reviews'), { recursive: true });
+    writeFileSync(join(projectPath, STATS_RELATIVE_PATH), 'not-json{', 'utf-8');
+
+    const stats = loadProjectStats(projectPath);
+
+    expect(stats.totalReviews).toBe(0);
+    expect(stats.reviews).toEqual([]);
+  });
+
+  it('returns empty stats when JSON does not match the ProjectStats shape', () => {
+    mkdirSync(join(projectPath, '.claude', 'reviews'), { recursive: true });
+    writeFileSync(
+      join(projectPath, STATS_RELATIVE_PATH),
+      JSON.stringify({ totalReviews: 'oops', somethingElse: true }),
+      'utf-8'
+    );
+
+    const stats = loadProjectStats(projectPath);
+
+    expect(stats.totalReviews).toBe(0);
+    expect(stats.reviews).toEqual([]);
+  });
+
+  it('coerces a missing reviews field to an empty array when shape is otherwise valid', () => {
+    mkdirSync(join(projectPath, '.claude', 'reviews'), { recursive: true });
+    writeFileSync(
+      join(projectPath, STATS_RELATIVE_PATH),
+      JSON.stringify({
+        totalReviews: 2,
+        totalDuration: 120000,
+        lastUpdated: '2024-01-15T10:00:00Z',
+      }),
+      'utf-8'
+    );
+
+    const stats = loadProjectStats(projectPath);
+
+    expect(stats.totalReviews).toBe(2);
+    expect(stats.reviews).toEqual([]);
+  });
+
+  it('coerces a non-array reviews field to an empty array', () => {
+    mkdirSync(join(projectPath, '.claude', 'reviews'), { recursive: true });
+    writeFileSync(
+      join(projectPath, STATS_RELATIVE_PATH),
+      JSON.stringify({
+        totalReviews: 1,
+        totalDuration: 60000,
+        lastUpdated: '2024-01-15T10:00:00Z',
+        reviews: 'not-an-array',
+      }),
+      'utf-8'
+    );
+
+    const stats = loadProjectStats(projectPath);
+
+    expect(stats.reviews).toEqual([]);
+  });
+
+  it('preserves a valid reviews array on load', () => {
+    mkdirSync(join(projectPath, '.claude', 'reviews'), { recursive: true });
+    const review = ReviewStatsFactory.create({ id: 'kept' });
+    writeFileSync(
+      join(projectPath, STATS_RELATIVE_PATH),
+      JSON.stringify({
+        totalReviews: 1,
+        totalDuration: 60000,
+        lastUpdated: '2024-01-15T10:00:00Z',
+        reviews: [review],
+      }),
+      'utf-8'
+    );
+
+    const stats = loadProjectStats(projectPath);
+
+    expect(stats.reviews).toHaveLength(1);
+    expect(stats.reviews[0].id).toBe('kept');
+  });
+});
+
+describe('saveProjectStats directory branch', () => {
+  let projectPath: string;
+
+  beforeEach(() => {
+    projectPath = join(tmpdir(), `reviewflow-save-${Date.now()}-${Math.random()}`);
+  });
+
+  afterEach(() => {
+    if (existsSync(projectPath)) {
+      rmSync(projectPath, { recursive: true, force: true });
+    }
+  });
+
+  it('creates the reviews directory when it does not exist', () => {
+    expect(existsSync(join(projectPath, '.claude', 'reviews'))).toBe(false);
+
+    saveProjectStats(projectPath, ProjectStatsFactory.create());
+
+    expect(existsSync(join(projectPath, STATS_RELATIVE_PATH))).toBe(true);
+  });
+
+  it('stamps lastUpdated with a fresh ISO timestamp on save', () => {
+    const stats = ProjectStatsFactory.create({ lastUpdated: '2000-01-01T00:00:00Z' });
+
+    saveProjectStats(projectPath, stats);
+
+    const reloaded = loadProjectStats(projectPath);
+    expect(reloaded.lastUpdated).not.toBe('2000-01-01T00:00:00Z');
+  });
+});
+
+describe('parseReviewOutput branch coverage', () => {
+  it('parses a full structured stats line', () => {
+    const result = parseReviewOutput('[REVIEW_STATS:blocking=1:warnings=2:suggestions=3:score=7.5]');
+
+    expect(result).toEqual({ score: 7.5, blocking: 1, warnings: 2, suggestions: 3 });
+  });
+
+  it('leaves defaults when structured fields are partially absent', () => {
+    const result = parseReviewOutput('[REVIEW_STATS:blocking=4]');
+
+    expect(result).toEqual({ score: null, blocking: 4, warnings: 0, suggestions: 0 });
+  });
+
+  it('parses the summary format with score, blocking, warnings and suggestions', () => {
+    const stdout = [
+      'Score global : 8/10',
+      '🚨 Bloquants : 2',
+      '⚠️ Importants : 3',
+      '💡 Suggestions : 4',
+    ].join('\n');
+
+    const result = parseReviewOutput(stdout);
+
+    expect(result).toEqual({ score: 8, blocking: 2, warnings: 3, suggestions: 4 });
+  });
+
+  it('returns summary results when only the score is present alongside a blocking summary line', () => {
+    const result = parseReviewOutput('Score global : 6.5/10\n🚨 Bloquant : 1');
+
+    expect(result.score).toBe(6.5);
+    expect(result.blocking).toBe(1);
+    expect(result.warnings).toBe(0);
+    expect(result.suggestions).toBe(0);
+  });
+
+  it('falls back to counting inline markers when no summary lines exist', () => {
+    const stdout = [
+      '🚨 [BLOQUANT] first',
+      '🚨 [BLOQUANT] second',
+      '⚠️ [IMPORTANT] one',
+      '💡 [SUGGESTION] tip',
+    ].join('\n');
+
+    const result = parseReviewOutput(stdout);
+
+    expect(result).toEqual({ score: null, blocking: 2, warnings: 1, suggestions: 1 });
+  });
+
+  it('reaches the section-header branches without lowering inline marker counts', () => {
+    const stdout = [
+      '🚨 [BLOQUANT] inline blocker',
+      '## Corrections Bloquantes',
+      'narrative only, no numbered headers',
+      '⚠️ [IMPORTANT] inline warning',
+      '## Corrections Importantes',
+      'narrative only',
+      '💡 [SUGGESTION] inline suggestion',
+      '## Suggestions',
+      'narrative only',
+    ].join('\n');
+
+    const result = parseReviewOutput(stdout);
+
+    expect(result.blocking).toBe(1);
+    expect(result.warnings).toBe(1);
+    expect(result.suggestions).toBe(1);
+  });
+
+  it('returns all zeros and null score when nothing matches', () => {
+    const result = parseReviewOutput('a review with no recognizable markers at all');
+
+    expect(result).toEqual({ score: null, blocking: 0, warnings: 0, suggestions: 0 });
+  });
+});
+
+describe('addReviewStats branch coverage', () => {
+  let projectPath: string;
+
+  beforeEach(() => {
+    projectPath = join(tmpdir(), `reviewflow-add-${Date.now()}-${Math.random()}`);
+    mkdirSync(join(projectPath, '.claude', 'reviews'), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(projectPath)) {
+      rmSync(projectPath, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps averageScore null when the review carries no score', () => {
+    const review = addReviewStats(projectPath, 7, 60000, 'no markers here');
+
+    expect(review.score).toBeNull();
+
+    const updated = loadProjectStats(projectPath);
+    expect(updated.averageScore).toBeNull();
+    expect(updated.scoredReviewCount).toBe(0);
+  });
+
+  it('stores diffStats and updates additions/deletions aggregates when provided', () => {
+    const diffStats = DiffStatsFactory.create({ additions: 80, deletions: 12 });
+
+    const review = addReviewStats(
+      projectPath,
+      9,
+      60000,
+      '[REVIEW_STATS:blocking=0:warnings=0:suggestions=0:score=9]',
+      'reviewer',
+      diffStats
+    );
+
+    expect(review.diffStats).toEqual(diffStats);
+    expect(review.assignedBy).toBe('reviewer');
+
+    const updated = loadProjectStats(projectPath);
+    expect(updated.totalAdditions).toBe(80);
+    expect(updated.totalDeletions).toBe(12);
+    expect(updated.averageAdditions).toBe(80);
+    expect(updated.averageDeletions).toBe(12);
+    expect(updated.diffStatsReviewCount).toBe(1);
+  });
+
+  it('defaults diffStats to null when none is supplied', () => {
+    const review = addReviewStats(projectPath, 11, 60000, 'no markers');
+
+    expect(review.diffStats).toBeNull();
+
+    const updated = loadProjectStats(projectPath);
+    expect(updated.totalAdditions).toBe(0);
+    expect(updated.totalDeletions).toBe(0);
+    expect(updated.averageAdditions).toBeNull();
+    expect(updated.averageDeletions).toBeNull();
+  });
+
+  it('leaves assignedBy undefined when not supplied', () => {
+    const review = addReviewStats(projectPath, 12, 60000, 'no markers');
+
+    expect(review.assignedBy).toBeUndefined();
+  });
+});
+
+describe('getStatsSummary formatting and trend branches', () => {
+  it('formats durations including hours when above one hour', () => {
+    const stats = ProjectStatsFactory.create({
+      totalDuration: 3 * 3600000 + 25 * 60000,
+      averageDuration: 90 * 60000,
+    });
+
+    const summary = getStatsSummary(stats);
+
+    expect(summary.totalTime).toBe('3h 25m');
+    expect(summary.averageTime).toBe('1h 30m');
+  });
+
+  it('formats durations as minutes only when below one hour', () => {
+    const stats = ProjectStatsFactory.create({
+      totalDuration: 45 * 60000,
+      averageDuration: 45 * 60000,
+    });
+
+    const summary = getStatsSummary(stats);
+
+    expect(summary.totalTime).toBe('45m');
+    expect(summary.averageTime).toBe('45m');
+  });
+
+  it('renders averageScore as "-" when it is null', () => {
+    const stats = ProjectStatsFactory.create({ averageScore: null });
+
+    const summary = getStatsSummary(stats);
+
+    expect(summary.averageScore).toBe('-');
+  });
+
+  it('keeps trends stable when there are too few reviews to compare', () => {
+    const reviews = [
+      ReviewStatsFactory.create({ id: 'a', score: 8, blocking: 0 }),
+      ReviewStatsFactory.create({ id: 'b', score: 8, blocking: 0 }),
+    ];
+    const stats = ProjectStatsFactory.withReviews(reviews);
+
+    const summary = getStatsSummary(stats);
+
+    expect(summary.trend.score).toBe('stable');
+    expect(summary.trend.blocking).toBe('stable');
+  });
+
+  it('reports score up and blocking up when recent reviews improve', () => {
+    const previous = Array.from({ length: 5 }, (_, index) =>
+      ReviewStatsFactory.create({ id: `p${index}`, score: 5, blocking: 3 })
+    );
+    const recent = Array.from({ length: 5 }, (_, index) =>
+      ReviewStatsFactory.create({ id: `r${index}`, score: 9, blocking: 0 })
+    );
+    const stats = ProjectStatsFactory.withReviews([...previous, ...recent]);
+
+    const summary = getStatsSummary(stats);
+
+    expect(summary.trend.score).toBe('up');
+    expect(summary.trend.blocking).toBe('up');
+  });
+
+  it('reports score down and blocking down when recent reviews worsen', () => {
+    const previous = Array.from({ length: 5 }, (_, index) =>
+      ReviewStatsFactory.create({ id: `p${index}`, score: 9, blocking: 0 })
+    );
+    const recent = Array.from({ length: 5 }, (_, index) =>
+      ReviewStatsFactory.create({ id: `r${index}`, score: 5, blocking: 4 })
+    );
+    const stats = ProjectStatsFactory.withReviews([...previous, ...recent]);
+
+    const summary = getStatsSummary(stats);
+
+    expect(summary.trend.score).toBe('down');
+    expect(summary.trend.blocking).toBe('down');
+  });
+
+  it('keeps score trend stable when no scored reviews exist in either window', () => {
+    const previous = Array.from({ length: 5 }, (_, index) =>
+      ReviewStatsFactory.create({ id: `p${index}`, score: null, blocking: 1 })
+    );
+    const recent = Array.from({ length: 5 }, (_, index) =>
+      ReviewStatsFactory.create({ id: `r${index}`, score: null, blocking: 1 })
+    );
+    const stats = ProjectStatsFactory.withReviews([...previous, ...recent]);
+
+    const summary = getStatsSummary(stats);
+
+    expect(summary.trend.score).toBe('stable');
+    expect(summary.trend.blocking).toBe('stable');
+  });
+
+  it('keeps score trend stable when changes stay within the threshold', () => {
+    const previous = Array.from({ length: 5 }, (_, index) =>
+      ReviewStatsFactory.create({ id: `p${index}`, score: 7, blocking: 1 })
+    );
+    const recent = Array.from({ length: 5 }, (_, index) =>
+      ReviewStatsFactory.create({ id: `r${index}`, score: 7.2, blocking: 1 })
+    );
+    const stats = ProjectStatsFactory.withReviews([...previous, ...recent]);
+
+    const summary = getStatsSummary(stats);
+
+    expect(summary.trend.score).toBe('stable');
+    expect(summary.trend.blocking).toBe('stable');
+  });
+});

--- a/src/tests/units/shared/services/logFileReader.test.ts
+++ b/src/tests/units/shared/services/logFileReader.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, writeFileSync, appendFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  logFileExists,
+  readLastLines,
+  watchLogFile,
+} from '@/shared/services/logFileReader.js';
+
+describe('logFileReader', () => {
+  let dir: string;
+  let logPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'log-reader-'));
+    logPath = join(dir, 'app.log');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  describe('logFileExists', () => {
+    it('is false when the file is absent', () => {
+      expect(logFileExists(logPath)).toBe(false);
+    });
+
+    it('is true once the file exists', () => {
+      writeFileSync(logPath, 'line\n');
+      expect(logFileExists(logPath)).toBe(true);
+    });
+  });
+
+  describe('readLastLines', () => {
+    it('returns an empty array when the file is absent', () => {
+      expect(readLastLines(logPath, 10)).toEqual([]);
+    });
+
+    it('returns the last N non-empty lines', () => {
+      writeFileSync(logPath, 'a\nb\n\n  \nc\nd\n');
+      expect(readLastLines(logPath, 2)).toEqual(['c', 'd']);
+    });
+  });
+
+  describe('watchLogFile', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('emits appended lines on each poll and stops cleanly', () => {
+      writeFileSync(logPath, 'initial\n');
+      const received: string[] = [];
+      const watcher = watchLogFile(logPath, (line) => received.push(line));
+
+      appendFileSync(logPath, 'fresh-1\nfresh-2\n');
+      vi.advanceTimersByTime(500);
+
+      expect(received).toEqual(['fresh-1', 'fresh-2']);
+
+      watcher.stop();
+      appendFileSync(logPath, 'after-stop\n');
+      vi.advanceTimersByTime(500);
+      expect(received).toEqual(['fresh-1', 'fresh-2']);
+    });
+
+    it('does not emit when the file has not grown', () => {
+      writeFileSync(logPath, 'initial\n');
+      const received: string[] = [];
+      const watcher = watchLogFile(logPath, (line) => received.push(line));
+
+      vi.advanceTimersByTime(500);
+
+      expect(received).toEqual([]);
+      watcher.stop();
+    });
+
+    it('ignores polls while the file is absent', () => {
+      const received: string[] = [];
+      const watcher = watchLogFile(logPath, (line) => received.push(line));
+
+      vi.advanceTimersByTime(500);
+
+      expect(received).toEqual([]);
+      watcher.stop();
+    });
+  });
+});

--- a/src/tests/units/usecases/insights/buildAiInsightsPrompt.test.ts
+++ b/src/tests/units/usecases/insights/buildAiInsightsPrompt.test.ts
@@ -205,4 +205,251 @@ describe('buildAiInsightsPrompt', () => {
     expect(prompt.length).toBeGreaterThan(0);
     expect(prompt.length).toBeLessThan(200000);
   });
+
+  it('should report N/A score when every review score is null', () => {
+    const reviews: ReviewStats[] = [
+      ReviewStatsFactory.create({ id: 'r1', assignedBy: 'alice', mrNumber: 1, score: null }),
+      ReviewStatsFactory.create({ id: 'r2', assignedBy: 'alice', mrNumber: 2, score: null }),
+    ];
+
+    const prompt = buildAiInsightsPrompt({
+      reviews,
+      reviewContents: new Map(),
+      trackedMrs: [],
+      language: 'en',
+    });
+
+    expect(prompt).toContain('Average score: N/A/10');
+    expect(prompt).toContain('First-pass quality rate: N/A');
+  });
+
+  it('should format review duration in hours when at least 60 minutes', () => {
+    const reviews: ReviewStats[] = [
+      ReviewStatsFactory.create({
+        id: 'r1',
+        assignedBy: 'alice',
+        mrNumber: 1,
+        score: 7,
+        duration: 5_400_000,
+      }),
+    ];
+
+    const prompt = buildAiInsightsPrompt({
+      reviews,
+      reviewContents: new Map(),
+      trackedMrs: [],
+      language: 'en',
+    });
+
+    expect(prompt).toContain('Average review duration: 1h 30min');
+  });
+
+  it('should not emit excerpt section when review content has no recognizable sections', () => {
+    const reviews: ReviewStats[] = [
+      ReviewStatsFactory.create({ id: 'r1', assignedBy: 'alice', mrNumber: 7, score: 8 }),
+    ];
+
+    const reviewContents = new Map<string, string>();
+    reviewContents.set('7', 'Just a plain note without any structured headings.');
+
+    const prompt = buildAiInsightsPrompt({
+      reviews,
+      reviewContents,
+      trackedMrs: [],
+      language: 'en',
+    });
+
+    expect(prompt).not.toContain('Recent review excerpts:');
+    expect(prompt).not.toContain('--- MR 7');
+  });
+
+  it('should not emit excerpt section when no content is mapped for the review', () => {
+    const reviews: ReviewStats[] = [
+      ReviewStatsFactory.create({ id: 'r1', assignedBy: 'alice', mrNumber: 99, score: 8 }),
+    ];
+
+    const prompt = buildAiInsightsPrompt({
+      reviews,
+      reviewContents: new Map(),
+      trackedMrs: [],
+      language: 'en',
+    });
+
+    expect(prompt).not.toContain('Recent review excerpts:');
+  });
+
+  it('should aggregate multiple tracked MRs for the same developer', () => {
+    const reviews: ReviewStats[] = [
+      ReviewStatsFactory.create({ assignedBy: 'alice', mrNumber: 1, score: 8 }),
+    ];
+
+    const trackedMrs: TrackedMr[] = [
+      TrackedMrFactory.create({
+        id: 'mr-1',
+        assignment: { username: 'alice', assignedAt: '2024-01-15T10:00:00Z' },
+        totalReviews: 1,
+        totalFollowups: 0,
+        state: 'approved',
+      }),
+      TrackedMrFactory.create({
+        id: 'mr-2',
+        assignment: { username: 'alice', assignedAt: '2024-01-16T10:00:00Z' },
+        totalReviews: 2,
+        totalFollowups: 1,
+        state: 'pending-review',
+      }),
+    ];
+
+    const prompt = buildAiInsightsPrompt({
+      reviews,
+      reviewContents: new Map(),
+      trackedMrs,
+      language: 'en',
+    });
+
+    expect(prompt).toContain('Total MRs: 2');
+    expect(prompt).toContain('Total reviews across MRs: 3');
+    expect(prompt).toContain('Total followups: 1');
+    expect(prompt).toContain('MRs approved on first review: 1');
+  });
+
+  it('should not emit MR lifecycle section when developer has no tracked MRs', () => {
+    const reviews: ReviewStats[] = [
+      ReviewStatsFactory.create({ assignedBy: 'alice', mrNumber: 1, score: 8 }),
+    ];
+
+    const trackedMrs: TrackedMr[] = [
+      TrackedMrFactory.create({
+        assignment: { username: 'bob', assignedAt: '2024-01-15T10:00:00Z' },
+      }),
+    ];
+
+    const prompt = buildAiInsightsPrompt({
+      reviews,
+      reviewContents: new Map(),
+      trackedMrs,
+      language: 'en',
+    });
+
+    expect(prompt).not.toContain('### MR Lifecycle for alice:');
+  });
+
+  it('should extract executive summary and positive observations into the excerpt', () => {
+    const reviews: ReviewStats[] = [
+      ReviewStatsFactory.create({ id: 'r1', assignedBy: 'alice', mrNumber: 5, score: 9 }),
+    ];
+
+    const content = `## Synthèse Exécutive
+
+| Audit | Score |
+|-------|-------|
+| Clean Architecture | 9/10 |
+
+## Corrections Bloquantes
+
+### 1. Race condition in queue
+
+## Constats Positifs
+
+### 1. Excellent test coverage
+`;
+
+    const reviewContents = new Map<string, string>();
+    reviewContents.set('5', content);
+
+    const prompt = buildAiInsightsPrompt({
+      reviews,
+      reviewContents,
+      trackedMrs: [],
+      language: 'en',
+    });
+
+    expect(prompt).toContain('Synthèse Exécutive');
+    expect(prompt).toContain('Corrections: ### 1. Race condition in queue');
+    expect(prompt).toContain('Points positifs: ### 1. Excellent test coverage');
+  });
+
+  it('should treat missing diffStats as zero additions and deletions', () => {
+    const reviews: ReviewStats[] = [
+      ReviewStatsFactory.create({ assignedBy: 'alice', mrNumber: 1, score: 8 }),
+    ];
+
+    const prompt = buildAiInsightsPrompt({
+      reviews,
+      reviewContents: new Map(),
+      trackedMrs: [],
+      language: 'en',
+    });
+
+    expect(prompt).toContain('Total additions: 0, deletions: 0');
+  });
+
+  it('should report 0% first-pass rate when scored reviews are all below 7', () => {
+    const reviews: ReviewStats[] = [
+      ReviewStatsFactory.create({ id: 'r1', assignedBy: 'alice', mrNumber: 1, score: 5 }),
+      ReviewStatsFactory.create({ id: 'r2', assignedBy: 'alice', mrNumber: 2, score: 6 }),
+    ];
+
+    const prompt = buildAiInsightsPrompt({
+      reviews,
+      reviewContents: new Map(),
+      trackedMrs: [],
+      language: 'en',
+    });
+
+    expect(prompt).toContain('First-pass quality rate: 0%');
+  });
+
+  it('should label the excerpt MR score as N/A when the review score is null', () => {
+    const reviews: ReviewStats[] = [
+      ReviewStatsFactory.create({ id: 'r1', assignedBy: 'alice', mrNumber: 13, score: null }),
+    ];
+
+    const reviewContents = new Map<string, string>();
+    reviewContents.set('13', createReviewContent(13, 8));
+
+    const prompt = buildAiInsightsPrompt({
+      reviews,
+      reviewContents,
+      trackedMrs: [],
+      language: 'en',
+    });
+
+    expect(prompt).toContain('--- MR 13 (score: N/A) ---');
+  });
+
+  it('should ignore a blocking-corrections section that has no numbered titles', () => {
+    const reviews: ReviewStats[] = [
+      ReviewStatsFactory.create({ id: 'r1', assignedBy: 'alice', mrNumber: 21, score: 8 }),
+    ];
+
+    const content = `## Synthèse Exécutive
+
+| Audit | Score |
+|-------|-------|
+| Clean Architecture | 8/10 |
+
+## Corrections Bloquantes
+
+No numbered items here, just prose.
+
+## Constats Positifs
+
+Only prose, no numbered titles.
+`;
+
+    const reviewContents = new Map<string, string>();
+    reviewContents.set('21', content);
+
+    const prompt = buildAiInsightsPrompt({
+      reviews,
+      reviewContents,
+      trackedMrs: [],
+      language: 'en',
+    });
+
+    expect(prompt).toContain('Synthèse Exécutive');
+    expect(prompt).not.toContain('Corrections: ');
+    expect(prompt).not.toContain('Points positifs: ');
+  });
 });

--- a/src/tests/units/usecases/insights/computeDeveloperInsights.usecase.test.ts
+++ b/src/tests/units/usecases/insights/computeDeveloperInsights.usecase.test.ts
@@ -445,6 +445,32 @@ describe('computeDeveloperInsights', () => {
       expect(alice.metrics.averageDeletions).toBe(50);
     });
 
+    it('should exclude high-score reviews with blocking issues from quality rate', () => {
+      const cleanReviews = Array.from({ length: 3 }, (_, index) =>
+        ReviewStatsFactory.create({
+          id: `alice-clean-${index}`,
+          assignedBy: 'alice',
+          mrNumber: index + 1,
+          score: 8,
+          blocking: 0,
+        }),
+      );
+      const highScoreButBlocking = Array.from({ length: 2 }, (_, index) =>
+        ReviewStatsFactory.create({
+          id: `alice-blocking-${index}`,
+          assignedBy: 'alice',
+          mrNumber: index + 4,
+          score: 9,
+          blocking: 1,
+        }),
+      );
+
+      const result = computeDeveloperInsights([...cleanReviews, ...highScoreButBlocking]);
+
+      const alice = result[0];
+      expect(alice.metrics.firstReviewQualityRate).toBe(0.6);
+    });
+
     it('should compute first review quality rate based on reviews with score >= 7', () => {
       const goodReviews = Array.from({ length: 3 }, (_, index) =>
         ReviewStatsFactory.create({
@@ -543,6 +569,33 @@ describe('computeDeveloperInsights', () => {
       expect(result).toHaveLength(1);
       const alice = result[0];
       expect(alice.categoryLevels.codeVolume.level).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should handle zero developer duration when generating responsiveness strength', () => {
+      const instantReviews = createReviewsForDeveloper('alice', 10, {
+        score: 9,
+        blocking: 0,
+        warnings: 0,
+        duration: 0,
+      });
+      const slowReviews = createReviewsForDeveloper('bob', 10, {
+        score: 5,
+        blocking: 2,
+        warnings: 3,
+        duration: 600000,
+      });
+
+      const result = computeDeveloperInsights([...instantReviews, ...slowReviews]);
+
+      const alice = result.find((insight) => insight.developerName === 'alice');
+      expect(alice).toBeDefined();
+      expect(alice?.strengths).toContain('responsiveness');
+      const responsivenessStrength = alice?.insightDescriptions.find(
+        (description) =>
+          description.category === 'responsiveness' && description.type === 'strength',
+      );
+      expect(responsivenessStrength).toBeDefined();
+      expect(responsivenessStrength?.params?.percent).toBe(0);
     });
 
     it('should produce valid DeveloperInsight objects', () => {

--- a/src/tests/units/usecases/insights/computeInsightsWithPersistence.usecase.test.ts
+++ b/src/tests/units/usecases/insights/computeInsightsWithPersistence.usecase.test.ts
@@ -4,6 +4,7 @@ import { computeDeveloperInsights } from '@/modules/statistics-insights/usecases
 import { computeTeamInsights } from '@/modules/statistics-insights/usecases/insights/computeTeamInsights.usecase.js';
 import { ReviewStatsFactory } from '@/tests/factories/projectStats.factory.js';
 import { PersistedInsightsDataFactory, PersistedDeveloperMetricsFactory } from '@/tests/factories/persistedInsightsData.factory.js';
+import { DiffStatsFactory } from '@/tests/factories/diffStats.factory.js';
 import type { ReviewStats } from '@/modules/statistics-insights/services/statsService.js';
 
 function createReviewsForDeveloper(
@@ -394,6 +395,256 @@ describe('computeInsightsWithPersistence', () => {
       expect(aliceMetrics?.totalAdditions).toBe(1000);
       expect(aliceMetrics?.totalDeletions).toBe(250);
       expect(aliceMetrics?.diffStatsReviewCount).toBe(5);
+    });
+
+    it('should report zero average additions/deletions when no diffStats were ever recorded', () => {
+      const reviews = createReviewsForDeveloper('alice', 6, {
+        score: 8,
+        diffStats: null,
+      });
+
+      const result = computeInsightsWithPersistence(reviews, null);
+
+      expect(result.developerInsights).toHaveLength(1);
+      const alice = result.developerInsights[0];
+      expect(alice.metrics.averageAdditions).toBe(0);
+      expect(alice.metrics.averageDeletions).toBe(0);
+    });
+
+    it('should compute non-zero average additions/deletions from cumulative diffStats', () => {
+      const reviews = createReviewsForDeveloper('alice', 6, {
+        score: 8,
+        diffStats: { commitsCount: 2, additions: 300, deletions: 100 },
+      });
+
+      const result = computeInsightsWithPersistence(reviews, null);
+
+      const alice = result.developerInsights[0];
+      expect(alice.metrics.averageAdditions).toBe(300);
+      expect(alice.metrics.averageDeletions).toBe(100);
+    });
+  });
+
+  describe('aiInsights preservation', () => {
+    it('should default aiInsights to null and reviewCountAtAiGeneration to 0 on first run', () => {
+      const reviews = createReviewsForDeveloper('alice', 6, { score: 8 });
+
+      const result = computeInsightsWithPersistence(reviews, null);
+
+      expect(result.persistedData.aiInsights).toBeNull();
+      expect(result.persistedData.reviewCountAtAiGeneration).toBe(0);
+    });
+
+    it('should preserve existing aiInsights and reviewCountAtAiGeneration', () => {
+      const recentReviews = createReviewsForDeveloper('alice', 6, { score: 8 });
+      const aiInsights = {
+        developers: [
+          {
+            developerName: 'alice',
+            title: 'Architect',
+            titleExplanation: 'Strong design',
+            strengths: ['quality'],
+            weaknesses: [],
+            recommendations: ['keep going'],
+            summary: 'Solid contributor',
+          },
+        ],
+        team: {
+          summary: 'Healthy team',
+          strengths: ['velocity'],
+          weaknesses: [],
+          recommendations: ['document more'],
+          dynamics: 'collaborative',
+        },
+        generatedAt: '2024-01-10T08:00:00Z',
+      };
+
+      const persistedData = PersistedInsightsDataFactory.create({
+        developers: [PersistedDeveloperMetricsFactory.create({
+          developerName: 'alice',
+          totalReviews: 6,
+          recentReviews,
+        })],
+        processedReviewIds: recentReviews.map((review) => review.id),
+        aiInsights,
+        reviewCountAtAiGeneration: 6,
+      });
+
+      const result = computeInsightsWithPersistence([], persistedData);
+
+      expect(result.persistedData.aiInsights).toEqual(aiInsights);
+      expect(result.persistedData.reviewCountAtAiGeneration).toBe(6);
+    });
+  });
+
+  describe('strength and weakness descriptions', () => {
+    it('should generate strength descriptions for a high-performing single developer', () => {
+      const reviews = createReviewsForDeveloper('star', 8, {
+        score: 10,
+        blocking: 0,
+        warnings: 0,
+        suggestions: 0,
+        duration: 5000,
+        diffStats: { commitsCount: 4, additions: 500, deletions: 200 },
+      });
+
+      const result = computeInsightsWithPersistence(reviews, null);
+
+      expect(result.developerInsights).toHaveLength(1);
+      const star = result.developerInsights[0];
+      expect(star.strengths.length).toBeGreaterThan(0);
+      const strengthDescriptions = star.insightDescriptions.filter(
+        (description) => description.type === 'strength',
+      );
+      expect(strengthDescriptions.length).toBeGreaterThan(0);
+      for (const description of strengthDescriptions) {
+        expect(description.descriptionKey).toMatch(/^insight\./);
+      }
+    });
+
+    it('should generate weakness descriptions for a low-performing single developer', () => {
+      const reviews = createReviewsForDeveloper('struggler', 8, {
+        score: 2,
+        blocking: 5,
+        warnings: 8,
+        suggestions: 10,
+        duration: 600000,
+        diffStats: { commitsCount: 1, additions: 5, deletions: 1 },
+      });
+
+      const result = computeInsightsWithPersistence(reviews, null);
+
+      expect(result.developerInsights).toHaveLength(1);
+      const struggler = result.developerInsights[0];
+      expect(struggler.weaknesses.length).toBeGreaterThan(0);
+      const weaknessDescriptions = struggler.insightDescriptions.filter(
+        (description) => description.type === 'weakness',
+      );
+      expect(weaknessDescriptions.length).toBeGreaterThan(0);
+      for (const description of weaknessDescriptions) {
+        expect(description.descriptionKey).toMatch(/^insight\./);
+      }
+    });
+  });
+
+  describe('trend-based strength descriptions', () => {
+    it('should emit an improving-trend description when a strength category has level below 7 and an improving trend', () => {
+      const recentReviews = Array.from({ length: 20 }, (_, index) =>
+        ReviewStatsFactory.create({
+          id: `alice-${index}`,
+          assignedBy: 'alice',
+          mrNumber: index + 1,
+          score: index < 10 ? 5 : 7,
+          blocking: 1,
+          warnings: 2,
+          suggestions: 3,
+          duration: 120000,
+          timestamp: new Date(2024, 0, index + 1).toISOString(),
+          diffStats: null,
+        }),
+      );
+
+      const result = computeInsightsWithPersistence(recentReviews, null);
+
+      expect(result.developerInsights).toHaveLength(1);
+      const alice = result.developerInsights[0];
+      expect(alice.categoryLevels.quality.trend).toBe('improving');
+      expect(alice.categoryLevels.quality.level).toBeLessThan(7);
+      expect(alice.strengths).toContain('quality');
+
+      const qualityDescription = alice.insightDescriptions.find(
+        (description) => description.category === 'quality' && description.type === 'strength',
+      );
+      expect(qualityDescription?.descriptionKey).toBe('insight.quality.improving');
+      expect(qualityDescription?.params).toEqual({});
+    });
+  });
+
+  describe('code volume score correlation', () => {
+    it('should compute a non-zero correlation when both score and volume vary across recent reviews', () => {
+      const varyingData = [
+        { score: 5, additions: 100, deletions: 20 },
+        { score: 7, additions: 300, deletions: 60 },
+        { score: 9, additions: 500, deletions: 100 },
+        { score: 6, additions: 200, deletions: 40 },
+        { score: 8, additions: 400, deletions: 80 },
+      ];
+      const reviews = varyingData.map((data, index) =>
+        ReviewStatsFactory.create({
+          id: `alice-corr-${index}`,
+          assignedBy: 'alice',
+          mrNumber: index + 1,
+          score: data.score,
+          blocking: 0,
+          warnings: 1,
+          suggestions: 2,
+          duration: 60000,
+          timestamp: new Date(2024, 0, index + 1).toISOString(),
+          diffStats: DiffStatsFactory.create({
+            additions: data.additions,
+            deletions: data.deletions,
+          }),
+        }),
+      );
+
+      const result = computeInsightsWithPersistence(reviews, null);
+
+      expect(result.developerInsights).toHaveLength(1);
+      const alice = result.developerInsights[0];
+      expect(alice.categoryLevels.codeVolume.level).toBe(9);
+    });
+
+    it('should fall back to zero correlation when volume has no variance (zero denominator)', () => {
+      const constantVolume = DiffStatsFactory.create({ additions: 100, deletions: 20 });
+      const reviews = [5, 7, 9, 5, 7].map((score, index) =>
+        ReviewStatsFactory.create({
+          id: `bob-flat-${index}`,
+          assignedBy: 'bob',
+          mrNumber: index + 1,
+          score,
+          blocking: 0,
+          warnings: 1,
+          suggestions: 2,
+          duration: 60000,
+          timestamp: new Date(2024, 0, index + 1).toISOString(),
+          diffStats: constantVolume,
+        }),
+      );
+
+      const result = computeInsightsWithPersistence(reviews, null);
+
+      expect(result.developerInsights).toHaveLength(1);
+      const bob = result.developerInsights[0];
+      expect(bob.categoryLevels.codeVolume.level).toBe(3);
+    });
+  });
+
+  describe('multiple developers (team metrics)', () => {
+    it('should compute team metrics across developers instead of absolute benchmarks', () => {
+      const aliceReviews = createReviewsForDeveloper('alice', 6, {
+        score: 9,
+        blocking: 0,
+        warnings: 1,
+        duration: 30000,
+        diffStats: { commitsCount: 3, additions: 300, deletions: 100 },
+      });
+      const bobReviews = createReviewsForDeveloper('bob', 6, {
+        score: 4,
+        blocking: 3,
+        warnings: 5,
+        duration: 300000,
+        diffStats: { commitsCount: 1, additions: 20, deletions: 10 },
+      });
+
+      const result = computeInsightsWithPersistence(
+        [...aliceReviews, ...bobReviews],
+        null,
+      );
+
+      expect(result.developerInsights).toHaveLength(2);
+      const names = result.developerInsights.map((insight) => insight.developerName);
+      expect(names).toContain('alice');
+      expect(names).toContain('bob');
     });
   });
 });

--- a/src/tests/units/usecases/insights/getInsightsWithAiStatus.usecase.test.ts
+++ b/src/tests/units/usecases/insights/getInsightsWithAiStatus.usecase.test.ts
@@ -158,6 +158,75 @@ describe('getInsightsWithAiStatus', () => {
     expect(result.hasNewReviewsSinceAiGeneration).toBe(false);
   });
 
+  it('should return null aiInsights and false flag when no stats but persisted data has no AI insights', () => {
+    const persistedData = PersistedInsightsDataFactory.create({
+      processedReviewIds: ['r1', 'r2', 'r3'],
+      aiInsights: null,
+      reviewCountAtAiGeneration: 0,
+    });
+    insightsGateway.savePersistedInsights('/test/project', persistedData);
+
+    const result = getInsightsWithAiStatus({
+      projectPath: '/test/project',
+      statsGateway,
+      insightsGateway,
+    });
+
+    expect(result.aiInsights).toBeNull();
+    expect(result.hasNewReviewsSinceAiGeneration).toBe(false);
+  });
+
+  it('should detect new reviews since AI generation when no stats but persisted count is below processed reviews', () => {
+    const persistedData = PersistedInsightsDataFactory.create({
+      processedReviewIds: ['r1', 'r2', 'r3', 'r4', 'r5'],
+      aiInsights: validAiInsights,
+      reviewCountAtAiGeneration: 3,
+    });
+    insightsGateway.savePersistedInsights('/test/project', persistedData);
+
+    const result = getInsightsWithAiStatus({
+      projectPath: '/test/project',
+      statsGateway,
+      insightsGateway,
+    });
+
+    expect(result.aiInsights).toEqual(validAiInsights);
+    expect(result.hasNewReviewsSinceAiGeneration).toBe(true);
+  });
+
+  it('should persist null aiInsights and zero count when no stats but persisted data lacks AI insights', () => {
+    const persistedData = PersistedInsightsDataFactory.create({
+      processedReviewIds: ['r1'],
+      aiInsights: null,
+      reviewCountAtAiGeneration: 0,
+    });
+    insightsGateway.savePersistedInsights('/test/project', persistedData);
+
+    getInsightsWithAiStatus({
+      projectPath: '/test/project',
+      statsGateway,
+      insightsGateway,
+    });
+
+    const saved = insightsGateway.loadPersistedInsights('/test/project');
+    expect(saved?.aiInsights).toBeNull();
+    expect(saved?.reviewCountAtAiGeneration).toBe(0);
+  });
+
+  it('should treat an empty reviews array as no stats and return empty insights', () => {
+    statsGateway.saveProjectStats('/test/project', ProjectStatsFactory.withReviews([]));
+
+    const result = getInsightsWithAiStatus({
+      projectPath: '/test/project',
+      statsGateway,
+      insightsGateway,
+    });
+
+    expect(result.developerInsights).toEqual([]);
+    expect(result.aiInsights).toBeNull();
+    expect(result.hasNewReviewsSinceAiGeneration).toBe(false);
+  });
+
   it('should save updated persisted data', () => {
     const reviews = [
       ReviewStatsFactory.create({ id: 'r1', assignedBy: 'alice', score: 8 }),

--- a/src/tests/units/usecases/insights/insightLevelComputation.service.test.ts
+++ b/src/tests/units/usecases/insights/insightLevelComputation.service.test.ts
@@ -5,9 +5,41 @@ import {
   computeDeveloperMetrics,
   computeTeamMetrics,
   computeCategoryLevels,
+  average,
+  averageOfScores,
+  averageCodeVolume,
+  clampLevel,
+  trendToScore,
+  invertTrend,
+  computeTrendForMetric,
+  computeCodeVolumeTrend,
+  identifyStrengths,
+  identifyWeaknesses,
+  identifyTopPriority,
+  computeTitle,
+  computeOverallLevel,
 } from '@/modules/statistics-insights/usecases/insights/insightLevelComputation.service.js';
 import { ReviewStatsFactory } from '@/tests/factories/projectStats.factory.js';
 import type { ReviewStats } from '@/modules/statistics-insights/services/statsService.js';
+import type {
+  CategoryLevel,
+  CategoryLevels,
+} from '@/modules/statistics-insights/entities/insight/developerInsight.js';
+import type { InsightTrend } from '@/modules/statistics-insights/entities/insight/insightTrend.js';
+
+function categoryLevel(level: number, trend: InsightTrend = 'stable'): CategoryLevel {
+  return { level, trend };
+}
+
+function createCategoryLevels(overrides: Partial<CategoryLevels> = {}): CategoryLevels {
+  return {
+    quality: categoryLevel(5),
+    responsiveness: categoryLevel(5),
+    codeVolume: categoryLevel(5),
+    iteration: categoryLevel(5),
+    ...overrides,
+  };
+}
 
 function createReviewsForDeveloper(
   developerName: string,
@@ -166,5 +198,499 @@ describe('level calibration with real-world data', () => {
 
     expect(highLevels.quality.level).toBeGreaterThanOrEqual(8);
     expect(lowLevels.quality.level).toBeLessThanOrEqual(3);
+  });
+});
+
+describe('average', () => {
+  it('should return 0 for an empty array', () => {
+    expect(average([])).toBe(0);
+  });
+
+  it('should return the arithmetic mean for a non-empty array', () => {
+    expect(average([2, 4, 6])).toBe(4);
+  });
+});
+
+describe('averageOfScores', () => {
+  it('should return the neutral fallback of 5 when no review has a score', () => {
+    const reviews = [
+      ReviewStatsFactory.create({ score: null }),
+      ReviewStatsFactory.create({ score: null }),
+    ];
+
+    expect(averageOfScores(reviews)).toBe(5);
+  });
+
+  it('should average only the scored reviews', () => {
+    const reviews = [
+      ReviewStatsFactory.create({ score: 8 }),
+      ReviewStatsFactory.create({ score: null }),
+      ReviewStatsFactory.create({ score: 6 }),
+    ];
+
+    expect(averageOfScores(reviews)).toBe(7);
+  });
+});
+
+describe('averageCodeVolume', () => {
+  it('should return 0 when no review has diff stats', () => {
+    const reviews = [
+      ReviewStatsFactory.create({ diffStats: null }),
+      ReviewStatsFactory.create({ diffStats: undefined }),
+    ];
+
+    expect(averageCodeVolume(reviews)).toBe(0);
+  });
+
+  it('should sum additions and deletions across reviews with diff stats', () => {
+    const reviews = [
+      ReviewStatsFactory.withDiffStats({ commitsCount: 1, additions: 100, deletions: 20 }),
+      ReviewStatsFactory.create({ diffStats: null }),
+      ReviewStatsFactory.withDiffStats({ commitsCount: 1, additions: 30, deletions: 10 }),
+    ];
+
+    expect(averageCodeVolume(reviews)).toBe(80);
+  });
+});
+
+describe('clampLevel', () => {
+  it('should clamp below the minimum to 1', () => {
+    expect(clampLevel(-3)).toBe(1);
+  });
+
+  it('should clamp above the maximum to 10', () => {
+    expect(clampLevel(42)).toBe(10);
+  });
+
+  it('should pass through values inside the range', () => {
+    expect(clampLevel(6)).toBe(6);
+  });
+});
+
+describe('trendToScore', () => {
+  it('should map improving to 0.8', () => {
+    expect(trendToScore('improving')).toBe(0.8);
+  });
+
+  it('should map stable to 0.5', () => {
+    expect(trendToScore('stable')).toBe(0.5);
+  });
+
+  it('should map declining to 0.2', () => {
+    expect(trendToScore('declining')).toBe(0.2);
+  });
+});
+
+describe('invertTrend', () => {
+  it('should invert improving to declining', () => {
+    expect(invertTrend('improving')).toBe('declining');
+  });
+
+  it('should invert declining to improving', () => {
+    expect(invertTrend('declining')).toBe('improving');
+  });
+
+  it('should keep stable unchanged', () => {
+    expect(invertTrend('stable')).toBe('stable');
+  });
+});
+
+describe('computeTrendForMetric', () => {
+  const extractScore = (review: ReviewStats): number => review.score ?? 0;
+
+  function reviewsWithScores(scores: number[]): ReviewStats[] {
+    return scores.map((score, index) =>
+      ReviewStatsFactory.create({
+        id: `r-${index}`,
+        score,
+        timestamp: `2024-01-${String(index + 1).padStart(2, '0')}T10:00:00Z`,
+      }),
+    );
+  }
+
+  it('should return stable when there are fewer reviews than the trend window', () => {
+    const reviews = reviewsWithScores([5, 6, 7]);
+
+    expect(computeTrendForMetric(reviews, extractScore)).toBe('stable');
+  });
+
+  it('should return stable when the previous window is empty', () => {
+    const reviews = reviewsWithScores(new Array(10).fill(5));
+
+    expect(computeTrendForMetric(reviews, extractScore)).toBe('stable');
+  });
+
+  it('should return stable when both windows average exactly 0', () => {
+    const reviews = reviewsWithScores(new Array(15).fill(0));
+
+    expect(computeTrendForMetric(reviews, extractScore)).toBe('stable');
+  });
+
+  it('should return improving when the recent window is clearly higher', () => {
+    const reviews = reviewsWithScores([1, 1, 1, 1, 1, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9]);
+
+    expect(computeTrendForMetric(reviews, extractScore)).toBe('improving');
+  });
+
+  it('should return declining when the recent window is clearly lower', () => {
+    const reviews = reviewsWithScores([9, 9, 9, 9, 9, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]);
+
+    expect(computeTrendForMetric(reviews, extractScore)).toBe('declining');
+  });
+
+  it('should return stable when the change stays within the threshold', () => {
+    const reviews = reviewsWithScores(new Array(15).fill(5));
+
+    expect(computeTrendForMetric(reviews, extractScore)).toBe('stable');
+  });
+});
+
+describe('computeCodeVolumeTrend', () => {
+  function volumeReviews(volumes: number[]): ReviewStats[] {
+    return volumes.map((volume, index) =>
+      ReviewStatsFactory.withDiffStats(
+        { commitsCount: 1, additions: volume, deletions: 0 },
+        { id: `v-${index}`, timestamp: `2024-01-${String(index + 1).padStart(2, '0')}T10:00:00Z` },
+      ),
+    );
+  }
+
+  it('should return stable when there are fewer reviews than the trend window', () => {
+    expect(computeCodeVolumeTrend(volumeReviews([10, 20]))).toBe('stable');
+  });
+
+  it('should return stable when the previous window is empty', () => {
+    expect(computeCodeVolumeTrend(volumeReviews(new Array(10).fill(100)))).toBe('stable');
+  });
+
+  it('should return stable when the previous window volume is 0', () => {
+    const reviews = [
+      ...new Array(5).fill(0).map((_, index) =>
+        ReviewStatsFactory.create({
+          id: `z-${index}`,
+          diffStats: null,
+          timestamp: `2024-01-0${index + 1}T10:00:00Z`,
+        }),
+      ),
+      ...volumeReviews(new Array(10).fill(100)).map((review, index) => ({
+        ...review,
+        timestamp: `2024-01-${String(index + 6).padStart(2, '0')}T10:00:00Z`,
+      })),
+    ];
+
+    expect(computeCodeVolumeTrend(reviews)).toBe('stable');
+  });
+
+  it('should return improving when recent volume grows beyond 15%', () => {
+    const reviews = volumeReviews([
+      100, 100, 100, 100, 100, 300, 300, 300, 300, 300, 300, 300, 300, 300, 300,
+    ]);
+
+    expect(computeCodeVolumeTrend(reviews)).toBe('improving');
+  });
+
+  it('should return declining when recent volume drops beyond 15%', () => {
+    const reviews = volumeReviews([
+      300, 300, 300, 300, 300, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100,
+    ]);
+
+    expect(computeCodeVolumeTrend(reviews)).toBe('declining');
+  });
+
+  it('should return stable when the volume change stays within 15%', () => {
+    const reviews = volumeReviews(new Array(15).fill(100));
+
+    expect(computeCodeVolumeTrend(reviews)).toBe('stable');
+  });
+});
+
+describe('identifyStrengths', () => {
+  it('should include a category whose level meets the strength threshold', () => {
+    const levels = createCategoryLevels({ quality: categoryLevel(8) });
+
+    expect(identifyStrengths(levels)).toContain('quality');
+  });
+
+  it('should include a category improving above the trend threshold even below the level threshold', () => {
+    const levels = createCategoryLevels({
+      responsiveness: categoryLevel(5, 'improving'),
+    });
+
+    expect(identifyStrengths(levels)).toContain('responsiveness');
+  });
+
+  it('should return an empty array when no category qualifies', () => {
+    const levels = createCategoryLevels({
+      quality: categoryLevel(4, 'declining'),
+      responsiveness: categoryLevel(4, 'declining'),
+      codeVolume: categoryLevel(4, 'declining'),
+      iteration: categoryLevel(4, 'declining'),
+    });
+
+    expect(identifyStrengths(levels)).toEqual([]);
+  });
+});
+
+describe('identifyWeaknesses', () => {
+  it('should include a category whose level is at or below the weakness threshold', () => {
+    const levels = createCategoryLevels({ quality: categoryLevel(4) });
+
+    expect(identifyWeaknesses(levels)).toContain('quality');
+  });
+
+  it('should include a declining category below the trend threshold even above the level threshold', () => {
+    const levels = createCategoryLevels({
+      responsiveness: categoryLevel(6, 'declining'),
+    });
+
+    expect(identifyWeaknesses(levels)).toContain('responsiveness');
+  });
+
+  it('should return an empty array when no category qualifies', () => {
+    const levels = createCategoryLevels({
+      quality: categoryLevel(8, 'improving'),
+      responsiveness: categoryLevel(8, 'improving'),
+      codeVolume: categoryLevel(8, 'improving'),
+      iteration: categoryLevel(8, 'improving'),
+    });
+
+    expect(identifyWeaknesses(levels)).toEqual([]);
+  });
+});
+
+describe('identifyTopPriority', () => {
+  it('should return the lowest category when it is at or below 6', () => {
+    const levels = createCategoryLevels({
+      quality: categoryLevel(8),
+      responsiveness: categoryLevel(3),
+      codeVolume: categoryLevel(7),
+      iteration: categoryLevel(9),
+    });
+
+    expect(identifyTopPriority(levels)).toBe('responsiveness');
+  });
+
+  it('should weight a declining category by lowering its priority score', () => {
+    const levels = createCategoryLevels({
+      quality: categoryLevel(5),
+      responsiveness: categoryLevel(6, 'declining'),
+      codeVolume: categoryLevel(7),
+      iteration: categoryLevel(8),
+    });
+
+    expect(identifyTopPriority(levels)).toBe('responsiveness');
+  });
+
+  it('should return null when the lowest category is still above 6', () => {
+    const levels = createCategoryLevels({
+      quality: categoryLevel(7),
+      responsiveness: categoryLevel(8),
+      codeVolume: categoryLevel(9),
+      iteration: categoryLevel(10),
+    });
+
+    expect(identifyTopPriority(levels)).toBeNull();
+  });
+});
+
+describe('computeTitle', () => {
+  it('should return polyvalent when the level spread is within the balanced threshold', () => {
+    const levels = createCategoryLevels({
+      quality: categoryLevel(6),
+      responsiveness: categoryLevel(7),
+      codeVolume: categoryLevel(8),
+      iteration: categoryLevel(6),
+    });
+
+    expect(computeTitle(levels)).toBe('polyvalent');
+  });
+
+  it('should return risingStar when the lowest category is improving', () => {
+    const levels = createCategoryLevels({
+      quality: categoryLevel(9),
+      responsiveness: categoryLevel(8),
+      codeVolume: categoryLevel(2, 'improving'),
+      iteration: categoryLevel(7),
+    });
+
+    expect(computeTitle(levels)).toBe('risingStar');
+  });
+
+  it('should map a dominant quality category to architect', () => {
+    const levels = createCategoryLevels({
+      quality: categoryLevel(10),
+      responsiveness: categoryLevel(4),
+      codeVolume: categoryLevel(3),
+      iteration: categoryLevel(5),
+    });
+
+    expect(computeTitle(levels)).toBe('architect');
+  });
+
+  it('should map a dominant responsiveness category to firefighter', () => {
+    const levels = createCategoryLevels({
+      quality: categoryLevel(4),
+      responsiveness: categoryLevel(10),
+      codeVolume: categoryLevel(3),
+      iteration: categoryLevel(5),
+    });
+
+    expect(computeTitle(levels)).toBe('firefighter');
+  });
+
+  it('should map a dominant codeVolume category to workhorse', () => {
+    const levels = createCategoryLevels({
+      quality: categoryLevel(4),
+      responsiveness: categoryLevel(3),
+      codeVolume: categoryLevel(10),
+      iteration: categoryLevel(5),
+    });
+
+    expect(computeTitle(levels)).toBe('workhorse');
+  });
+
+  it('should map a dominant iteration category to sentinel', () => {
+    const levels = createCategoryLevels({
+      quality: categoryLevel(4),
+      responsiveness: categoryLevel(3),
+      codeVolume: categoryLevel(5),
+      iteration: categoryLevel(10),
+    });
+
+    expect(computeTitle(levels)).toBe('sentinel');
+  });
+});
+
+describe('computeOverallLevel', () => {
+  it('should clamp the rounded average of all category levels', () => {
+    const levels = createCategoryLevels({
+      quality: categoryLevel(8),
+      responsiveness: categoryLevel(7),
+      codeVolume: categoryLevel(6),
+      iteration: categoryLevel(7),
+    });
+
+    expect(computeOverallLevel(levels)).toBe(7);
+  });
+});
+
+describe('computeDeveloperMetrics', () => {
+  it('should report zero code volume and zero correlation when no diff stats exist', () => {
+    const reviews = [
+      ReviewStatsFactory.create({ diffStats: null }),
+      ReviewStatsFactory.create({ diffStats: undefined }),
+    ];
+
+    const metrics = computeDeveloperMetrics(reviews);
+
+    expect(metrics.averageCodeVolume).toBe(0);
+    expect(metrics.codeVolumeScoreCorrelation).toBe(0);
+  });
+
+  it('should return zero correlation with fewer than three scored reviews carrying diff stats', () => {
+    const reviews = [
+      ReviewStatsFactory.withDiffStats({ commitsCount: 1, additions: 50, deletions: 10 }, { score: 8 }),
+      ReviewStatsFactory.withDiffStats({ commitsCount: 1, additions: 30, deletions: 5 }, { score: 6 }),
+    ];
+
+    expect(computeDeveloperMetrics(reviews).codeVolumeScoreCorrelation).toBe(0);
+  });
+
+  it('should return zero correlation when volume has no variance', () => {
+    const reviews = new Array(4).fill(0).map((_, index) =>
+      ReviewStatsFactory.withDiffStats(
+        { commitsCount: 1, additions: 100, deletions: 0 },
+        { id: `c-${index}`, score: index + 1 },
+      ),
+    );
+
+    expect(computeDeveloperMetrics(reviews).codeVolumeScoreCorrelation).toBe(0);
+  });
+
+  it('should compute a positive correlation when score grows with volume', () => {
+    const reviews = [
+      ReviewStatsFactory.withDiffStats({ commitsCount: 1, additions: 10, deletions: 0 }, { id: 'p-1', score: 2 }),
+      ReviewStatsFactory.withDiffStats({ commitsCount: 1, additions: 50, deletions: 0 }, { id: 'p-2', score: 5 }),
+      ReviewStatsFactory.withDiffStats({ commitsCount: 1, additions: 100, deletions: 0 }, { id: 'p-3', score: 9 }),
+    ];
+
+    expect(computeDeveloperMetrics(reviews).codeVolumeScoreCorrelation).toBeGreaterThan(0);
+  });
+});
+
+describe('computeTeamMetrics', () => {
+  it('should aggregate reviews across all developers', () => {
+    const reviewsByDeveloper = new Map<string, ReviewStats[]>();
+    reviewsByDeveloper.set('alice', [
+      ReviewStatsFactory.create({ id: 'a-1', score: 8, blocking: 0, warnings: 1 }),
+    ]);
+    reviewsByDeveloper.set('bob', [
+      ReviewStatsFactory.create({ id: 'b-1', score: 6, blocking: 2, warnings: 3 }),
+    ]);
+
+    const metrics = computeTeamMetrics(reviewsByDeveloper);
+
+    expect(metrics.averageScore).toBe(7);
+    expect(metrics.averageBlocking).toBe(1);
+    expect(metrics.averageWarnings).toBe(2);
+  });
+
+  it('should fall back to neutral score and zero volume for an empty team', () => {
+    const metrics = computeTeamMetrics(new Map<string, ReviewStats[]>());
+
+    expect(metrics.averageScore).toBe(5);
+    expect(metrics.averageCodeVolume).toBe(0);
+  });
+});
+
+describe('computeCategoryLevels code volume and iteration branches', () => {
+  it('should use the neutral volume score when the team code volume is 0', () => {
+    const reviews = [ReviewStatsFactory.create({ diffStats: null })];
+    const metrics = computeDeveloperMetrics(reviews);
+    const teamMetrics = computeTeamMetrics(new Map([['solo', reviews]]));
+
+    const levels = computeCategoryLevels(reviews, metrics, teamMetrics);
+
+    expect(levels.codeVolume.level).toBeGreaterThanOrEqual(1);
+    expect(levels.codeVolume.level).toBeLessThanOrEqual(10);
+  });
+
+  it('should use the neutral suggestion fallback when reviews carry no suggestions', () => {
+    const reviews = [
+      ReviewStatsFactory.create({ id: 'it-1', suggestions: undefined, blocking: 0, warnings: 0 }),
+      ReviewStatsFactory.create({ id: 'it-2', suggestions: undefined, blocking: 0, warnings: 0 }),
+    ];
+    const metrics = computeDeveloperMetrics(reviews);
+    const teamMetrics = computeTeamMetrics(new Map([['solo', reviews]]));
+
+    const levels = computeCategoryLevels(reviews, metrics, teamMetrics);
+
+    expect(levels.iteration.level).toBeGreaterThanOrEqual(1);
+    expect(levels.iteration.level).toBeLessThanOrEqual(10);
+  });
+
+  it('should fall back to neutral iteration scores for an empty review set', () => {
+    const metrics = computeDeveloperMetrics([]);
+    const teamMetrics = computeTeamMetrics(new Map<string, ReviewStats[]>());
+
+    const levels = computeCategoryLevels([], metrics, teamMetrics);
+
+    expect(levels.iteration.level).toBeGreaterThanOrEqual(1);
+    expect(levels.iteration.level).toBeLessThanOrEqual(10);
+  });
+
+  it('should reward a positive code volume correlation', () => {
+    const reviews = [
+      ReviewStatsFactory.withDiffStats({ commitsCount: 1, additions: 10, deletions: 0 }, { id: 'cv-1', score: 2 }),
+      ReviewStatsFactory.withDiffStats({ commitsCount: 1, additions: 50, deletions: 0 }, { id: 'cv-2', score: 5 }),
+      ReviewStatsFactory.withDiffStats({ commitsCount: 1, additions: 100, deletions: 0 }, { id: 'cv-3', score: 9 }),
+    ];
+    const metrics = computeDeveloperMetrics(reviews);
+    const teamMetrics = computeTeamMetrics(new Map([['solo', reviews]]));
+
+    const levels = computeCategoryLevels(reviews, metrics, teamMetrics);
+
+    expect(levels.codeVolume.level).toBeGreaterThanOrEqual(1);
+    expect(metrics.codeVolumeScoreCorrelation).toBeGreaterThan(0);
   });
 });

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "_comment": "PILOT scope: statistics-insights module only. Run locally on demand (yarn test:mutation). NOT wired into CI / yarn verify — mutation testing is slow and costly.",
+  "packageManager": "yarn",
+  "testRunner": "vitest",
+  "vitest": {
+    "configFile": "vitest.config.ts"
+  },
+  "coverageAnalysis": "perTest",
+  "mutate": [
+    "src/modules/statistics-insights/**/*.ts",
+    "!src/modules/statistics-insights/**/*.schema.ts",
+    "!src/modules/statistics-insights/**/*.gateway.ts",
+    "!src/**/*.d.ts"
+  ],
+  "reporters": ["html", "clear-text", "progress"],
+  "htmlReporter": {
+    "fileName": "reports/mutation/insights.html"
+  },
+  "thresholds": {
+    "high": 80,
+    "low": 60,
+    "break": null
+  },
+  "concurrency": 4,
+  "tempDirName": ".stryker-tmp",
+  "cleanTempDir": true
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,6 +24,12 @@ export default defineConfig({
         'src/dashboard/**',
         'src/**/*.d.ts',
       ],
+      thresholds: {
+        statements: 80,
+        branches: 80,
+        functions: 80,
+        lines: 80,
+      },
     },
   },
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -155,15 +155,174 @@
   dependencies:
     "@algolia/client-common" "5.48.1"
 
+"@babel/code-frame@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
+  integrity sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.29.7"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
+
+"@babel/compat-data@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.29.7.tgz#6f0237f0f36d2e51c0570a636faed9d2d0efe629"
+  integrity sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==
+
+"@babel/core@~7.29.0":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.29.7.tgz#80c10b17248082968b57a857b91640971f2070f7"
+  integrity sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/generator" "^7.29.7"
+    "@babel/helper-compilation-targets" "^7.29.7"
+    "@babel/helper-module-transforms" "^7.29.7"
+    "@babel/helpers" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/template" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
+    "@jridgewell/remapping" "^2.3.5"
+    convert-source-map "^2.0.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.3"
+    semver "^6.3.1"
+
+"@babel/generator@^7.29.7", "@babel/generator@~7.29.0":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.29.7.tgz#cca0b8827e6bcf3ba176788e7f3b180ad6db2fa3"
+  integrity sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==
+  dependencies:
+    "@babel/parser" "^7.29.7"
+    "@babel/types" "^7.29.7"
+    "@jridgewell/gen-mapping" "^0.3.12"
+    "@jridgewell/trace-mapping" "^0.3.28"
+    jsesc "^3.0.2"
+
+"@babel/helper-annotate-as-pure@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz#c70fe3c6ecbdc3fd2dd1b0f498428b88b82ce47f"
+  integrity sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==
+  dependencies:
+    "@babel/types" "^7.29.7"
+
+"@babel/helper-compilation-targets@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz#7a1def704302401c47f64fa85589e974ae217042"
+  integrity sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==
+  dependencies:
+    "@babel/compat-data" "^7.29.7"
+    "@babel/helper-validator-option" "^7.29.7"
+    browserslist "^4.24.0"
+    lru-cache "^5.1.1"
+    semver "^6.3.1"
+
+"@babel/helper-create-class-features-plugin@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz#6eddf286f2ec418f740c91d60a83347c55838ddd"
+  integrity sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.29.7"
+    "@babel/helper-member-expression-to-functions" "^7.29.7"
+    "@babel/helper-optimise-call-expression" "^7.29.7"
+    "@babel/helper-replace-supers" "^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+    semver "^6.3.1"
+
+"@babel/helper-globals@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-7.29.7.tgz#f04a96fbd8473241b1079243f5b3f03a3010ab7b"
+  integrity sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==
+
+"@babel/helper-member-expression-to-functions@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz#8dbdb3ce0b5c487e1aec10e13c9a43a500814df8"
+  integrity sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==
+  dependencies:
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
+"@babel/helper-module-imports@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz#ef25048a518e828d7393fac5882ddd73921d7396"
+  integrity sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==
+  dependencies:
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
+"@babel/helper-module-transforms@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz#b062747a5997ba138637201328bbff77960574ae"
+  integrity sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+
+"@babel/helper-optimise-call-expression@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz#77b0b5b94f1997fa9d6e3125f445227b1faf9d85"
+  integrity sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==
+  dependencies:
+    "@babel/types" "^7.29.7"
+
+"@babel/helper-plugin-utils@^7.27.1", "@babel/helper-plugin-utils@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz#c0a0766f1a13617d8a17407d7ab8f9d486225ea4"
+  integrity sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==
+
+"@babel/helper-replace-supers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz#bc3c3964329043c79112e513c1b198f16589ac21"
+  integrity sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.29.7"
+    "@babel/helper-optimise-call-expression" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+
+"@babel/helper-skip-transparent-expression-wrappers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz#50c95c7e4c4f54936cfa0116428edc559862d551"
+  integrity sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==
+  dependencies:
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
 "@babel/helper-string-parser@^7.27.1":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz"
   integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
 
+"@babel/helper-string-parser@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz#7f0871d99824d23137d60f86fcf6130fd5a1b51f"
+  integrity sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==
+
 "@babel/helper-validator-identifier@^7.28.5":
   version "7.28.5"
   resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz"
   integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
+
+"@babel/helper-validator-identifier@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz#bd87084ced0c796ec46bda492de6e83d29e89fc2"
+  integrity sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==
+
+"@babel/helper-validator-option@^7.27.1", "@babel/helper-validator-option@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz#cf315be940213b354eb4abcc0bd01ebe3f73bc2a"
+  integrity sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==
+
+"@babel/helpers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.29.7.tgz#45abfde7548997e34376c3e69feb475cffb4a607"
+  integrity sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==
+  dependencies:
+    "@babel/template" "^7.29.7"
+    "@babel/types" "^7.29.7"
 
 "@babel/parser@^7.28.5", "@babel/parser@^7.29.0":
   version "7.29.0"
@@ -172,6 +331,111 @@
   dependencies:
     "@babel/types" "^7.29.0"
 
+"@babel/parser@^7.29.7", "@babel/parser@~7.29.0":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.7.tgz#837b87387cbf5ec5530cb634b3c622f68edb9334"
+  integrity sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==
+  dependencies:
+    "@babel/types" "^7.29.7"
+
+"@babel/plugin-proposal-decorators@~7.29.0":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.7.tgz#ebc57bd4d711df920a553de8a456a3a020ce0d72"
+  integrity sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/plugin-syntax-decorators" "^7.29.7"
+
+"@babel/plugin-syntax-decorators@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.29.7.tgz#9a23ab91fb8e61d142684108bca6f343ceee88f6"
+  integrity sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-syntax-jsx@^7.27.1":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz#622c16f9ad63782fe6e83dadc7e40330744b7f1e"
+  integrity sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-syntax-typescript@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz#7c29388932313ed58413a0343048d75d92fb5b24"
+  integrity sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-destructuring@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.29.7.tgz#5781ec6947852e27b64c1165f0db431f408090e4"
+  integrity sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+
+"@babel/plugin-transform-explicit-resource-management@^7.28.0":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.29.7.tgz#65c8b9f76ec915b02a0e1df703125a0fca58abaa"
+  integrity sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/plugin-transform-destructuring" "^7.29.7"
+
+"@babel/plugin-transform-modules-commonjs@^7.27.1":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz#70e6835abf2663dafbe94b8ef1f51de7351ef135"
+  integrity sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-typescript@^7.28.5":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz#f0449c3df7037bbe232043476851c38f5e4a7615"
+  integrity sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.29.7"
+    "@babel/helper-create-class-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.29.7"
+    "@babel/plugin-syntax-typescript" "^7.29.7"
+
+"@babel/preset-typescript@~7.28.0":
+  version "7.28.5"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz#540359efa3028236958466342967522fd8f2a60c"
+  integrity sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-validator-option" "^7.27.1"
+    "@babel/plugin-syntax-jsx" "^7.27.1"
+    "@babel/plugin-transform-modules-commonjs" "^7.27.1"
+    "@babel/plugin-transform-typescript" "^7.28.5"
+
+"@babel/template@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.29.7.tgz#4d9d4004f645cdd304de958c725162784ecac700"
+  integrity sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
+"@babel/traverse@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.29.7.tgz#c47b07a41b95da0907d026b5dd894d98de7d2f2d"
+  integrity sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/generator" "^7.29.7"
+    "@babel/helper-globals" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/template" "^7.29.7"
+    "@babel/types" "^7.29.7"
+    debug "^4.3.1"
+
 "@babel/types@^7.28.5", "@babel/types@^7.29.0":
   version "7.29.0"
   resolved "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz"
@@ -179,6 +443,14 @@
   dependencies:
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
+
+"@babel/types@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.7.tgz#8005e31d82712ee7adaef6e23c63b71a62770a92"
+  integrity sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==
+  dependencies:
+    "@babel/helper-string-parser" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
 
 "@bcoe/v8-coverage@^1.0.2":
   version "1.0.2"
@@ -607,6 +879,11 @@
   resolved "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.3.tgz"
   integrity sha512-g44zhR3NIKVs0zUesa4iMzExmZpLUdTLRMCStqX3GE5NT6VkPcxQGJ+uC8tDgBUC/vB1rUhUd55cOf++4NZcmw==
 
+"@inquirer/ansi@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@inquirer/ansi/-/ansi-2.0.7.tgz#86de22810cac3ed406ec10f8d66016815b8226b4"
+  integrity sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==
+
 "@inquirer/checkbox@^5.0.4":
   version "5.0.4"
   resolved "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.0.4.tgz"
@@ -617,6 +894,16 @@
     "@inquirer/figures" "^2.0.3"
     "@inquirer/type" "^4.0.3"
 
+"@inquirer/checkbox@^5.2.1":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@inquirer/checkbox/-/checkbox-5.2.1.tgz#7f148b3153a776cee202015b10f9a985068d188d"
+  integrity sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==
+  dependencies:
+    "@inquirer/ansi" "^2.0.7"
+    "@inquirer/core" "^11.2.1"
+    "@inquirer/figures" "^2.0.7"
+    "@inquirer/type" "^4.0.7"
+
 "@inquirer/confirm@^6.0.4":
   version "6.0.4"
   resolved "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.4.tgz"
@@ -624,6 +911,14 @@
   dependencies:
     "@inquirer/core" "^11.1.1"
     "@inquirer/type" "^4.0.3"
+
+"@inquirer/confirm@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@inquirer/confirm/-/confirm-6.1.1.tgz#9c6a7d79c6132b2af57fdb75747f056204e55356"
+  integrity sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==
+  dependencies:
+    "@inquirer/core" "^11.2.1"
+    "@inquirer/type" "^4.0.7"
 
 "@inquirer/core@^11.1.1":
   version "11.1.1"
@@ -638,6 +933,19 @@
     signal-exit "^4.1.0"
     wrap-ansi "^9.0.2"
 
+"@inquirer/core@^11.2.1":
+  version "11.2.1"
+  resolved "https://registry.yarnpkg.com/@inquirer/core/-/core-11.2.1.tgz#54ccd8f7d47852140b6066cbd77d63b2c2b168fd"
+  integrity sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==
+  dependencies:
+    "@inquirer/ansi" "^2.0.7"
+    "@inquirer/figures" "^2.0.7"
+    "@inquirer/type" "^4.0.7"
+    cli-width "^4.1.0"
+    fast-wrap-ansi "^0.2.0"
+    mute-stream "^3.0.0"
+    signal-exit "^4.1.0"
+
 "@inquirer/editor@^5.0.4":
   version "5.0.4"
   resolved "https://registry.npmjs.org/@inquirer/editor/-/editor-5.0.4.tgz"
@@ -647,6 +955,15 @@
     "@inquirer/external-editor" "^2.0.3"
     "@inquirer/type" "^4.0.3"
 
+"@inquirer/editor@^5.2.1":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@inquirer/editor/-/editor-5.2.1.tgz#28fdf504efd73dc29268fb4a47e7d36ad8049b24"
+  integrity sha512-NFLxWmTPc2WORINoffcbVwB2+tujeNZ6Cu50HbXvTbk0fHSmhA5PgCckxXuyUniQvX7bhxkZi0nODfJIGsnCdA==
+  dependencies:
+    "@inquirer/core" "^11.2.1"
+    "@inquirer/external-editor" "^3.0.2"
+    "@inquirer/type" "^4.0.7"
+
 "@inquirer/expand@^5.0.4":
   version "5.0.4"
   resolved "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.4.tgz"
@@ -654,6 +971,14 @@
   dependencies:
     "@inquirer/core" "^11.1.1"
     "@inquirer/type" "^4.0.3"
+
+"@inquirer/expand@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@inquirer/expand/-/expand-5.1.1.tgz#e2afeac247d97dd64ee18aa81e902bdd1fe0ea70"
+  integrity sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==
+  dependencies:
+    "@inquirer/core" "^11.2.1"
+    "@inquirer/type" "^4.0.7"
 
 "@inquirer/external-editor@^2.0.3":
   version "2.0.3"
@@ -663,10 +988,23 @@
     chardet "^2.1.1"
     iconv-lite "^0.7.2"
 
+"@inquirer/external-editor@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@inquirer/external-editor/-/external-editor-3.0.2.tgz#f072164f073a60cfebeef21a7b763b39793b9c56"
+  integrity sha512-1X+KN2PinUcy/aS3f3OBSKJaWk+jBikMry4Qblj5ysqN4T+8BeA1rNJdTSOlQ2iOmvKg7ZsR4tDQvl1p0PLgKg==
+  dependencies:
+    chardet "^2.1.1"
+    iconv-lite "^0.7.2"
+
 "@inquirer/figures@^2.0.3":
   version "2.0.3"
   resolved "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.3.tgz"
   integrity sha512-y09iGt3JKoOCBQ3w4YrSJdokcD8ciSlMIWsD+auPu+OZpfxLuyz+gICAQ6GCBOmJJt4KEQGHuZSVff2jiNOy7g==
+
+"@inquirer/figures@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@inquirer/figures/-/figures-2.0.7.tgz#f5cc5843732a81304d06a0db4b53cc7dbda15541"
+  integrity sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==
 
 "@inquirer/input@^5.0.4":
   version "5.0.4"
@@ -676,6 +1014,14 @@
     "@inquirer/core" "^11.1.1"
     "@inquirer/type" "^4.0.3"
 
+"@inquirer/input@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@inquirer/input/-/input-5.1.1.tgz#0f3a60c1550a6608843fd0cf4b8036a19034435b"
+  integrity sha512-3wuHoDBBtU+o0TB4uP2R+ACdNrn6SgdZBc1YUaiU9GcfXNaTNUgSM/Ft7eQ3gYWP2H1MiT6glycmfWYpmPzVKw==
+  dependencies:
+    "@inquirer/core" "^11.2.1"
+    "@inquirer/type" "^4.0.7"
+
 "@inquirer/number@^4.0.4":
   version "4.0.4"
   resolved "https://registry.npmjs.org/@inquirer/number/-/number-4.0.4.tgz"
@@ -683,6 +1029,14 @@
   dependencies:
     "@inquirer/core" "^11.1.1"
     "@inquirer/type" "^4.0.3"
+
+"@inquirer/number@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@inquirer/number/-/number-4.1.1.tgz#b133668d8e0e099b4133abb915221501e0ff75d7"
+  integrity sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==
+  dependencies:
+    "@inquirer/core" "^11.2.1"
+    "@inquirer/type" "^4.0.7"
 
 "@inquirer/password@^5.0.4":
   version "5.0.4"
@@ -692,6 +1046,31 @@
     "@inquirer/ansi" "^2.0.3"
     "@inquirer/core" "^11.1.1"
     "@inquirer/type" "^4.0.3"
+
+"@inquirer/password@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@inquirer/password/-/password-5.1.1.tgz#f21efb614da9c905095262f51781fd2a721fceac"
+  integrity sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==
+  dependencies:
+    "@inquirer/ansi" "^2.0.7"
+    "@inquirer/core" "^11.2.1"
+    "@inquirer/type" "^4.0.7"
+
+"@inquirer/prompts@^8.0.0":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@inquirer/prompts/-/prompts-8.5.1.tgz#c7c6bda06640b15ee27da0131e20f18ce7d1a4fd"
+  integrity sha512-EwbBgs5e3a5MwQglQ736lx0UY/bbirddCbwe32AJMzQVSeAQK1jmwtDu8lwG9Izp+cdPhZ9NvuEt8aFmav6iLw==
+  dependencies:
+    "@inquirer/checkbox" "^5.2.1"
+    "@inquirer/confirm" "^6.1.1"
+    "@inquirer/editor" "^5.2.1"
+    "@inquirer/expand" "^5.1.1"
+    "@inquirer/input" "^5.1.1"
+    "@inquirer/number" "^4.1.1"
+    "@inquirer/password" "^5.1.1"
+    "@inquirer/rawlist" "^5.3.1"
+    "@inquirer/search" "^4.2.1"
+    "@inquirer/select" "^5.2.1"
 
 "@inquirer/prompts@^8.2.0":
   version "8.2.0"
@@ -717,6 +1096,14 @@
     "@inquirer/core" "^11.1.1"
     "@inquirer/type" "^4.0.3"
 
+"@inquirer/rawlist@^5.3.1":
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/@inquirer/rawlist/-/rawlist-5.3.1.tgz#66f6b8e6aa82d47399c433b8262128e7c1a4f9ce"
+  integrity sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==
+  dependencies:
+    "@inquirer/core" "^11.2.1"
+    "@inquirer/type" "^4.0.7"
+
 "@inquirer/search@^4.1.0":
   version "4.1.0"
   resolved "https://registry.npmjs.org/@inquirer/search/-/search-4.1.0.tgz"
@@ -725,6 +1112,15 @@
     "@inquirer/core" "^11.1.1"
     "@inquirer/figures" "^2.0.3"
     "@inquirer/type" "^4.0.3"
+
+"@inquirer/search@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@inquirer/search/-/search-4.2.1.tgz#c8f4b78ab3f866fdf0503fac0cd08c4a6661c11e"
+  integrity sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==
+  dependencies:
+    "@inquirer/core" "^11.2.1"
+    "@inquirer/figures" "^2.0.7"
+    "@inquirer/type" "^4.0.7"
 
 "@inquirer/select@^5.0.4":
   version "5.0.4"
@@ -736,22 +1132,53 @@
     "@inquirer/figures" "^2.0.3"
     "@inquirer/type" "^4.0.3"
 
+"@inquirer/select@^5.2.1":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@inquirer/select/-/select-5.2.1.tgz#3a05e76e58d9e1bb095e912c3e7093aa04cd4604"
+  integrity sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==
+  dependencies:
+    "@inquirer/ansi" "^2.0.7"
+    "@inquirer/core" "^11.2.1"
+    "@inquirer/figures" "^2.0.7"
+    "@inquirer/type" "^4.0.7"
+
 "@inquirer/type@^4.0.3":
   version "4.0.3"
   resolved "https://registry.npmjs.org/@inquirer/type/-/type-4.0.3.tgz"
   integrity sha512-cKZN7qcXOpj1h+1eTTcGDVLaBIHNMT1Rz9JqJP5MnEJ0JhgVWllx7H/tahUp5YEK1qaByH2Itb8wLG/iScD5kw==
+
+"@inquirer/type@^4.0.7":
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/@inquirer/type/-/type-4.0.7.tgz#9c6f0d857fe6ad549a3a932343b64e76acb34b10"
+  integrity sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==
+
+"@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
+  version "0.3.13"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
+  integrity sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.0"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
+"@jridgewell/remapping@^2.3.5":
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/remapping/-/remapping-2.3.5.tgz#375c476d1972947851ba1e15ae8f123047445aa1"
+  integrity sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.24"
 
 "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.2"
   resolved "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz"
   integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
 
-"@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.5":
+"@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0", "@jridgewell/sourcemap-codec@^1.5.5":
   version "1.5.5"
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
-"@jridgewell/trace-mapping@^0.3.31":
+"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.28", "@jridgewell/trace-mapping@^0.3.31":
   version "0.3.31"
   resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz"
   integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
@@ -943,6 +1370,11 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz#4584a8a87b29188a4c1fe987a9fcf701e256d86c"
   integrity sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==
 
+"@sec-ant/readable-stream@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz#60de891bb126abfdc5410fdc6166aca065f10a0c"
+  integrity sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==
+
 "@shikijs/core@2.5.0", "@shikijs/core@^2.1.0":
   version "2.5.0"
   resolved "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz"
@@ -1007,10 +1439,90 @@
   resolved "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz"
   integrity sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==
 
+"@sindresorhus/merge-streams@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz#abb11d99aeb6d27f1b563c38147a72d50058e339"
+  integrity sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==
+
 "@standard-schema/spec@^1.0.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz"
   integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
+
+"@stryker-mutator/api@9.6.1":
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/@stryker-mutator/api/-/api-9.6.1.tgz#df8072cb268a6fd8dec2994cc64b477978fa3d69"
+  integrity sha512-g8VNoFWQWbx0pdal3Vt8jVCZW+v3sc3gi94iI0GVtVgUGTqphAjJF6EAruPTx0lqvtonsaAxn5TD36hcG1d6Wg==
+  dependencies:
+    mutation-testing-metrics "3.7.3"
+    mutation-testing-report-schema "3.7.3"
+    tslib "~2.8.0"
+    typed-inject "~5.0.0"
+
+"@stryker-mutator/core@^9.6.1":
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/@stryker-mutator/core/-/core-9.6.1.tgz#c149d80754b9fc73c11f6282ec199af24be535f4"
+  integrity sha512-WMgnvf+Wyh/yiruhNZwc8w8DlzmmjXhPjSn5MR8RhAXzlnWji8TQrUYgBUkHk9bEgSaIlB3KZHm37iiU5Q2cLQ==
+  dependencies:
+    "@inquirer/prompts" "^8.0.0"
+    "@stryker-mutator/api" "9.6.1"
+    "@stryker-mutator/instrumenter" "9.6.1"
+    "@stryker-mutator/util" "9.6.1"
+    ajv "~8.18.0"
+    chalk "~5.6.0"
+    commander "~14.0.0"
+    diff-match-patch "1.0.5"
+    emoji-regex "~10.6.0"
+    execa "~9.6.0"
+    json-rpc-2.0 "^1.7.0"
+    lodash.groupby "~4.6.0"
+    minimatch "~10.2.4"
+    mutation-server-protocol "~0.4.0"
+    mutation-testing-elements "3.7.3"
+    mutation-testing-metrics "3.7.3"
+    mutation-testing-report-schema "3.7.3"
+    npm-run-path "~6.0.0"
+    progress "~2.0.3"
+    rxjs "~7.8.1"
+    semver "^7.6.3"
+    source-map "~0.7.4"
+    tree-kill "~1.2.2"
+    tslib "2.8.1"
+    typed-inject "~5.0.0"
+    typed-rest-client "~2.3.0"
+
+"@stryker-mutator/instrumenter@9.6.1":
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/@stryker-mutator/instrumenter/-/instrumenter-9.6.1.tgz#97e0e03da440712fac29a52c82f5cc0945183480"
+  integrity sha512-5K8wH4Pthly25c2uKKik4Dfcoeou7sbJdFS6u3QIYHlulgFVDJwtEMWTZGkZfs7IiUEXIDNa0keRACq5jn5AvA==
+  dependencies:
+    "@babel/core" "~7.29.0"
+    "@babel/generator" "~7.29.0"
+    "@babel/parser" "~7.29.0"
+    "@babel/plugin-proposal-decorators" "~7.29.0"
+    "@babel/plugin-transform-explicit-resource-management" "^7.28.0"
+    "@babel/preset-typescript" "~7.28.0"
+    "@stryker-mutator/api" "9.6.1"
+    "@stryker-mutator/util" "9.6.1"
+    angular-html-parser "~10.4.0"
+    semver "~7.7.0"
+    tslib "2.8.1"
+    weapon-regex "~1.3.2"
+
+"@stryker-mutator/util@9.6.1":
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/@stryker-mutator/util/-/util-9.6.1.tgz#f4ce5cb3a5379002c56b742b70dfdc96d392acc0"
+  integrity sha512-Lk/ALVctJjFv1vvwR+CFoKzDCWvsBlq7flDUnmnpuwTrGbm156EdZD1Jjq4o8KdOap0ezUZqQNE9OAI1m2+pUQ==
+
+"@stryker-mutator/vitest-runner@^9.6.1":
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/@stryker-mutator/vitest-runner/-/vitest-runner-9.6.1.tgz#61e5fb7e539ad209e5f51e34f6f5b1bb13c21750"
+  integrity sha512-eyUHTCf3Ui+SUn/tpFJwzw6MV391kyBLZk/cDHFUfKFELqKMLbvd7e81axArlApKqO6cOnLfrxlwED+2SRN0ow==
+  dependencies:
+    "@stryker-mutator/api" "9.6.1"
+    "@stryker-mutator/util" "9.6.1"
+    semver "^7.7.4"
+    tslib "~2.8.0"
 
 "@types/chai@^5.2.2":
   version "5.2.3"
@@ -1348,7 +1860,7 @@ ajv-formats@^3.0.1:
   dependencies:
     ajv "^8.0.0"
 
-ajv@^8.0.0, ajv@^8.12.0, ajv@^8.17.1:
+ajv@^8.0.0, ajv@^8.12.0, ajv@^8.17.1, ajv@~8.18.0:
   version "8.18.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.18.0.tgz#8864186b6738d003eb3a933172bb3833e10cefbc"
   integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
@@ -1377,6 +1889,11 @@ algoliasearch@^5.14.2:
     "@algolia/requester-browser-xhr" "5.48.1"
     "@algolia/requester-fetch" "5.48.1"
     "@algolia/requester-node-http" "5.48.1"
+
+angular-html-parser@~10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/angular-html-parser/-/angular-html-parser-10.4.0.tgz#1f22bc19b466a4411b5dcaa6c0e508fe553e2306"
+  integrity sha512-++nLNyZwRfHqFh7akH5Gw/JYizoFlMRz0KRigfwfsLqV8ZqlcVRb1LkPEWdYvEKDnbktknM2J4BXaYUGrQZPww==
 
 animejs@^4:
   version "4.4.1"
@@ -1443,6 +1960,11 @@ base64-js@^1.3.1:
   resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
+baseline-browser-mapping@^2.10.12:
+  version "2.10.33"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz#27c299b096404978831958d429f48390424c4f9b"
+  integrity sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==
+
 binary-extensions@^2.0.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz"
@@ -1482,6 +2004,17 @@ braces@^3.0.3, braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
+browserslist@^4.24.0:
+  version "4.28.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.2.tgz#f50b65362ef48974ca9f50b3680566d786b811d2"
+  integrity sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==
+  dependencies:
+    baseline-browser-mapping "^2.10.12"
+    caniuse-lite "^1.0.30001782"
+    electron-to-chromium "^1.5.328"
+    node-releases "^2.0.36"
+    update-browserslist-db "^1.2.3"
+
 buffer@^6.0.3:
   version "6.0.3"
   resolved "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz"
@@ -1511,6 +2044,11 @@ call-bound@^1.0.2:
     call-bind-apply-helpers "^1.0.2"
     get-intrinsic "^1.3.0"
 
+caniuse-lite@^1.0.30001782:
+  version "1.0.30001793"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz#238887ddf5fcfc8c36d872394d0a78a517312a72"
+  integrity sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==
+
 ccount@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz"
@@ -1520,6 +2058,11 @@ chai@^6.2.1:
   version "6.2.2"
   resolved "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz"
   integrity sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==
+
+chalk@~5.6.0:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.6.2.tgz#b1238b6e23ea337af71c7f8a295db5af0c158aea"
+  integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
 
 character-entities-html4@^2.0.0:
   version "2.1.0"
@@ -1571,6 +2114,11 @@ commander@^9.0.0:
   resolved "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz"
   integrity sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==
 
+commander@~14.0.0:
+  version "14.0.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-14.0.3.tgz#425d79b48f9af82fcd9e4fc1ea8af6c5ec07bbc2"
+  integrity sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==
+
 content-disposition@^1.0.0, content-disposition@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-1.1.0.tgz#f3db789c752d45564cc7e9e1e0b31790d4a38e17"
@@ -1580,6 +2128,11 @@ content-type@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz"
   integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
+
+convert-source-map@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
+  integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
 cookie-signature@^1.2.1:
   version "1.2.2"
@@ -1611,7 +2164,7 @@ cors@^2.8.5:
     object-assign "^4"
     vary "^1"
 
-cross-spawn@^7.0.5:
+cross-spawn@^7.0.5, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -1630,7 +2183,7 @@ dateformat@^4.6.3:
   resolved "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz"
   integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==
 
-debug@^4.4.0, debug@^4.4.3:
+debug@^4.1.0, debug@^4.3.1, debug@^4.4.0, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -1647,12 +2200,25 @@ dequal@^2.0.0, dequal@^2.0.3:
   resolved "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
 
+des.js@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.1.0.tgz#1d37f5766f3bbff4ee9638e871a8768c173b81da"
+  integrity sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==
+  dependencies:
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+
 devlop@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz"
   integrity sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==
   dependencies:
     dequal "^2.0.0"
+
+diff-match-patch@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.5.tgz#abb584d5f10cd1196dfc55aa03701592ae3f7b37"
+  integrity sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -1690,12 +2256,17 @@ ee-first@1.1.1:
   resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
+electron-to-chromium@^1.5.328:
+  version "1.5.364"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.364.tgz#38af950b724b22b937c342c0c4b361bd2fb50669"
+  integrity sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==
+
 emoji-regex-xs@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz"
   integrity sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==
 
-emoji-regex@^10.3.0:
+emoji-regex@^10.3.0, emoji-regex@~10.6.0:
   version "10.6.0"
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz"
   integrity sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==
@@ -1800,6 +2371,11 @@ esbuild@^0.27.0, esbuild@~0.27.0:
     "@esbuild/win32-ia32" "0.27.2"
     "@esbuild/win32-x64" "0.27.2"
 
+escalade@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
+  integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
+
 escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
@@ -1848,6 +2424,24 @@ eventsource@^3.0.2:
   integrity sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==
   dependencies:
     eventsource-parser "^3.0.1"
+
+execa@~9.6.0:
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-9.6.1.tgz#5b90acedc6bdc0fa9b9a6ddf8f9cbb0c75a7c471"
+  integrity sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==
+  dependencies:
+    "@sindresorhus/merge-streams" "^4.0.0"
+    cross-spawn "^7.0.6"
+    figures "^6.1.0"
+    get-stream "^9.0.0"
+    human-signals "^8.0.1"
+    is-plain-obj "^4.1.0"
+    is-stream "^4.0.1"
+    npm-run-path "^6.0.0"
+    pretty-ms "^9.2.0"
+    signal-exit "^4.1.0"
+    strip-final-newline "^4.0.0"
+    yoctocolors "^2.1.1"
 
 expect-type@^1.2.2:
   version "1.3.0"
@@ -1950,10 +2544,29 @@ fast-safe-stringify@^2.1.1:
   resolved "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
+fast-string-truncated-width@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz#23afe0da67d752ca0727538f1e6967759728ce49"
+  integrity sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==
+
+fast-string-width@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/fast-string-width/-/fast-string-width-3.0.2.tgz#16dbabb491ce5585b5ecb675b65c165d71688eeb"
+  integrity sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==
+  dependencies:
+    fast-string-truncated-width "^3.0.2"
+
 fast-uri@^3.0.0, fast-uri@^3.0.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
   integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
+
+fast-wrap-ansi@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz#95e952a0145bce3f59ad56e179f84c48d4072935"
+  integrity sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==
+  dependencies:
+    fast-string-width "^3.0.2"
 
 fastify-plugin@^5.0.0:
   version "5.1.0"
@@ -1997,6 +2610,13 @@ fflate@^0.8.2:
   version "0.8.2"
   resolved "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz"
   integrity sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==
+
+figures@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-6.1.0.tgz#935479f51865fa7479f6fa94fc6fc7ac14e62c4a"
+  integrity sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==
+  dependencies:
+    is-unicode-supported "^2.0.0"
 
 fill-range@^7.1.1:
   version "7.1.1"
@@ -2058,6 +2678,11 @@ function-bind@^1.1.2:
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
+gensync@^1.0.0-beta.2:
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
+  integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
+
 get-east-asian-width@^1.0.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz"
@@ -2086,6 +2711,14 @@ get-proto@^1.0.1:
   dependencies:
     dunder-proto "^1.0.1"
     es-object-atoms "^1.0.0"
+
+get-stream@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-9.0.1.tgz#95157d21df8eb90d1647102b63039b1df60ebd27"
+  integrity sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==
+  dependencies:
+    "@sec-ant/readable-stream" "^0.4.1"
+    is-stream "^4.0.1"
 
 get-tsconfig@^4.10.0, get-tsconfig@^4.7.5:
   version "4.13.0"
@@ -2204,6 +2837,11 @@ http-errors@^2.0.0, http-errors@^2.0.1, http-errors@~2.0.1:
     statuses "~2.0.2"
     toidentifier "~1.0.1"
 
+human-signals@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-8.0.1.tgz#f08bb593b6d1db353933d06156cedec90abe51fb"
+  integrity sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==
+
 iconv-lite@^0.7.0, iconv-lite@^0.7.2, iconv-lite@~0.7.0:
   version "0.7.2"
   resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz"
@@ -2221,7 +2859,7 @@ ignore@^5.2.0:
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
-inherits@^2.0.3, inherits@~2.0.4:
+inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2265,10 +2903,25 @@ is-number@^7.0.0:
   resolved "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-plain-obj@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
+  integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
+
 is-promise@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz"
   integrity sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==
+
+is-stream@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-4.0.1.tgz#375cf891e16d2e4baec250b85926cffc14720d9b"
+  integrity sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==
+
+is-unicode-supported@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz#09f0ab0de6d3744d48d265ebb98f65d11f2a9b3a"
+  integrity sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==
 
 is-what@^5.2.0:
   version "5.5.0"
@@ -2312,10 +2965,30 @@ joycon@^3.1.1:
   resolved "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz"
   integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
 
+js-md4@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/js-md4/-/js-md4-0.3.2.tgz#cd3b3dc045b0c404556c81ddb5756c23e59d7cf5"
+  integrity sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==
+
 js-tokens@^10.0.0:
   version "10.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz"
   integrity sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==
+
+js-tokens@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
+jsesc@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
+  integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
+
+json-rpc-2.0@^1.7.0:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/json-rpc-2.0/-/json-rpc-2.0-1.7.1.tgz#f4a5095d0a7e51701bffe153ce19087a8b13418e"
+  integrity sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==
 
 json-schema-ref-resolver@^3.0.0:
   version "3.0.0"
@@ -2334,6 +3007,11 @@ json-schema-typed@^8.0.2:
   resolved "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz"
   integrity sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==
 
+json5@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
 light-my-request@^6.0.0:
   version "6.6.0"
   resolved "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz"
@@ -2343,10 +3021,22 @@ light-my-request@^6.0.0:
     process-warning "^4.0.0"
     set-cookie-parser "^2.6.0"
 
+lodash.groupby@~4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.groupby/-/lodash.groupby-4.6.0.tgz#0b08a1dcf68397c397855c3239783832df7403d1"
+  integrity sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==
+
 lru-cache@^11.0.0:
   version "11.2.5"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz"
   integrity sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==
+
+lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
 
 magic-string@^0.30.21:
   version "0.30.21"
@@ -2468,7 +3158,12 @@ mime@^3:
   resolved "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz"
   integrity sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==
 
-minimatch@^10.2.2:
+minimalistic-assert@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
+
+minimatch@^10.2.2, minimatch@~10.2.4:
   version "10.2.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
   integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
@@ -2510,6 +3205,30 @@ ms@^2.1.3:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+mutation-server-protocol@~0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/mutation-server-protocol/-/mutation-server-protocol-0.4.1.tgz#1109b1cdf615d944429281a5c2461453ecfabdf0"
+  integrity sha512-SBGK0j8hLDne7bktgThKI8kGvGTx3rY3LAeQTmOKZ5bVnL/7TorLMvcVF7dIPJCu5RNUWhkkuF53kurygYVt3g==
+  dependencies:
+    zod "^4.1.12"
+
+mutation-testing-elements@3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/mutation-testing-elements/-/mutation-testing-elements-3.7.3.tgz#ae53b36dec076fd1146e2cc473f5a872f924a9a7"
+  integrity sha512-SMeIPxngJpfjfNYctFpYQQtlBlZaVO0aoB3FKdwrI8Ee/2bkyUuCZzAOCLv1U9fnmfA37dPFq0Owduoxs2XgGQ==
+
+mutation-testing-metrics@3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/mutation-testing-metrics/-/mutation-testing-metrics-3.7.3.tgz#6958a1a154fcbfb28a1cdc7764db56cb65a6b68d"
+  integrity sha512-B8QrP0ZomErzTPNlhrzKWPNBln+3afwBZPHv0Q7N8wZZTYxMptzb/Gdm3ExXVmioVYrtZAtsDs7W/T/b2AixOQ==
+  dependencies:
+    mutation-testing-report-schema "3.7.3"
+
+mutation-testing-report-schema@3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/mutation-testing-report-schema/-/mutation-testing-report-schema-3.7.3.tgz#f3a42f9084e1eb324494b87c9464df0b6d0f802d"
+  integrity sha512-BHm3MYq+ckO+t5CtlG8zpqxc75rdJCkxVlE+fGuGJM3F7tNCQ/OW2N+TQVHN3BHsYa84+BFc6g3AwDYkUsw2MA==
+
 mute-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz"
@@ -2530,10 +3249,23 @@ negotiator@^1.0.0:
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz"
   integrity sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==
 
+node-releases@^2.0.36:
+  version "2.0.46"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.46.tgz#d188a129a83f5e03a101aacb58f260f2ee8faaa1"
+  integrity sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==
+
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
+npm-run-path@^6.0.0, npm-run-path@~6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-6.0.0.tgz#25cfdc4eae04976f3349c0b1afc089052c362537"
+  integrity sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==
+  dependencies:
+    path-key "^4.0.0"
+    unicorn-magic "^0.3.0"
 
 object-assign@^4:
   version "4.1.1"
@@ -2591,6 +3323,11 @@ p-timeout@^6.1.2:
   resolved "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz"
   integrity sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==
 
+parse-ms@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-4.0.0.tgz#c0c058edd47c2a590151a718990533fd62803df4"
+  integrity sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==
+
 parseurl@^1.3.3:
   version "1.3.3"
   resolved "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz"
@@ -2600,6 +3337,11 @@ path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
+path-key@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-4.0.0.tgz#295588dc3aee64154f877adb9d780b81c554bf18"
+  integrity sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==
 
 path-scurry@^2.0.2:
   version "2.0.2"
@@ -2749,6 +3491,13 @@ preact@^10.0.0:
   resolved "https://registry.npmjs.org/preact/-/preact-10.28.3.tgz"
   integrity sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA==
 
+pretty-ms@^9.2.0:
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-9.3.0.tgz#dd2524fcb3c326b4931b2272dfd1e1a8ed9a9f5a"
+  integrity sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==
+  dependencies:
+    parse-ms "^4.0.0"
+
 process-warning@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz"
@@ -2768,6 +3517,11 @@ process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.npmjs.org/process/-/process-0.11.10.tgz"
   integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
+
+progress@~2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 property-information@^7.0.0:
   version "7.1.0"
@@ -2789,6 +3543,13 @@ pump@^3.0.0:
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
+
+qs@6.15.1:
+  version "6.15.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.1.tgz#bdb55aed06bfac257a90c44a446a73fba5575c8f"
+  integrity sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==
+  dependencies:
+    side-channel "^1.1.0"
 
 qs@^6.14.0, qs@^6.14.1:
   version "6.15.2"
@@ -2955,6 +3716,13 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+rxjs@~7.8.1:
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.2.tgz#955bc473ed8af11a002a2be52071bf475638607b"
+  integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==
+  dependencies:
+    tslib "^2.1.0"
+
 safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
@@ -2987,10 +3755,25 @@ secure-json-parse@^4.0.0:
   resolved "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz"
   integrity sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==
 
+semver@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
 semver@^7.5.3, semver@^7.6.0:
   version "7.7.3"
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz"
   integrity sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==
+
+semver@^7.6.3, semver@^7.7.4:
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.1.tgz#bf4970b5e70fda0686363cc18bfe8805d5ed957e"
+  integrity sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==
+
+semver@~7.7.0:
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
+  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
 
 send@^1.1.0, send@^1.2.0:
   version "1.2.1"
@@ -3138,6 +3921,11 @@ source-map-js@^1.2.1:
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
+source-map@~0.7.4:
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.6.tgz#a3658ab87e5b6429c8a1f3ba0083d4c61ca3ef02"
+  integrity sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==
+
 space-separated-tokens@^2.0.0:
   version "2.0.2"
   resolved "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz"
@@ -3203,6 +3991,11 @@ strip-ansi@^7.1.0:
   integrity sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==
   dependencies:
     ansi-regex "^6.0.1"
+
+strip-final-newline@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-4.0.0.tgz#35a369ec2ac43df356e3edd5dcebb6429aa1fa5c"
+  integrity sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==
 
 strip-json-comments@^3.1.1:
   version "3.1.1"
@@ -3287,6 +4080,11 @@ totalist@^3.0.0:
   resolved "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz"
   integrity sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==
 
+tree-kill@~1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
+  integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
+
 trim-lines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz"
@@ -3305,6 +4103,11 @@ tsc-alias@^1.8.16:
     normalize-path "^3.0.0"
     plimit-lit "^1.2.6"
 
+tslib@2.8.1, tslib@^2.1.0, tslib@~2.8.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
 tsx@^4.7.0:
   version "4.21.0"
   resolved "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz"
@@ -3315,6 +4118,11 @@ tsx@^4.7.0:
   optionalDependencies:
     fsevents "~2.3.3"
 
+tunnel@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
+  integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
+
 type-is@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz"
@@ -3324,15 +4132,41 @@ type-is@^2.0.1:
     media-typer "^1.1.0"
     mime-types "^3.0.0"
 
+typed-inject@~5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/typed-inject/-/typed-inject-5.0.0.tgz#03e19e41188ec6a05496a5d37dc307d649aa7e87"
+  integrity sha512-0Ql2ORqBORLMdAW89TQKZsb1PQkFGImFfVmncXWe7a+AA3+7dh7Se9exxZowH4kbnlvKEFkMxUYdHUpjYWFJaA==
+
+typed-rest-client@~2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/typed-rest-client/-/typed-rest-client-2.3.1.tgz#8a7e488da15da381e82d5cbbdedd0b08828e897d"
+  integrity sha512-k4kX5Up6qA68D0Cby2AK+6+vM5k3qTxe+/3FqhnHRExjY5cfbOnzjQZbP/LXleF8hVoDvDqxlgk9KK83HoBZlQ==
+  dependencies:
+    des.js "^1.1.0"
+    js-md4 "^0.3.2"
+    qs "6.15.1"
+    tunnel "0.0.6"
+    underscore "^1.13.8"
+
 typescript@^5.8.0:
   version "5.9.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
+underscore@^1.13.8:
+  version "1.13.8"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.8.tgz#a93a21186c049dbf0e847496dba72b7bd8c1e92b"
+  integrity sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==
+
 undici-types@~6.21.0:
   version "6.21.0"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+
+unicorn-magic@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.3.0.tgz#4efd45c85a69e0dd576d25532fbfa22aa5c8a104"
+  integrity sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==
 
 unist-util-is@^6.0.0:
   version "6.0.1"
@@ -3376,6 +4210,14 @@ unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
+
+update-browserslist-db@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz#64d76db58713136acbeb4c49114366cc6cc2e80d"
+  integrity sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==
+  dependencies:
+    escalade "^3.2.0"
+    picocolors "^1.1.1"
 
 util-deprecate@^1.0.1:
   version "1.0.2"
@@ -3489,6 +4331,11 @@ vue@^3.5.13, vue@^3.5.27:
     "@vue/server-renderer" "3.5.28"
     "@vue/shared" "3.5.28"
 
+weapon-regex@~1.3.2:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/weapon-regex/-/weapon-regex-1.3.6.tgz#e2248700d2516581093e77739d821883418f6ddf"
+  integrity sha512-wsf1m1jmMrso5nhwVFJJHSubEBf3+pereGd7+nBKtYJ18KoB/PWJOHS3WRkwS04VrOU0iJr2bZU+l1QaTJ+9nA==
+
 which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.npmjs.org/which/-/which-2.0.2.tgz"
@@ -3523,6 +4370,16 @@ ws@^8.16.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
   integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
 
+yallist@^3.0.2:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yoctocolors@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yoctocolors/-/yoctocolors-2.1.2.tgz#d795f54d173494e7d8db93150cec0ed7f678c83a"
+  integrity sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==
+
 zod-to-json-schema@^3.25.1:
   version "3.25.1"
   resolved "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz"
@@ -3532,6 +4389,11 @@ zod-to-json-schema@^3.25.1:
   version "4.3.6"
   resolved "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz"
   integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==
+
+zod@^4.1.12:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
+  integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==
 
 zwitch@^2.0.4:
   version "2.0.4"


### PR DESCRIPTION
Follow-up to #263 (spec-191): two commits that landed on the branch *after* #263 was merged and were therefore never in master.

## 1. Coverage to 80% on all metrics + enforced thresholds (`cde8de1`)

Branch coverage was the laggard (~70%). Added ~290 tests across pure-logic usecases/services/guards, webhook controllers, HTTP routes (Fastify `inject`), and real-filesystem integration tests for I/O gateways and the `--bg` transcript glue (ember + insights). **No production source changed.**

Global coverage: statements 84.9%, **branches 80.95%**, functions 80.06%, lines 85.15% — all ≥ 80%.

Enforced via `coverage.thresholds` in `vitest.config.ts` (`yarn coverage` now fails below 80% on every metric). CLAUDE.md coverage requirements updated.

> Note: branches (80.95%) and functions (80.06%) sit just above the 80% gate — thin margins, aligned with the project's TDD rule (new code must come with tests).

## 2. Stryker mutation-testing pilot, insights module, local-only (`a63f2c4`)

On-demand mutation testing, **deliberately NOT wired into CI / `yarn verify`** (slow + costly).

- devDeps: `@stryker-mutator/core`, `@stryker-mutator/vitest-runner` (+ `typescript` pinned for Stryker's tsconfig preprocessor)
- `stryker.config.json` scoped to `src/modules/statistics-insights` (excludes schemas, gateway contracts, d.ts); vitest runner; `perTest` analysis; `break: null` (report-only)
- `yarn test:mutation` script; `.stryker-tmp/` + `reports/mutation/` gitignored

**Pilot baseline:** insights module mutation score **67.8%** (1679 killed / 764 survived). Surfaced weak-assertion hotspots (high line coverage, low mutation score): `computeTeamInsights` 31%, `statsService` 58%, `insights.routes` 54%.

### ⚠️ Environment caveat
This environment runs with `NODE_ENV=production` (npm `omit=dev`), so any `yarn add`/`install` prunes devDependencies. To run the pilot locally: `yarn install --production=false` first, then `yarn test:mutation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)