### PR TITLE
fix: #270 create isolated HOME/config dirs for the scoped GitLab executor (ENOENT)

### DIFF
--- a/src/modules/platform-integration/interface-adapters/gateways/threadFetch.gitlab.gateway.ts
+++ b/src/modules/platform-integration/interface-adapters/gateways/threadFetch.gitlab.gateway.ts
@@ -14,6 +14,9 @@ const realFileWriter: ExecutorFileWriter = {
     mkdirSync(dirname(path), { recursive: true })
     writeFileSync(path, contents, { mode: 0o600 })
   },
+  ensureDir(path: string): void {
+    mkdirSync(path, { recursive: true })
+  },
 }
 
 const scopedSpawn = (command: string, env: ScopedExecutorEnv, cwd: string): string =>

--- a/src/modules/platform-integration/services/scopedExecutorEnvironment.ts
+++ b/src/modules/platform-integration/services/scopedExecutorEnvironment.ts
@@ -1,3 +1,5 @@
+import { join } from 'node:path'
+
 export const EXECUTOR_TOKEN_ENV_KEY = 'REVIEWFLOW_EXECUTOR_TOKEN'
 
 export const ENV_ALLOWLIST = ['PATH', 'HOME', 'GLAB_CONFIG_DIR', 'LANG'] as const
@@ -17,6 +19,7 @@ export class MissingExecutorTokenError extends Error {
 
 export interface ExecutorFileWriter {
   write(path: string, contents: string): void
+  ensureDir(path: string): void
 }
 
 export interface BuildScopedExecutorEnvironmentInput {
@@ -48,8 +51,8 @@ export function buildScopedExecutorEnvironment(
     throw new MissingExecutorTokenError()
   }
 
-  const home = `${input.isolatedDir}/home`
-  const glabConfigDir = `${input.isolatedDir}/glab-config`
+  const home = join(input.isolatedDir, 'home')
+  const glabConfigDir = join(input.isolatedDir, 'glab-config')
 
   const env: ScopedExecutorEnv = {
     HOME: home,
@@ -62,7 +65,12 @@ export function buildScopedExecutorEnvironment(
   const lang = input.parentEnv.LANG
   if (lang) env.LANG = lang
 
-  const configFilePath = `${glabConfigDir}/glab-cli/config.yml`
+  // cwd at spawn time is HOME and glab reads GLAB_CONFIG_DIR; both directories
+  // must exist on disk before the spawn, else execSync fails with ENOENT.
+  input.fileWriter.ensureDir(home)
+  input.fileWriter.ensureDir(glabConfigDir)
+
+  const configFilePath = join(glabConfigDir, 'glab-cli', 'config.yml')
   input.fileWriter.write(configFilePath, renderGlabConfig(token))
 
   return { env, configFilePath }

--- a/src/tests/units/modules/platform-integration/gateways/scopedGitLabExecutor.test.ts
+++ b/src/tests/units/modules/platform-integration/gateways/scopedGitLabExecutor.test.ts
@@ -8,8 +8,12 @@ const TOKEN = 'glpat-scoped-exec-1'
 
 class RecordingFileWriter {
   public readonly writes: Array<{ path: string; contents: string }> = []
+  public readonly ensuredDirs: string[] = []
   write(path: string, contents: string): void {
     this.writes.push({ path, contents })
+  }
+  ensureDir(path: string): void {
+    this.ensuredDirs.push(path)
   }
 }
 

--- a/src/tests/units/modules/platform-integration/services/scopedExecutorEnvironment.test.ts
+++ b/src/tests/units/modules/platform-integration/services/scopedExecutorEnvironment.test.ts
@@ -7,8 +7,12 @@ import {
 
 class RecordingFileWriter {
   public readonly writes: Array<{ path: string; contents: string }> = []
+  public readonly ensuredDirs: string[] = []
   write(path: string, contents: string): void {
     this.writes.push({ path, contents })
+  }
+  ensureDir(path: string): void {
+    this.ensuredDirs.push(path)
   }
 }
 
@@ -135,5 +139,15 @@ describe('scoped executor environment (AC1/AC2/AC3/AC4)', () => {
     for (const write of fileWriter.writes) {
       expect(write.path.startsWith(TEMP_ROOT)).toBe(true)
     }
+  })
+
+  it('AC4: creates the isolated HOME directory so the spawn cwd exists', () => {
+    const fileWriter = new RecordingFileWriter()
+    const { env } = buildScopedExecutorEnvironment({
+      parentEnv: { REVIEWFLOW_EXECUTOR_TOKEN: TOKEN, PATH: '/usr/bin' },
+      isolatedDir: TEMP_ROOT,
+      fileWriter,
+    })
+    expect(fileWriter.ensuredDirs).toContain(env.HOME)
   })
 })


### PR DESCRIPTION
Fixes #270.

The scoped GitLab executor (SPEC-196) set `cwd` to an isolated `HOME` that was **never created**, with paths built via template strings. `execSync` then failed with `spawnSync /bin/sh ENOENT` → the review context file was never written → **no progress steps on the dashboard and no report posted on the MR** (every GitLab review affected).

## Fix
- `ExecutorFileWriter` gains `ensureDir()`; `buildScopedExecutorEnvironment` now creates the isolated `HOME` and `GLAB_CONFIG_DIR` **before** the spawn.
- `realFileWriter.ensureDir = mkdirSync(recursive)`; paths via `path.join` for cross-platform safety.
- Covered by a test asserting the `HOME` dir is **created** (not just present in the args) — the existing SPEC-196 tests mocked the spawn, so this runtime bug slipped through.

`yarn verify` green (438 files, 3646 tests).

Full Windows portability of the scoped executor (`HOME` vs `USERPROFILE`, shell) is tracked separately in #271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
