### PR TITLE
fix: #276 shell-quote comment body so the review report posts (no more /bin/sh error)

### DIFF
--- a/src/modules/platform-integration/interface-adapters/gateways/cli/noteCommentPost.github.cli.gateway.ts
+++ b/src/modules/platform-integration/interface-adapters/gateways/cli/noteCommentPost.github.cli.gateway.ts
@@ -8,7 +8,10 @@ export class GitHubNoteCommentPostCliGateway implements NoteCommentPostGateway {
   constructor(private readonly executor: CommandExecutor) {}
 
   async postComment(input: NoteCommentPostInput): Promise<void> {
-    const command = `gh api --method POST repos/${input.projectPath}/issues/${input.mrNumber}/comments --field body=${JSON.stringify(input.body)}`;
+    // Single-quote for the shell: the executor runs this string through /bin/sh,
+    // and a markdown body (backticks, $(), parens) must not be interpreted/injected.
+    const quotedBody = `'${input.body.replace(/'/g, "'\\''")}'`;
+    const command = `gh api --method POST repos/${input.projectPath}/issues/${input.mrNumber}/comments --field body=${quotedBody}`;
     this.executor(command);
   }
 }

--- a/src/modules/platform-integration/interface-adapters/gateways/cli/noteCommentPost.gitlab.cli.gateway.ts
+++ b/src/modules/platform-integration/interface-adapters/gateways/cli/noteCommentPost.gitlab.cli.gateway.ts
@@ -9,7 +9,10 @@ export class GitLabNoteCommentPostCliGateway implements NoteCommentPostGateway {
 
   async postComment(input: NoteCommentPostInput): Promise<void> {
     const encodedProject = input.projectPath.replace(/\//g, '%2F');
-    const command = `glab api --method POST projects/${encodedProject}/merge_requests/${input.mrNumber}/notes --field body=${JSON.stringify(input.body)}`;
+    // Single-quote for the shell: the executor runs this string through /bin/sh,
+    // and a markdown body (backticks, $(), parens) must not be interpreted/injected.
+    const quotedBody = `'${input.body.replace(/'/g, "'\\''")}'`;
+    const command = `glab api --method POST projects/${encodedProject}/merge_requests/${input.mrNumber}/notes --field body=${quotedBody}`;
     this.executor(command);
   }
 }

--- a/src/tests/units/modules/platform-integration/interface-adapters/gateways/cli/noteCommentPost.cli.shellSafety.test.ts
+++ b/src/tests/units/modules/platform-integration/interface-adapters/gateways/cli/noteCommentPost.cli.shellSafety.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { GitLabNoteCommentPostCliGateway } from '@/modules/platform-integration/interface-adapters/gateways/cli/noteCommentPost.gitlab.cli.gateway.js'
+import { GitHubNoteCommentPostCliGateway } from '@/modules/platform-integration/interface-adapters/gateways/cli/noteCommentPost.github.cli.gateway.js'
+
+// A real review report: markdown with backticks wrapping code that contains
+// parentheses, plus $() and quotes. Inside a double-quoted shell string these
+// trigger command substitution and break the shell — the regression we fix.
+const DANGEROUS_BODY =
+  "## Review (MG-2416)\n`isJobboardOffer(offerWithApplications)` and $(whoami) and it's \"quoted\" \\x"
+
+function parsesAsValidShell(command: string): boolean {
+  try {
+    // sh -n parses without executing: a syntax error throws.
+    execFileSync('/bin/sh', ['-n', '-c', command])
+    return true
+  } catch {
+    return false
+  }
+}
+
+describe('CLI note-comment post gateways — shell safety (issue #276)', () => {
+  it('GitLab: builds a shell-valid command for a body with backticks/parens/$()/quotes', async () => {
+    let captured = ''
+    const gateway = new GitLabNoteCommentPostCliGateway((command: string): string => {
+      captured = command
+      return ''
+    })
+
+    await gateway.postComment({ projectPath: 'group/project', mrNumber: 42, body: DANGEROUS_BODY })
+
+    expect(parsesAsValidShell(captured)).toBe(true)
+  })
+
+  it('GitHub: builds a shell-valid command for a body with backticks/parens/$()/quotes', async () => {
+    let captured = ''
+    const gateway = new GitHubNoteCommentPostCliGateway((command: string): string => {
+      captured = command
+      return ''
+    })
+
+    await gateway.postComment({ projectPath: 'owner/repo', mrNumber: 7, body: DANGEROUS_BODY })
+
+    expect(parsesAsValidShell(captured)).toBe(true)
+  })
+})


### PR DESCRIPTION
Fixes #276 — last link of the executor chain.

`POST_COMMENT` built `glab/gh api --field body=${JSON.stringify(body)}` into a shell command. JSON double-quotes do **not** neutralize shell metacharacters: inside `"..."`, backticks and `$()` in the markdown report (e.g. `` `isJobboardOffer(offerWithApplications)` ``) trigger command substitution → `/bin/sh` syntax error → **report never posted**. Also a **shell-injection** risk (the body carries MR/diff content).

## Fix
Single-quote the body (`'` → `'\''`) in both the GitLab and GitHub CLI gateways, matching `defaultCommandExecutor`. New test asserts the generated command is **valid shell syntax** (`sh -n`) for a body containing backticks, parentheses, `$()`, and quotes — reproduces the exact `Syntax error`.

`yarn verify` green (439 files, 3648 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
