### PR TITLE
fix: #247 setup wizard deadlock when initiating tab is lost

### DIFF
--- a/src/dashboard/setup.html
+++ b/src/dashboard/setup.html
@@ -33,10 +33,11 @@
     <div id="setup-disconnect" class="setup-disconnect" hidden role="alert">
       <span class="setup-banner-title">// CONNEXION PERDUE</span>
       <span class="setup-disconnect-detail">Lecture dégradée via interrogation périodique de l'état.</span>
-      <a class="btn btn-secondary" href="/setup">Relancer le wizard</a>
     </div>
 
     <div id="setup-readonly" class="setup-readonly" hidden role="status"></div>
+
+    <button type="button" id="setup-relaunch" class="btn btn-secondary" hidden>Relancer le wizard</button>
 
     <div id="setup-avatar" class="setup-avatar" hidden>
       <span class="setup-corner setup-corner--tl" aria-hidden="true"></span>
@@ -84,6 +85,7 @@
     const bannersContainer = document.getElementById('setup-banners');
     const disconnectBanner = document.getElementById('setup-disconnect');
     const readOnlyBanner = document.getElementById('setup-readonly');
+    const relaunchButton = document.getElementById('setup-relaunch');
     const liveRegion = document.getElementById('setup-live');
     const shell = document.querySelector('.setup-shell');
     const headingElement = document.getElementById('setup-heading');
@@ -260,11 +262,25 @@
 
     function showDisconnect() {
       disconnectBanner.hidden = false;
+      relaunchButton.hidden = false;
     }
 
     function showReadOnly(notice) {
       readOnlyBanner.hidden = false;
       readOnlyBanner.textContent = notice;
+      relaunchButton.hidden = false;
+    }
+
+    if (relaunchButton) {
+      relaunchButton.addEventListener('click', async () => {
+        relaunchButton.disabled = true;
+        try {
+          await fetch('/api/setup/cancel', { method: 'POST' });
+        } catch {
+          /* a failed cancel still lets the reload retry a fresh /start */
+        }
+        window.location.href = '/setup';
+      });
     }
 
     async function pollOnce() {

--- a/src/modules/setup-wizard/interface-adapters/controllers/http/setupWizard.routes.ts
+++ b/src/modules/setup-wizard/interface-adapters/controllers/http/setupWizard.routes.ts
@@ -75,6 +75,17 @@ export const setupWizardRoutes: FastifyPluginAsync<SetupWizardRoutesOptions> = a
     return { status: 'written' };
   });
 
+  fastify.post('/api/setup/cancel', async (_request, reply) => {
+    const result = registry.cancel();
+    if (result.status === 'no-active-run') {
+      reply.code(409);
+      return { error: 'no-active-run' };
+    }
+
+    logger.info('Setup wizard run cancelled');
+    return { status: 'cancelled' };
+  });
+
   fastify.get('/api/setup/state', async () => {
     const loaded = setupStateGateway.load();
     return { state: loaded.state, corrupted: loaded.corrupted };

--- a/src/modules/setup-wizard/usecases/streamSetupRun.usecase.ts
+++ b/src/modules/setup-wizard/usecases/streamSetupRun.usecase.ts
@@ -16,6 +16,8 @@ export type StartSetupRunResult =
 
 export type SubmitInputResult = { status: 'written' } | { status: 'no-active-run' };
 
+export type CancelSetupRunResult = { status: 'cancelled' } | { status: 'no-active-run' };
+
 interface ActiveRun {
   runId: string;
   handle: SetupProcessHandle;
@@ -23,12 +25,25 @@ interface ActiveRun {
   subscribers: Set<SetupRunSubscriber>;
   exitCode: number | null;
   exited: boolean;
+  expiryTimer: ReturnType<typeof setTimeout> | null;
 }
+
+export interface SetupRunRegistryOptions {
+  inactivityTimeoutMs?: number;
+}
+
+const DEFAULT_INACTIVITY_TIMEOUT_MS = 30_000;
 
 export class SetupRunRegistry {
   private activeRun: ActiveRun | null = null;
+  private readonly inactivityTimeoutMs: number;
 
-  constructor(private readonly processGateway: SetupProcessGateway) {}
+  constructor(
+    private readonly processGateway: SetupProcessGateway,
+    options?: SetupRunRegistryOptions,
+  ) {
+    this.inactivityTimeoutMs = options?.inactivityTimeoutMs ?? DEFAULT_INACTIVITY_TIMEOUT_MS;
+  }
 
   start(options: SetupProcessSpawnOptions): StartSetupRunResult {
     if (this.activeRun !== null && !this.activeRun.exited) {
@@ -43,6 +58,7 @@ export class SetupRunRegistry {
       subscribers: new Set(),
       exitCode: null,
       exited: false,
+      expiryTimer: null,
     };
     this.activeRun = run;
 
@@ -54,13 +70,10 @@ export class SetupRunRegistry {
     });
 
     handle.onExit((code) => {
-      run.exited = true;
-      run.exitCode = code;
-      for (const subscriber of run.subscribers) {
-        subscriber.onClose(code);
-      }
+      this.finalizeRun(run, code);
     });
 
+    this.armExpiry(run);
     return { status: 'started', runId: run.runId };
   }
 
@@ -80,8 +93,12 @@ export class SetupRunRegistry {
     }
 
     run.subscribers.add(subscriber);
+    this.clearExpiry(run);
     return () => {
       run.subscribers.delete(subscriber);
+      if (run.subscribers.size === 0 && !run.exited) {
+        this.armExpiry(run);
+      }
     };
   }
 
@@ -95,7 +112,51 @@ export class SetupRunRegistry {
     return { status: 'written' };
   }
 
+  cancel(): CancelSetupRunResult {
+    const run = this.activeRun;
+    if (run === null || run.exited) {
+      return { status: 'no-active-run' };
+    }
+
+    run.handle.kill();
+    this.finalizeRun(run, null);
+    return { status: 'cancelled' };
+  }
+
   hasActiveRun(): boolean {
     return this.activeRun !== null && !this.activeRun.exited;
+  }
+
+  private finalizeRun(run: ActiveRun, code: number | null): void {
+    if (run.exited) {
+      return;
+    }
+    run.exited = true;
+    run.exitCode = code;
+    this.clearExpiry(run);
+    for (const subscriber of run.subscribers) {
+      subscriber.onClose(code);
+    }
+    run.subscribers.clear();
+  }
+
+  private armExpiry(run: ActiveRun): void {
+    this.clearExpiry(run);
+    const timer = setTimeout(() => {
+      if (run.exited) {
+        return;
+      }
+      run.handle.kill();
+      this.finalizeRun(run, null);
+    }, this.inactivityTimeoutMs);
+    timer.unref?.();
+    run.expiryTimer = timer;
+  }
+
+  private clearExpiry(run: ActiveRun): void {
+    if (run.expiryTimer !== null) {
+      clearTimeout(run.expiryTimer);
+      run.expiryTimer = null;
+    }
   }
 }

--- a/src/tests/units/modules/setup-wizard/interface-adapters/controllers/http/setupWizard.routes.test.ts
+++ b/src/tests/units/modules/setup-wizard/interface-adapters/controllers/http/setupWizard.routes.test.ts
@@ -201,4 +201,21 @@ describe('setupWizard routes', () => {
     expect(response.statusCode).toBe(400);
     expect(processGateway.lastWrittenLine).toBeNull();
   });
+
+  it('cancels the active run and returns 200', async () => {
+    await application.inject({ method: 'POST', url: '/api/setup/start' });
+
+    const response = await application.inject({ method: 'POST', url: '/api/setup/cancel' });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body).status).toBe('cancelled');
+    expect(processGateway.killed).toBe(true);
+    expect(registry.hasActiveRun()).toBe(false);
+  });
+
+  it('returns 409 when cancelling with no active run', async () => {
+    const response = await application.inject({ method: 'POST', url: '/api/setup/cancel' });
+
+    expect(response.statusCode).toBe(409);
+  });
 });

--- a/src/tests/units/modules/setup-wizard/usecases/streamSetupRun.usecase.test.ts
+++ b/src/tests/units/modules/setup-wizard/usecases/streamSetupRun.usecase.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { StubSetupProcessGateway } from '@/tests/stubs/setupProcess.stub.js';
 import { SetupRunRegistry } from '@/modules/setup-wizard/usecases/streamSetupRun.usecase.js';
 
@@ -116,5 +116,79 @@ describe('SetupRunRegistry', () => {
 
     expect(result.status).toBe('no-active-run');
     expect(gateway.writtenLines).toEqual([]);
+  });
+
+  it('cancels the active run, killing the process and allowing a new run', () => {
+    registry.start({ projectPath: null });
+
+    const result = registry.cancel();
+
+    expect(result.status).toBe('cancelled');
+    expect(gateway.killed).toBe(true);
+    expect(registry.hasActiveRun()).toBe(false);
+
+    const second = registry.start({ projectPath: null });
+    expect(second.status).toBe('started');
+    expect(gateway.spawnCount).toBe(2);
+  });
+
+  it('notifies subscribers when the run is cancelled', () => {
+    const started = registry.start({ projectPath: null });
+    let closed = false;
+    if (started.status === 'started') {
+      registry.subscribe(started.runId, {
+        onEvent: () => {},
+        onClose: () => {
+          closed = true;
+        },
+      });
+    }
+
+    registry.cancel();
+
+    expect(closed).toBe(true);
+  });
+
+  it('returns no-active-run when cancelling with no run in progress', () => {
+    expect(registry.cancel().status).toBe('no-active-run');
+  });
+
+  describe('inactivity expiry', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('cancels the run after the timeout once no subscriber remains', () => {
+      const localGateway = new StubSetupProcessGateway();
+      const localRegistry = new SetupRunRegistry(localGateway, { inactivityTimeoutMs: 1000 });
+      const started = localRegistry.start({ projectPath: null });
+      const runId = started.status === 'started' ? started.runId : '';
+      const unsubscribe = localRegistry.subscribe(runId, { onEvent: () => {}, onClose: () => {} });
+      unsubscribe();
+
+      vi.advanceTimersByTime(1000);
+
+      expect(localGateway.killed).toBe(true);
+      expect(localRegistry.hasActiveRun()).toBe(false);
+    });
+
+    it('keeps the run alive when a new subscriber attaches before the timeout', () => {
+      const localGateway = new StubSetupProcessGateway();
+      const localRegistry = new SetupRunRegistry(localGateway, { inactivityTimeoutMs: 1000 });
+      const started = localRegistry.start({ projectPath: null });
+      const runId = started.status === 'started' ? started.runId : '';
+      const unsubscribe = localRegistry.subscribe(runId, { onEvent: () => {}, onClose: () => {} });
+      unsubscribe();
+      vi.advanceTimersByTime(500);
+      localRegistry.subscribe(runId, { onEvent: () => {}, onClose: () => {} });
+      vi.advanceTimersByTime(500);
+
+      expect(localGateway.killed).toBe(false);
+      expect(localRegistry.hasActiveRun()).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Context

Fixes #247 — the dashboard setup wizard wedged into an unrecoverable state once the tab that **started** a run was closed or reloaded. The run could neither complete nor be cancelled from the UI; only killing the spawned child or restarting the daemon recovered it.

## Root cause (confirmed)

Four facts, all verified in code:

1. `SetupRunRegistry.activeRun` was an in-memory singleton with **no timeout**, cleared only when the child exited.
2. The handle's `kill()` existed but was **never invoked** by the registry.
3. The SSE route's `request.raw.on('close', …)` only `unsubscribe()`d — the `setup --json` child stayed blocked on stdin at `awaiting_input` indefinitely.
4. Cascade: `start()` returned `already-active` → route replied `409` → every new tab forced read-only with no takeover path.

## Fix (Cancel + inactivity timeout)

| Layer | Change |
|-------|--------|
| **Use case** | `SetupRunRegistry.cancel()` kills the child and resets state; an inactivity timeout (30 s default) is armed once no subscriber remains and disarmed on re-attach; `finalizeRun()` centralizes teardown to prevent double-close |
| **Route** | `POST /api/setup/cancel` → `200 { status: 'cancelled' }` / `409 { error: 'no-active-run' }` |
| **Frontend** | "Relancer le wizard" button now calls `/api/setup/cancel` then reloads (replacing the old `<a href="/setup">` that just re-triggered the 409); shown on read-only and on disconnect |

## Tests

Added (TDD RED→GREEN):
- Registry: cancel kills + allows new run, cancel notifies subscribers, cancel with no run → `no-active-run`, timeout fires after no subscriber, timeout cancelled on re-attach
- Route: cancel → 200, cancel with no run → 409

Full suite green locally: **3214 tests / 415 files**, typecheck + Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
