### PR TITLE
feat(settings): expose trigger mode as a dashboard-editable runtime setting

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,4 +1,5 @@
 {
+  "triggerMode": "full-auto",
   "server": {
     "port": 3000
   },

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -27,6 +27,7 @@ The system uses two configuration files:
 
 ```json
 {
+  "triggerMode": "full-auto",
   "server": {
     "port": 3847
   },
@@ -52,6 +53,14 @@ The system uses two configuration files:
 ```
 
 ### Fields
+
+#### `triggerMode`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `triggerMode` | `"full-auto"` \| `"semi-auto"` | `"full-auto"` | When a review/follow-up is triggered. `full-auto` enqueues it immediately; `semi-auto` parks it as **pending** and waits for manual confirmation (dashboard or `POST /api/pending-reviews/:id/confirm`). |
+
+The value in `config.json` is the **boot default**. It can be changed at runtime from the dashboard (the `Trigger` chip); the dashboard choice is persisted to `~/.claude-review/settings.json` and takes effect immediately without a restart, overriding `config.json` from then on. A non-trusted actor is always parked regardless of mode (SPEC-197).
 
 #### `server`
 

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -76,6 +76,13 @@
             <option value="sonnet" id="i18n-model-sonnet"></option>
           </select>
         </div>
+        <div class="toolchain-chip toolchain-chip-model">
+          <span class="toolchain-chip-label" id="i18n-card-trigger-mode"></span>
+          <select id="trigger-mode-select" class="model-select" onchange="changeTriggerMode(this.value)">
+            <option value="full-auto" id="i18n-trigger-mode-full-auto"></option>
+            <option value="semi-auto" id="i18n-trigger-mode-semi-auto"></option>
+          </select>
+        </div>
       </div>
     </div>
 
@@ -2428,6 +2435,35 @@
       }
     }
 
+    async function loadTriggerModeSetting() {
+      try {
+        const response = await fetch(`${API_URL}/api/settings/triggerMode`);
+        const data = await response.json();
+        const select = document.getElementById('trigger-mode-select');
+        if (select && data.triggerMode) {
+          select.value = data.triggerMode;
+        }
+      } catch (error) {
+        console.error('Error loading trigger mode setting:', error);
+      }
+    }
+
+    async function changeTriggerMode(triggerMode) {
+      try {
+        const response = await fetch(`${API_URL}/api/settings/triggerMode`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ triggerMode })
+        });
+        const data = await response.json();
+        if (data.success) {
+          console.log('Trigger mode changed to:', triggerMode);
+        }
+      } catch (error) {
+        console.error('Error changing trigger mode:', error);
+      }
+    }
+
     async function loadLanguageSetting() {
       try {
         const response = await fetch(`${API_URL}/api/settings`);
@@ -3204,6 +3240,9 @@
       const cardModel = document.getElementById('i18n-card-model');
       if (cardModel) cardModel.textContent = t('card.model');
 
+      const cardTriggerMode = document.getElementById('i18n-card-trigger-mode');
+      if (cardTriggerMode) cardTriggerMode.textContent = t('card.triggerMode');
+
       const cardLanguage = document.getElementById('i18n-card-language');
       if (cardLanguage) cardLanguage.textContent = t('card.language');
 
@@ -3233,6 +3272,13 @@
 
       const modelSonnet = document.getElementById('i18n-model-sonnet');
       if (modelSonnet) modelSonnet.textContent = t('model.sonnet');
+
+      // Trigger mode options
+      const triggerModeFullAuto = document.getElementById('i18n-trigger-mode-full-auto');
+      if (triggerModeFullAuto) triggerModeFullAuto.textContent = t('triggerMode.fullAuto');
+
+      const triggerModeSemiAuto = document.getElementById('i18n-trigger-mode-semi-auto');
+      if (triggerModeSemiAuto) triggerModeSemiAuto.textContent = t('triggerMode.semiAuto');
 
       // Login sections
       const claudeLoginTitle = document.getElementById('i18n-claude-login-title');
@@ -3543,6 +3589,7 @@
     fetchStatus();
     checkClaudeStatus();
     loadModelSetting();
+    loadTriggerModeSetting();
     loadLanguageSetting();
     initOverviewAndTabs();
     refreshBudgetTile();

--- a/src/dashboard/modules/i18n.js
+++ b/src/dashboard/modules/i18n.js
@@ -26,6 +26,7 @@ const translations = {
     'card.completed': 'Completed',
     'card.claudeCli': 'Claude CLI',
     'card.model': 'Model',
+    'card.triggerMode': 'Trigger',
     'card.language': 'Language',
     'card.gitCli': 'Git CLI',
     'card.gitlabCli': 'GitLab CLI',
@@ -101,6 +102,10 @@ const translations = {
     // Model options
     'model.opus': 'Opus (powerful)',
     'model.sonnet': 'Sonnet (fast)',
+
+    // Trigger mode options
+    'triggerMode.fullAuto': 'Full auto',
+    'triggerMode.semiAuto': 'Semi auto (confirm)',
 
     // Status
     'status.connecting': 'Connecting...',
@@ -458,6 +463,7 @@ const translations = {
     'card.completed': 'Terminées',
     'card.claudeCli': 'Claude CLI',
     'card.model': 'Modèle',
+    'card.triggerMode': 'Déclenchement',
     'card.language': 'Langue',
     'card.gitCli': 'Git CLI',
     'card.gitlabCli': 'GitLab CLI',
@@ -533,6 +539,10 @@ const translations = {
     // Model options
     'model.opus': 'Opus (puissant)',
     'model.sonnet': 'Sonnet (rapide)',
+
+    // Trigger mode options
+    'triggerMode.fullAuto': 'Auto complet',
+    'triggerMode.semiAuto': 'Semi-auto (confirmation)',
 
     // Status
     'status.connecting': 'Connexion...',

--- a/src/frameworks/settings/runtimeSettings.ts
+++ b/src/frameworks/settings/runtimeSettings.ts
@@ -4,6 +4,10 @@ import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { z } from 'zod';
 import { languageSchema, type Language } from '@/modules/shared-kernel/entities/language/language.schema.js';
+import {
+  triggerModeSchema,
+  type TriggerMode,
+} from '@/modules/shared-kernel/entities/triggerMode/triggerMode.schema.js';
 
 export const claudeModelSchema = z.enum(['haiku', 'sonnet', 'opus']);
 export type ClaudeModel = z.infer<typeof claudeModelSchema>;
@@ -14,6 +18,7 @@ const runtimeSettingsSchema = z.object({
   language: languageSchema,
   model: claudeModelSchema,
   worktreeStaleThresholdHours: worktreeStaleThresholdHoursSchema.default(24),
+  triggerMode: triggerModeSchema.nullable().default(null),
 });
 
 type RuntimeSettings = z.infer<typeof runtimeSettingsSchema>;
@@ -26,6 +31,7 @@ const DEFAULT_SETTINGS: RuntimeSettings = {
   model: 'opus',
   language: 'en',
   worktreeStaleThresholdHours: 24,
+  triggerMode: null,
 };
 
 let settings: RuntimeSettings = { ...DEFAULT_SETTINGS };
@@ -137,6 +143,19 @@ export async function setWorktreeStaleThresholdHours(hours: number): Promise<voi
     throw new Error(`Invalid stale threshold (hours): ${hours}`);
   }
   settings.worktreeStaleThresholdHours = result.data;
+  await persistAsync();
+}
+
+export function getTriggerMode(): TriggerMode | null {
+  return settings.triggerMode;
+}
+
+export async function setTriggerMode(triggerMode: TriggerMode): Promise<void> {
+  const result = triggerModeSchema.safeParse(triggerMode);
+  if (!result.success) {
+    throw new Error(`Invalid trigger mode: ${triggerMode}`);
+  }
+  settings.triggerMode = result.data;
   await persistAsync();
 }
 

--- a/src/main/routes.ts
+++ b/src/main/routes.ts
@@ -119,7 +119,13 @@ import { SelfUpdateCliGateway } from '@/modules/cli-configuration/interface-adap
 import { InstallTypeDetectorFsGateway } from '@/modules/cli-configuration/interface-adapters/gateways/installTypeDetector.fs.gateway.js';
 import { broadcastBackfillProgress } from '@/main/websocket.js';
 import { AiInsightsSessionClaudeGateway } from '@/modules/statistics-insights/interface-adapters/gateways/aiInsightsSession.claude.gateway.js';
-import { getDefaultLanguage, getModel, getWorktreeStaleThresholdHours } from '@/frameworks/settings/runtimeSettings.js';
+import {
+  getDefaultLanguage,
+  getModel,
+  getTriggerMode,
+  getWorktreeStaleThresholdHours,
+  setTriggerMode,
+} from '@/frameworks/settings/runtimeSettings.js';
 import { detectDegradedWorktrees } from '@/modules/worktree-management/usecases/detectDegradedWorktrees.usecase.js';
 import type {
   RemoveResult,
@@ -271,8 +277,13 @@ export async function registerRoutes(
     },
     logger: deps.logger,
   });
+  // Seed the runtime-mutable trigger mode from config.json on first boot. From
+  // then on the dashboard setting is authoritative; config.json is the default.
+  if (getTriggerMode() === null) {
+    await setTriggerMode(deps.config.triggerMode);
+  }
   const gateClaudeInvocation = new GateClaudeInvocationUseCase({
-    triggerMode: deps.config.triggerMode,
+    getTriggerMode: () => getTriggerMode() ?? deps.config.triggerMode,
     pendingReviewRequestGateway,
     enqueue: enqueueReview,
     broadcastPendingChanged: () => broadcastPendingChanged(),

--- a/src/modules/cli-configuration/interface-adapters/controllers/http/settings.routes.ts
+++ b/src/modules/cli-configuration/interface-adapters/controllers/http/settings.routes.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import type { FastifyPluginAsync } from 'fastify';
 import {
   claudeModelSchema,
@@ -5,9 +6,14 @@ import {
   setModel,
   getDefaultLanguage,
   setDefaultLanguage,
+  getTriggerMode,
+  setTriggerMode,
   getSettings,
 } from '@/frameworks/settings/runtimeSettings.js';
 import { languageSchema } from '@/modules/shared-kernel/entities/language/language.schema.js';
+import { triggerModeSchema } from '@/modules/shared-kernel/entities/triggerMode/triggerMode.schema.js';
+
+const triggerModeRequestSchema = z.object({ triggerMode: triggerModeSchema });
 
 export const settingsRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.get('/api/settings', async () => {
@@ -42,5 +48,23 @@ export const settingsRoutes: FastifyPluginAsync = async (fastify) => {
 
     await setDefaultLanguage(parsed.data);
     return { success: true, language: getDefaultLanguage() };
+  });
+
+  fastify.get('/api/settings/triggerMode', async () => {
+    return { triggerMode: getTriggerMode() };
+  });
+
+  fastify.post('/api/settings/triggerMode', async (request, reply) => {
+    const parsed = triggerModeRequestSchema.safeParse(request.body);
+    if (!parsed.success) {
+      reply.code(400);
+      return {
+        success: false,
+        error: `Invalid trigger mode. Use: ${triggerModeSchema.options.join(', ')}`,
+      };
+    }
+
+    await setTriggerMode(parsed.data.triggerMode);
+    return { success: true, triggerMode: getTriggerMode() };
   });
 };

--- a/src/modules/review-execution/usecases/gateClaudeInvocation.usecase.ts
+++ b/src/modules/review-execution/usecases/gateClaudeInvocation.usecase.ts
@@ -6,8 +6,9 @@ import type {
   PendingReviewRequest,
   TriggerSource,
 } from '@/modules/review-execution/entities/pendingReviewRequest/pendingReviewRequest.schema.js';
+import type { TriggerMode } from '@/modules/shared-kernel/entities/triggerMode/triggerMode.schema.js';
 
-export type TriggerMode = 'full-auto' | 'semi-auto';
+export type { TriggerMode };
 
 export type GateClaudeInvocationProcessor = (
   job: ReviewJob,
@@ -20,7 +21,7 @@ export type EnqueueReviewFunction = (
 ) => Promise<boolean>;
 
 export interface GateClaudeInvocationDependencies {
-  triggerMode: TriggerMode;
+  getTriggerMode: () => TriggerMode;
   pendingReviewRequestGateway: PendingReviewRequestGateway;
   enqueue: EnqueueReviewFunction;
   broadcastPendingChanged: (pending: PendingReviewRequest) => void;
@@ -53,8 +54,9 @@ export class GateClaudeInvocationUseCase {
   constructor(private readonly deps: GateClaudeInvocationDependencies) {}
 
   async execute(input: GateClaudeInvocationInput): Promise<GateClaudeInvocationResult> {
-    const { triggerMode, pendingReviewRequestGateway, enqueue, broadcastPendingChanged, logger } = this.deps;
+    const { getTriggerMode, pendingReviewRequestGateway, enqueue, broadcastPendingChanged, logger } = this.deps;
 
+    const triggerMode = getTriggerMode();
     const actorParks = input.actorTrusted === false;
 
     if (triggerMode === 'full-auto' && !actorParks) {

--- a/src/modules/shared-kernel/entities/triggerMode/triggerMode.schema.ts
+++ b/src/modules/shared-kernel/entities/triggerMode/triggerMode.schema.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const triggerModeSchema = z.enum(['full-auto', 'semi-auto']);
+
+export type TriggerMode = z.infer<typeof triggerModeSchema>;

--- a/src/tests/acceptance/174-semi-auto-review-trigger-mode.acceptance.test.ts
+++ b/src/tests/acceptance/174-semi-auto-review-trigger-mode.acceptance.test.ts
@@ -64,7 +64,7 @@ describe('Acceptance — SPEC-174: Semi-automatic review trigger mode', () => {
   describe('Rule: semi-auto initial review parks the job instead of invoking Claude', () => {
     it('produces a persisted pending review and never invokes Claude', async () => {
       const useCase = new GateClaudeInvocationUseCase({
-        triggerMode: 'semi-auto',
+        getTriggerMode: () => 'semi-auto',
         pendingReviewRequestGateway: gateway,
         enqueue: fakeEnqueue,
         broadcastPendingChanged: () => {},
@@ -95,7 +95,7 @@ describe('Acceptance — SPEC-174: Semi-automatic review trigger mode', () => {
   describe('Rule: confirming a pending job invokes Claude exactly once', () => {
     it('confirms then enqueues + invokes Claude + deletes the pending file', async () => {
       const gateUseCase = new GateClaudeInvocationUseCase({
-        triggerMode: 'semi-auto',
+        getTriggerMode: () => 'semi-auto',
         pendingReviewRequestGateway: gateway,
         enqueue: fakeEnqueue,
         broadcastPendingChanged: () => {},
@@ -132,7 +132,7 @@ describe('Acceptance — SPEC-174: Semi-automatic review trigger mode', () => {
   describe('Rule: dismissing a pending job removes it without invoking Claude', () => {
     it('dismisses then deletes the pending file and never invokes Claude', async () => {
       const gateUseCase = new GateClaudeInvocationUseCase({
-        triggerMode: 'semi-auto',
+        getTriggerMode: () => 'semi-auto',
         pendingReviewRequestGateway: gateway,
         enqueue: fakeEnqueue,
         broadcastPendingChanged: () => {},

--- a/src/tests/units/frameworks/settings/runtimeSettings.test.ts
+++ b/src/tests/units/frameworks/settings/runtimeSettings.test.ts
@@ -10,10 +10,13 @@ import {
   setDefaultLanguage,
   getModel,
   setModel,
+  getTriggerMode,
+  setTriggerMode,
   getSettings,
   __resetForTestsOnly,
   type ClaudeModel,
 } from '@/frameworks/settings/runtimeSettings.js';
+import type { TriggerMode } from '@/modules/shared-kernel/entities/triggerMode/triggerMode.schema.js';
 
 describe('runtimeSettings', () => {
   describe('in-memory API (no path configured)', () => {
@@ -67,7 +70,12 @@ describe('runtimeSettings', () => {
 
         expect(existsSync(settingsPath)).toBe(true);
         const written = JSON.parse(readFileSync(settingsPath, 'utf-8'));
-        expect(written).toEqual({ language: 'en', model: 'opus', worktreeStaleThresholdHours: 24 });
+        expect(written).toEqual({
+          language: 'en',
+          model: 'opus',
+          worktreeStaleThresholdHours: 24,
+          triggerMode: null,
+        });
       });
 
       it('falls back to defaults silently when file is malformed JSON', async () => {
@@ -143,7 +151,69 @@ describe('runtimeSettings', () => {
         await Promise.all([setModel('sonnet'), setDefaultLanguage('fr')]);
 
         const written = JSON.parse(readFileSync(settingsPath, 'utf-8'));
-        expect(written).toEqual({ language: 'fr', model: 'sonnet', worktreeStaleThresholdHours: 24 });
+        expect(written).toEqual({
+          language: 'fr',
+          model: 'sonnet',
+          worktreeStaleThresholdHours: 24,
+          triggerMode: null,
+        });
+      });
+    });
+
+    describe('triggerMode', () => {
+      it('defaults to null when no settings file exists', async () => {
+        await loadSettingsFromDisk();
+
+        expect(getTriggerMode()).toBeNull();
+      });
+
+      it('restores triggerMode from an existing file', async () => {
+        writeFileSync(
+          settingsPath,
+          JSON.stringify({ language: 'en', model: 'opus', triggerMode: 'semi-auto' }),
+        );
+
+        await loadSettingsFromDisk();
+
+        expect(getTriggerMode()).toBe('semi-auto');
+      });
+
+      it('falls back to null when the persisted trigger mode is unknown', async () => {
+        writeFileSync(
+          settingsPath,
+          JSON.stringify({ language: 'en', model: 'opus', triggerMode: 'manual' }),
+        );
+
+        await loadSettingsFromDisk();
+
+        expect(getTriggerMode()).toBeNull();
+      });
+
+      it('persists triggerMode to disk after setTriggerMode', async () => {
+        await loadSettingsFromDisk();
+
+        await setTriggerMode('semi-auto');
+
+        const written = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+        expect(written.triggerMode).toBe('semi-auto');
+        expect(getTriggerMode()).toBe('semi-auto');
+      });
+
+      it('survives a simulated process restart', async () => {
+        await loadSettingsFromDisk();
+        await setTriggerMode('semi-auto');
+
+        __resetForTestsOnly();
+        configureSettingsPath(settingsPath);
+        await loadSettingsFromDisk();
+
+        expect(getTriggerMode()).toBe('semi-auto');
+      });
+
+      it('throws when setTriggerMode receives an unknown trigger mode', async () => {
+        await loadSettingsFromDisk();
+
+        await expect(setTriggerMode('manual' as TriggerMode)).rejects.toThrow(/Invalid trigger mode/);
       });
     });
 

--- a/src/tests/units/interface-adapters/controllers/http/settings.routes.test.ts
+++ b/src/tests/units/interface-adapters/controllers/http/settings.routes.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import Fastify from 'fastify'
 import type { FastifyInstance } from 'fastify'
 import { settingsRoutes } from '@/modules/cli-configuration/interface-adapters/controllers/http/settings.routes.js'
-import { setModel } from '@/frameworks/settings/runtimeSettings.js'
+import { setModel, setTriggerMode } from '@/frameworks/settings/runtimeSettings.js'
 
 describe('settings routes', () => {
   let application: FastifyInstance
@@ -25,6 +25,48 @@ describe('settings routes', () => {
       const body = JSON.parse(response.body)
       expect(response.statusCode).toBe(200)
       expect(body.model).toBe('sonnet')
+    })
+  })
+
+  describe('GET /api/settings/triggerMode', () => {
+    it('should return the current trigger mode', async () => {
+      await setTriggerMode('semi-auto')
+
+      const response = await application.inject({
+        method: 'GET',
+        url: '/api/settings/triggerMode',
+      })
+
+      const body = JSON.parse(response.body)
+      expect(response.statusCode).toBe(200)
+      expect(body.triggerMode).toBe('semi-auto')
+    })
+  })
+
+  describe('POST /api/settings/triggerMode', () => {
+    it('should persist a valid trigger mode', async () => {
+      const response = await application.inject({
+        method: 'POST',
+        url: '/api/settings/triggerMode',
+        payload: { triggerMode: 'full-auto' },
+      })
+
+      const body = JSON.parse(response.body)
+      expect(response.statusCode).toBe(200)
+      expect(body.success).toBe(true)
+      expect(body.triggerMode).toBe('full-auto')
+    })
+
+    it('should reject an unknown trigger mode with 400', async () => {
+      const response = await application.inject({
+        method: 'POST',
+        url: '/api/settings/triggerMode',
+        payload: { triggerMode: 'manual' },
+      })
+
+      const body = JSON.parse(response.body)
+      expect(response.statusCode).toBe(400)
+      expect(body.success).toBe(false)
     })
   })
 })

--- a/src/tests/units/interface-adapters/controllers/webhook/gitlab.controller.test.ts
+++ b/src/tests/units/interface-adapters/controllers/webhook/gitlab.controller.test.ts
@@ -554,7 +554,7 @@ describe('handleGitLabWebhook', () => {
       pendingGateway: StubPendingReviewRequestGateway,
     ) {
       const gateClaudeInvocation = new GateClaudeInvocationUseCase({
-        triggerMode: 'full-auto',
+        getTriggerMode: () => 'full-auto',
         pendingReviewRequestGateway: pendingGateway,
         enqueue: enqueueReview,
         broadcastPendingChanged: () => {},

--- a/src/tests/units/modules/review-execution/usecases/gateClaudeInvocation.usecase.test.ts
+++ b/src/tests/units/modules/review-execution/usecases/gateClaudeInvocation.usecase.test.ts
@@ -50,7 +50,7 @@ describe('GateClaudeInvocationUseCase', () => {
   describe('Rule: full-auto delegates directly to enqueue', () => {
     it('returns enqueued status and invokes the processor', async () => {
       const useCase = new GateClaudeInvocationUseCase({
-        triggerMode: 'full-auto',
+        getTriggerMode: () => 'full-auto',
         pendingReviewRequestGateway: gateway,
         enqueue: enqueueSuccess,
         broadcastPendingChanged: () => {},
@@ -71,7 +71,7 @@ describe('GateClaudeInvocationUseCase', () => {
     it('returns rejected status when enqueue refuses the job', async () => {
       const enqueueRejects = async (): Promise<boolean> => false;
       const useCase = new GateClaudeInvocationUseCase({
-        triggerMode: 'full-auto',
+        getTriggerMode: () => 'full-auto',
         pendingReviewRequestGateway: gateway,
         enqueue: enqueueRejects,
         broadcastPendingChanged: () => {},
@@ -91,7 +91,7 @@ describe('GateClaudeInvocationUseCase', () => {
   describe('Rule: semi-auto persists a pending request and skips enqueue', () => {
     it('saves the pending request and never calls enqueue', async () => {
       const useCase = new GateClaudeInvocationUseCase({
-        triggerMode: 'semi-auto',
+        getTriggerMode: () => 'semi-auto',
         pendingReviewRequestGateway: gateway,
         enqueue: enqueueSuccess,
         broadcastPendingChanged: () => {
@@ -115,7 +115,7 @@ describe('GateClaudeInvocationUseCase', () => {
 
     it('persists followup job type when triggered from webhook-followup source', async () => {
       const useCase = new GateClaudeInvocationUseCase({
-        triggerMode: 'semi-auto',
+        getTriggerMode: () => 'semi-auto',
         pendingReviewRequestGateway: gateway,
         enqueue: enqueueSuccess,
         broadcastPendingChanged: () => {},
@@ -136,7 +136,7 @@ describe('GateClaudeInvocationUseCase', () => {
 
     it('full-auto followup is unchanged: delegates to enqueue and invokes Claude', async () => {
       const useCase = new GateClaudeInvocationUseCase({
-        triggerMode: 'full-auto',
+        getTriggerMode: () => 'full-auto',
         pendingReviewRequestGateway: gateway,
         enqueue: enqueueSuccess,
         broadcastPendingChanged: () => {},
@@ -155,10 +155,41 @@ describe('GateClaudeInvocationUseCase', () => {
     });
   });
 
+  describe('Rule: trigger mode is read live on every gate (runtime-mutable)', () => {
+    it('reflects a trigger-mode change between two executions without reconstruction', async () => {
+      let mode: 'full-auto' | 'semi-auto' = 'semi-auto';
+      const useCase = new GateClaudeInvocationUseCase({
+        getTriggerMode: () => mode,
+        pendingReviewRequestGateway: gateway,
+        enqueue: enqueueSuccess,
+        broadcastPendingChanged: () => {},
+        logger,
+      });
+
+      const first = await useCase.execute({
+        job: buildReviewJob(),
+        triggerSource: 'webhook-initial',
+        processor,
+      });
+      expect(first.status).toBe('pending');
+      expect(enqueueCalls).toHaveLength(0);
+
+      mode = 'full-auto';
+
+      const second = await useCase.execute({
+        job: buildReviewJob(),
+        triggerSource: 'webhook-initial',
+        processor,
+      });
+      expect(second.status).toBe('enqueued');
+      expect(enqueueCalls).toHaveLength(1);
+    });
+  });
+
   describe('Rule: a non-trusted actor parks pending even in full-auto (SPEC-197)', () => {
     it('parks the job and never enqueues when actorTrusted is false', async () => {
       const useCase = new GateClaudeInvocationUseCase({
-        triggerMode: 'full-auto',
+        getTriggerMode: () => 'full-auto',
         pendingReviewRequestGateway: gateway,
         enqueue: enqueueSuccess,
         broadcastPendingChanged: () => {
@@ -183,7 +214,7 @@ describe('GateClaudeInvocationUseCase', () => {
 
     it('enqueues normally in full-auto when actorTrusted is true', async () => {
       const useCase = new GateClaudeInvocationUseCase({
-        triggerMode: 'full-auto',
+        getTriggerMode: () => 'full-auto',
         pendingReviewRequestGateway: gateway,
         enqueue: enqueueSuccess,
         broadcastPendingChanged: () => {},

--- a/src/tests/units/modules/shared-kernel/entities/triggerMode/triggerMode.schema.test.ts
+++ b/src/tests/units/modules/shared-kernel/entities/triggerMode/triggerMode.schema.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { triggerModeSchema } from '@/modules/shared-kernel/entities/triggerMode/triggerMode.schema.js';
+
+describe('triggerModeSchema', () => {
+  it('accepts full-auto', () => {
+    expect(triggerModeSchema.parse('full-auto')).toBe('full-auto');
+  });
+
+  it('accepts semi-auto', () => {
+    expect(triggerModeSchema.parse('semi-auto')).toBe('semi-auto');
+  });
+
+  it('rejects an unknown trigger mode', () => {
+    expect(triggerModeSchema.safeParse('manual').success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Context

Extends **SPEC-174** (semi-auto review trigger mode). `triggerMode` (`full-auto` | `semi-auto`) was only readable from `config.json` and **frozen at boot** — changing it required editing the file and restarting the service. Reviews/follow-ups silently auto-launched whenever the key was absent (defaults to `full-auto`).

## What this does

Makes `triggerMode` a first-class, **runtime-mutable** setting:

- **Documented** — added to `docs/reference/config.md` and `config.example.json`.
- **Dashboard-editable** — a new `Trigger` chip (Full auto / Semi auto), mirroring the existing model selector, with `en`/`fr` i18n.
- **Runtime-mutable** — the gate reads `getTriggerMode()` live on every review, so a dashboard change takes effect **immediately, no restart** (same reloadable pattern as `currentGitlabWebhookToken()`).

`config.json` stays the **boot default**: on first boot it seeds `~/.claude-review/settings.json`; the dashboard override wins thereafter. A non-trusted actor is still always parked (SPEC-197).

## Changes

| Layer | Change |
|-------|--------|
| Entity | `TriggerMode` moved to `shared-kernel/entities` (shared by settings, cli-configuration, review-execution — no cross-context coupling) |
| Framework | `runtimeSettings`: nullable `triggerMode` + `getTriggerMode`/`setTriggerMode`, persisted atomically |
| Use case | `GateClaudeInvocationUseCase` depends on an injected `getTriggerMode: () => TriggerMode` (DIP) instead of a captured value |
| Controller | `GET`/`POST /api/settings/triggerMode` (Zod-validated body, 400 on invalid) |
| Composition root | seed config → runtime on first boot; gate getter resolves `runtime ?? config` |
| Dashboard | `Trigger` chip + `load/change` functions + i18n |
| Docs | config reference + example |

## Tests

- `triggerModeSchema` guard (3)
- `runtimeSettings` triggerMode: default null, restore, fallback, persist, restart, invalid throws (6)
- Gate: migrated to getter + new **runtime-mutability** test (mode flips between two executions)
- Routes: GET, POST valid, POST invalid (3)
- `yarn verify` ✅ 3665 tests, typecheck, lint
- `yarn coverage` ✅ 85% st / 80.9% br / 80.2% fn / 85.3% ln (above 80% gate)

## Self-review

`/auto-review` → **9/10**, no blocking. Report at `.claude/reviews/2026-06-02-auto-review.md` (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)