### PR TITLE
fix: resolve follow-up threads and post GitHub replies in-thread

### DIFF
--- a/src/modules/review-execution/interface-adapters/gateways/cli/reviewAction.github.cli.gateway.ts
+++ b/src/modules/review-execution/interface-adapters/gateways/cli/reviewAction.github.cli.gateway.ts
@@ -37,10 +37,12 @@ export class GitHubReviewActionCliGateway
           command: 'gh',
           args: [
             'api',
-            '--method',
-            'POST',
-            `repos/${context.projectPath}/pulls/${context.mrNumber}/comments/${action.threadId}/replies`,
-            '--field',
+            'graphql',
+            '-f',
+            'query=mutation($threadId: ID!, $body: String!) { addPullRequestReviewThreadReply(input: { pullRequestReviewThreadId: $threadId, body: $body }) { comment { id } } }',
+            '-f',
+            `threadId=${action.threadId}`,
+            '-f',
             `body=${action.message}`,
           ],
         }

--- a/src/modules/review-execution/services/contextActionsExecutor.ts
+++ b/src/modules/review-execution/services/contextActionsExecutor.ts
@@ -12,6 +12,32 @@ import { filterAutoExecutorActions } from '@/modules/platform-integration/servic
  */
 export type { ReviewAction as ReviewContextAction }
 
+/**
+ * The auto-path capability filter drops THREAD_RESOLVE (it requires a privileged role).
+ * Context actions, however, travel with `context.threads` — the authenticated thread inventory
+ * written at job creation, never reachable by the LLM (which can only append to `actions` via MCP).
+ * Re-admit a dropped THREAD_RESOLVE only when its target id belongs to that inventory, so genuine
+ * resolves run while forged or out-of-MR ids stay dropped (fail-closed on an empty inventory).
+ */
+function selectExecutableContextActions(
+  actions: ReviewAction[],
+  authenticatedThreadIds: ReadonlySet<string>,
+): { allowed: ReviewAction[]; dropped: ReviewAction[] } {
+  const { allowed, dropped } = filterAutoExecutorActions(actions)
+
+  const reinstated: ReviewAction[] = []
+  const stillDropped: ReviewAction[] = []
+  for (const action of dropped) {
+    if (action.type === 'THREAD_RESOLVE' && authenticatedThreadIds.has(action.threadId.trim())) {
+      reinstated.push({ ...action, threadId: action.threadId.trim() })
+    } else {
+      stillDropped.push(action)
+    }
+  }
+
+  return { allowed: [...allowed, ...reinstated], dropped: stillDropped }
+}
+
 export type { ExecutionResult, CommandExecutor }
 
 interface Logger {
@@ -40,7 +66,11 @@ export async function executeActionsFromContext(
     baseUrl,
   }
 
-  const { allowed, dropped } = filterAutoExecutorActions(context.actions as ReviewAction[])
+  const authenticatedThreadIds = new Set(context.threads.map(thread => thread.id))
+  const { allowed, dropped } = selectExecutableContextActions(
+    context.actions as ReviewAction[],
+    authenticatedThreadIds,
+  )
 
   if (dropped.length > 0) {
     logger.warn(

--- a/src/modules/tracking/interface-adapters/controllers/http/mrTrackingAdvanced.routes.ts
+++ b/src/modules/tracking/interface-adapters/controllers/http/mrTrackingAdvanced.routes.ts
@@ -13,6 +13,7 @@ import type { SyncThreadsUseCase } from '@/modules/tracking/usecases/tracking/sy
 import { parseReviewOutput } from '@/modules/statistics-insights/services/statsService.js';
 import { parseThreadActions } from '@/modules/review-execution/services/threadActionsParser.js';
 import { executeThreadActions, defaultCommandExecutor } from '@/modules/review-execution/services/threadActionsExecutor.js';
+import { executeActionsFromContext } from '@/modules/review-execution/services/contextActionsExecutor.js';
 import type { ReviewContextFileSystemGateway } from '@/modules/review-execution/interface-adapters/gateways/reviewContext.fileSystem.gateway.js';
 import type { GitHubThreadFetchGateway } from '@/modules/platform-integration/interface-adapters/gateways/threadFetch.github.gateway.js';
 import type { GitLabThreadFetchGateway } from '@/modules/platform-integration/interface-adapters/gateways/threadFetch.gitlab.gateway.js';
@@ -248,18 +249,34 @@ export const mrTrackingAdvancedRoutes: FastifyPluginAsync<MrTrackingAdvancedRout
         const mcpActions = reviewContext?.actions ?? [];
         const markerActions = parseThreadActions(result.stdout);
 
-        // Combine actions (MCP takes priority, markers as fallback)
-        const threadActions = mcpActions.length > 0 ? mcpActions : markerActions;
-
         let threadResolveCount = 0;
-        if (threadActions.length > 0) {
-          threadResolveCount = threadActions.filter(a => a.type === 'THREAD_RESOLVE').length;
+        if (reviewContext && mcpActions.length > 0) {
+          // Primary path: MCP actions execute against the authenticated context inventory,
+          // which re-admits THREAD_RESOLVE for threads owned by this MR (forged ids stay dropped).
+          threadResolveCount = mcpActions.filter(a => a.type === 'THREAD_RESOLVE').length;
           logger.info(
-            { mcpActionsCount: mcpActions.length, markerActionsCount: markerActions.length, mrNumber: job.mrNumber },
+            { mcpActionsCount: mcpActions.length, mrNumber: job.mrNumber },
+            'Executing thread actions'
+          );
+          const actionResult = await executeActionsFromContext(
+            reviewContext,
+            job.localPath,
+            logger,
+            defaultCommandExecutor
+          );
+          logger.info(
+            { ...actionResult, threadResolveCount, mrNumber: job.mrNumber },
+            'Thread actions executed for manual followup'
+          );
+        } else if (markerActions.length > 0) {
+          // Legacy fallback: stdout markers carry no authenticated inventory, so resolves stay dropped.
+          threadResolveCount = markerActions.filter(a => a.type === 'THREAD_RESOLVE').length;
+          logger.info(
+            { markerActionsCount: markerActions.length, mrNumber: job.mrNumber },
             'Executing thread actions'
           );
           const actionResult = await executeThreadActions(
-            threadActions,
+            markerActions,
             {
               platform: job.platform,
               projectPath: job.projectPath,

--- a/src/tests/units/interface-adapters/gateways/cli/reviewAction.github.cli.gateway.test.ts
+++ b/src/tests/units/interface-adapters/gateways/cli/reviewAction.github.cli.gateway.test.ts
@@ -36,19 +36,22 @@ describe('GitHubReviewActionCliGateway', () => {
     expect(result.succeeded).toBe(1)
   })
 
-  it('should execute THREAD_REPLY action with gh api', async () => {
+  it('should execute THREAD_REPLY action with the gh graphql addPullRequestReviewThreadReply mutation', async () => {
     const executor = vi.fn()
     const gateway = new GitHubReviewActionCliGateway(executor)
-    const actions: ReviewAction[] = [{ type: 'THREAD_REPLY', threadId: '123456', message: 'Done!' }]
+    const actions: ReviewAction[] = [{ type: 'THREAD_REPLY', threadId: 'PRRT_node123', message: 'Done!' }]
     const context = { projectPath: 'owner/repo', mrNumber: 42, localPath: '/tmp', baseUrl: null as string | null }
 
     const result = await gateway.execute(actions, context)
 
-    expect(executor).toHaveBeenCalledWith(
-      'gh',
-      expect.arrayContaining(['repos/owner/repo/pulls/42/comments/123456/replies', 'body=Done!']),
-      '/tmp'
-    )
+    const call = executor.mock.calls[0]
+    expect(call[0]).toBe('gh')
+    const args: string[] = call[1]
+    expect(args).toContain('graphql')
+    expect(args.some((arg) => arg.includes('addPullRequestReviewThreadReply'))).toBe(true)
+    expect(args).toContain('threadId=PRRT_node123')
+    expect(args).toContain('body=Done!')
+    expect(call[2]).toBe('/tmp')
     expect(result.succeeded).toBe(1)
   })
 

--- a/src/tests/units/services/contextActionsExecutor.test.ts
+++ b/src/tests/units/services/contextActionsExecutor.test.ts
@@ -117,6 +117,90 @@ describe('executeActionsFromContext (auto path, capability-bounded)', () => {
     )
   })
 
+  describe('inventory-gated THREAD_RESOLVE re-admission', () => {
+    const thread = (id: string) => ({
+      id,
+      file: null,
+      line: null,
+      status: 'open' as const,
+      body: 'previous review note',
+    })
+
+    it('executes THREAD_RESOLVE when the threadId is in the authenticated thread inventory', async () => {
+      const context: ReviewContext = {
+        ...baseContext,
+        platform: 'gitlab',
+        projectPath: 'group/proj',
+        mergeRequestNumber: 5,
+        threads: [thread('disc-1')],
+        actions: [{ type: 'THREAD_RESOLVE', threadId: 'disc-1' }],
+      }
+
+      const result = await executeActionsFromContext(context, '/tmp/repo', mockLogger, mockExecutor)
+
+      expect(result.total).toBe(1)
+      expect(result.succeeded).toBe(1)
+      expect(mockExecutor).toHaveBeenCalledWith(
+        'glab',
+        expect.arrayContaining(['resolved=true']),
+        '/tmp/repo'
+      )
+    })
+
+    it('drops THREAD_RESOLVE whose threadId is not in the authenticated inventory (forged id)', async () => {
+      const context: ReviewContext = {
+        ...baseContext,
+        platform: 'gitlab',
+        threads: [thread('disc-1')],
+        actions: [{ type: 'THREAD_RESOLVE', threadId: 'forged-999' }],
+      }
+
+      const result = await executeActionsFromContext(context, '/tmp/repo', mockLogger, mockExecutor)
+
+      expect(result.total).toBe(0)
+      expect(mockExecutor).not.toHaveBeenCalled()
+    })
+
+    it('trims the threadId before checking inventory membership', async () => {
+      const context: ReviewContext = {
+        ...baseContext,
+        platform: 'gitlab',
+        threads: [thread('disc-1')],
+        actions: [{ type: 'THREAD_RESOLVE', threadId: 'disc-1 ' }],
+      }
+
+      const result = await executeActionsFromContext(context, '/tmp/repo', mockLogger, mockExecutor)
+
+      expect(result.succeeded).toBe(1)
+      const resolveArgs = mockExecutor.mock.calls[0][1] as string[]
+      const discussionArg = resolveArgs.find(arg => arg.includes('/discussions/'))
+      expect(discussionArg?.endsWith('discussions/disc-1')).toBe(true)
+      expect(resolveArgs).toContain('resolved=true')
+    })
+
+    it('posts the reply before resolving, then resolves the in-inventory thread', async () => {
+      const context: ReviewContext = {
+        ...baseContext,
+        platform: 'gitlab',
+        threads: [thread('disc-1')],
+        actions: [
+          { type: 'THREAD_RESOLVE', threadId: 'disc-1' },
+          { type: 'THREAD_REPLY', threadId: 'disc-1', message: 'Fixed' },
+        ],
+      }
+
+      const result = await executeActionsFromContext(context, '/tmp/repo', mockLogger, mockExecutor)
+
+      expect(result.total).toBe(2)
+      expect(result.succeeded).toBe(2)
+      const commands = mockExecutor.mock.calls.map((call) => (call[1] as string[]).join(' '))
+      const replyIndex = commands.findIndex((command) => command.includes('discussions/disc-1/notes'))
+      const resolveIndex = commands.findIndex((command) => command.includes('resolved=true'))
+      expect(replyIndex).toBeGreaterThanOrEqual(0)
+      expect(resolveIndex).toBeGreaterThan(replyIndex)
+    })
+  })
+
   it('continues executing when one allowed action fails', async () => {
     mockExecutor.mockImplementationOnce(() => {
       throw new Error('API error')


### PR DESCRIPTION
## Problem

Follow-up reviews did not resolve discussion threads, and GitHub replies landed outside threads.

**Root cause (confirmed in production logs)**: the auto-capability filter silently dropped every `THREAD_RESOLVE` before execution (`threadResolve` is `autoPath: false`) — `droppedTypes:["THREAD_RESOLVE"]` on each follow-up run. The constrained chokepoint that re-admits resolve was only wired to the deprecated stdout-marker path, never to the primary context-action path used by follow-up and both webhooks.

Separately on GitHub, `THREAD_REPLY` posted to the REST `…/comments/{id}/replies` endpoint (numeric comment id) while `get_threads` returns the GraphQL thread node id → replies failed / landed outside the thread.

## Fix

- **`contextActionsExecutor`** — re-admit `THREAD_RESOLVE` whose `threadId` belongs to `context.threads`, the authenticated inventory the LLM cannot mutate (it only appends to `actions` via MCP). Fail-closed on an empty inventory; forged / out-of-MR ids stay dropped. Fixes follow-up **and** both webhook primary paths.
- **`mrTrackingAdvanced.routes`** — route MCP follow-up actions through `executeActionsFromContext` so the gate applies; legacy stdout markers stay on the previous path.
- **`reviewAction.github.cli.gateway`** — `THREAD_REPLY` now uses the GraphQL `addPullRequestReviewThreadReply` mutation (thread node id), consistent with `resolveReviewThread`. Body is passed as a GraphQL variable (no manual escaping).

## Security

The re-admission is inventory-gated and fail-closed; it does **not** weaken the SPEC-196/198 trust model or change `constrainActionSurface`. Existing `executeActionsFromContext` tests (empty `threads`) stay green, preserving the AC6/AC7 "auto path blocks resolve" guarantee for the empty-inventory case.

## Tests

- RED-first: in-inventory resolve executes, forged id dropped, threadId trim, reply-before-resolve ordering, GitHub GraphQL reply.
- `yarn verify` green: typecheck + lint + 3652 tests.
- Local auto-review: **9/10** (0 blocking, 0 important).

🤖 Generated with [Claude Code](https://claude.com/claude-code)