### PR TITLE
fix: #273 write scoped glab config at GLAB_CONFIG_DIR root (was 401)

### DIFF
--- a/src/modules/platform-integration/services/scopedExecutorEnvironment.ts
+++ b/src/modules/platform-integration/services/scopedExecutorEnvironment.ts
@@ -70,7 +70,9 @@ export function buildScopedExecutorEnvironment(
   input.fileWriter.ensureDir(home)
   input.fileWriter.ensureDir(glabConfigDir)
 
-  const configFilePath = join(glabConfigDir, 'glab-cli', 'config.yml')
+  // When GLAB_CONFIG_DIR is set, glab reads its config at the root of that dir
+  // (config.yml directly); the glab-cli/ subdir only applies under HOME.
+  const configFilePath = join(glabConfigDir, 'config.yml')
   input.fileWriter.write(configFilePath, renderGlabConfig(token))
 
   return { env, configFilePath }

--- a/src/tests/units/modules/platform-integration/services/scopedExecutorEnvironment.test.ts
+++ b/src/tests/units/modules/platform-integration/services/scopedExecutorEnvironment.test.ts
@@ -119,14 +119,14 @@ describe('scoped executor environment (AC1/AC2/AC3/AC4)', () => {
     expect(env.GLAB_CONFIG_DIR?.startsWith(TEMP_ROOT)).toBe(true)
   })
 
-  it('AC4: the config file is written under GLAB_CONFIG_DIR/glab-cli/config.yml', () => {
+  it('AC4: the config file is written at GLAB_CONFIG_DIR/config.yml (glab ignores a glab-cli subdir when GLAB_CONFIG_DIR is set)', () => {
     const fileWriter = new RecordingFileWriter()
     const { env } = buildScopedExecutorEnvironment({
       parentEnv: { REVIEWFLOW_EXECUTOR_TOKEN: TOKEN, PATH: '/usr/bin' },
       isolatedDir: TEMP_ROOT,
       fileWriter,
     })
-    expect(fileWriter.writes[0]?.path).toBe(`${env.GLAB_CONFIG_DIR}/glab-cli/config.yml`)
+    expect(fileWriter.writes[0]?.path).toBe(`${env.GLAB_CONFIG_DIR}/config.yml`)
   })
 
   it('AC4: every written path stays under the isolated temp root', () => {


### PR DESCRIPTION
Fixes #273.

With `GLAB_CONFIG_DIR` set, glab reads its config at **`$GLAB_CONFIG_DIR/config.yml`** — the `glab-cli/` subdir only applies under HOME. The scoped executor wrote to `glab-cli/config.yml`, so glab ran **unauthenticated → 401**, the review context file was never built → no progress steps and no report (surfaced once #270 unblocked the spawn).

Proven with the real token in an isolated env:
- `$GLAB_CONFIG_DIR/config.yml` → **200** (discussions array)
- `$GLAB_CONFIG_DIR/glab-cli/config.yml` → **401**

## Fix
- Write the config at `join(glabConfigDir, 'config.yml')`.
- Fix the AC4 test which **asserted (and froze) the wrong path** — that is why the bug shipped.

`yarn verify` green (438 files, 3646 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
