### PR TITLE
feat(platform-integration): pin followup thread-fetch target (SPEC-196)

### DIFF
--- a/src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts
+++ b/src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts
@@ -34,7 +34,10 @@ import {
   filterGitLabNoteEvent,
 } from '@/modules/platform-integration/interface-adapters/controllers/webhook/eventFilter.js';
 import { defaultGitLabExecutor } from '@/modules/platform-integration/interface-adapters/gateways/threadFetch.gitlab.gateway.js';
-import { resolvePinnedThreadFetchTarget } from '@/modules/platform-integration/services/pinnedThreadFetchTarget.js';
+import {
+  resolvePinnedThreadFetchTarget,
+  resolvePinnedThreads,
+} from '@/modules/platform-integration/services/pinnedThreadFetchTarget.js';
 import type { IsTrustedActorUseCase } from '@/modules/platform-integration/usecases/isTrustedActor.usecase.js';
 import { resolveProvenance } from '@/modules/review-execution/entities/actionProvenance/actionProvenance.js';
 import type { ReviewJob } from '@/modules/review-execution/entities/job/reviewJob.js';
@@ -630,7 +633,18 @@ export async function handleGitLabWebhook(
             const diffMetadataFetchGw = deps.diffMetadataFetchGateway;
 
             try {
-              const threads = threadFetchGw.fetchThreads(j.projectPath, j.mrNumber);
+              const threads = resolvePinnedThreads({
+                payloadProjectPath: j.projectPath,
+                payloadMrNumber: j.mrNumber,
+                findRepository: (projectPath) => {
+                  const matched = findRepositoryByProjectPath(projectPath);
+                  return matched ? { projectPath } : null;
+                },
+                gatedMrNumber: j.mrNumber,
+                fetchThreads: (projectPath, mrNumber) =>
+                  threadFetchGw.fetchThreads(projectPath, mrNumber),
+                logger,
+              });
               let diffMetadata: DiffMetadata | undefined;
               try {
                 diffMetadata = diffMetadataFetchGw.fetchDiffMetadata(j.projectPath, j.mrNumber);

--- a/src/modules/platform-integration/services/pinnedThreadFetchTarget.ts
+++ b/src/modules/platform-integration/services/pinnedThreadFetchTarget.ts
@@ -1,3 +1,5 @@
+import type { ReviewContextThread } from '@/modules/review-execution/entities/reviewContext/reviewContext.js';
+
 export interface PinnedThreadFetchTarget {
   projectPath: string;
   mrNumber: number;
@@ -17,9 +19,15 @@ export interface ResolvePinnedThreadFetchTargetInput {
 /**
  * Anchors the (projectPath, mrNumber) pair driving fetchThreads to a server-validated
  * source (AC9). The forgeable webhook payload is never used as-is to widen scope:
- * - projectPath MUST resolve to a configured repository.
+ * - projectPath MUST resolve to a configured repository (live, enforced today).
  * - mrNumber MUST equal the merge-request that passed the upstream trusted-actor gate.
  * If either cannot be established, the action surface is empty (null, fail-closed).
+ *
+ * AC9 placeholder: the SPEC-197 trusted-actor gate currently validates {username, projectPath}
+ * and carries no distinct server-validated MR identity, so callers pass gatedMrNumber = the
+ * payload mrNumber and the equality check is a structural no-op until a gated-MR id is threaded
+ * through ReviewJob. The true MR pin lands with SPEC-197; the project-recognition half is the
+ * live fail-closed guard today. See docs/specs/196 AC9.
  */
 export function resolvePinnedThreadFetchTarget(
   input: ResolvePinnedThreadFetchTargetInput,
@@ -37,4 +45,32 @@ export function resolvePinnedThreadFetchTarget(
     projectPath: repository.projectPath,
     mrNumber: input.gatedMrNumber,
   };
+}
+
+interface PinLogger {
+  warn(obj: object, message: string): void;
+}
+
+export interface ResolvePinnedThreadsInput extends ResolvePinnedThreadFetchTargetInput {
+  fetchThreads: (projectPath: string, mergeRequestNumber: number) => ReviewContextThread[];
+  logger: PinLogger;
+}
+
+/**
+ * Fetches the MR thread inventory through the AC9 provenance pin. The forgeable payload
+ * is never used to drive fetchThreads directly: when the (projectPath, mrNumber) pair
+ * cannot be pinned to a server-validated source, the action surface is empty (fail-closed,
+ * no fetch). Shared by the review and followup processors so both close the same hole.
+ */
+export function resolvePinnedThreads(input: ResolvePinnedThreadsInput): ReviewContextThread[] {
+  const pinnedTarget = resolvePinnedThreadFetchTarget(input);
+  if (!pinnedTarget) {
+    input.logger.warn(
+      { projectPath: input.payloadProjectPath, mrNumber: input.payloadMrNumber },
+      'Thread-fetch target failed provenance pin; action surface is empty',
+    );
+    return [];
+  }
+
+  return input.fetchThreads(pinnedTarget.projectPath, pinnedTarget.mrNumber);
 }

--- a/src/tests/acceptance/196-least-privilege-platform-token.acceptance.test.ts
+++ b/src/tests/acceptance/196-least-privilege-platform-token.acceptance.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  AUTO_EXECUTOR_CAPABILITIES,
+  EXECUTOR_CAPABILITY_TABLE,
+} from '@/modules/platform-integration/entities/executorToken/executorCapability.js';
+import {
+  resolvePinnedThreadFetchTarget,
+  resolvePinnedThreads,
+} from '@/modules/platform-integration/services/pinnedThreadFetchTarget.js';
+import {
+  buildScopedExecutorEnvironment,
+  ENV_ALLOWLIST,
+  MissingExecutorTokenError,
+} from '@/modules/platform-integration/services/scopedExecutorEnvironment.js';
+import type { ReviewAction } from '@/modules/review-execution/entities/reviewAction/reviewAction.js';
+import type { ReviewContext } from '@/modules/review-execution/entities/reviewContext/reviewContext.js';
+import type {
+  ThreadInventoryGateway,
+  ThreadInventoryPage,
+} from '@/modules/review-execution/entities/threadInventory/threadInventory.gateway.js';
+import { executeActionsFromContext } from '@/modules/review-execution/services/contextActionsExecutor.js';
+import { dispatchConstrainedActions } from '@/modules/review-execution/services/dispatchConstrainedActions.js';
+
+const TOKEN = 'glpat-service-token-acceptance';
+const TEMP_ROOT = '/tmp/reviewflow-executor-acceptance';
+
+class RecordingFileWriter {
+  public readonly writes: Array<{ path: string; contents: string }> = [];
+  public readonly ensuredDirs: string[] = [];
+  write(path: string, contents: string): void {
+    this.writes.push({ path, contents });
+  }
+  ensureDir(path: string): void {
+    this.ensuredDirs.push(path);
+  }
+}
+
+class RecordingExecutor {
+  readonly calls: Array<{ command: string; args: string[] }> = [];
+  run = (command: string, args: string[]): void => {
+    this.calls.push({ command, args });
+  };
+}
+
+class RecordingCliExecutor {
+  readonly commands: string[] = [];
+  run = (command: string): string => {
+    this.commands.push(command);
+    return '';
+  };
+}
+
+class RecordingPostGateway {
+  readonly posts: Array<{ projectPath: string; mrNumber: number; body: string }> = [];
+  postComment = async (input: {
+    projectPath: string;
+    mrNumber: number;
+    body: string;
+  }): Promise<void> => {
+    this.posts.push(input);
+  };
+}
+
+class RecordingThreadFetch {
+  public readonly calls: Array<{ projectPath: string; mrNumber: number }> = [];
+  fetchThreads = (projectPath: string, mrNumber: number) => {
+    this.calls.push({ projectPath, mrNumber });
+    return [];
+  };
+}
+
+class StubInventoryGateway implements ThreadInventoryGateway {
+  private pages: ThreadInventoryPage[] = [];
+  setPages(pages: ThreadInventoryPage[]): void {
+    this.pages = pages;
+  }
+  fetchPage(_projectPath: string, _mergeRequestNumber: number, page: number): ThreadInventoryPage {
+    const found = this.pages.find((candidate) => candidate.page === page);
+    if (!found) throw new Error(`no page ${page}`);
+    return found;
+  }
+}
+
+class RecordingLogger {
+  readonly warnings: string[] = [];
+  readonly errors: string[] = [];
+  info(): void {}
+  warn(_obj: object, message: string): void {
+    this.warnings.push(message);
+  }
+  debug(): void {}
+  error(_obj: object, message: string): void {
+    this.errors.push(message);
+  }
+}
+
+const dispatchContext = {
+  platform: 'gitlab' as const,
+  projectPath: 'group/project',
+  mrNumber: 42,
+  localPath: '/tmp/repo',
+};
+
+function resolveDiscussionWrites(
+  executor: RecordingExecutor,
+): Array<{ command: string; args: string[] }> {
+  return executor.calls.filter(
+    (call) => call.args.includes('PUT') && call.args.some((arg) => arg.includes('/discussions/')),
+  );
+}
+
+function buildContextWith(actions: ReviewAction[], threadIds: string[]): ReviewContext {
+  return {
+    version: '1',
+    mergeRequestId: 'gitlab-group/project-42',
+    platform: 'gitlab',
+    projectPath: 'group/project',
+    mergeRequestNumber: 42,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    threads: threadIds.map((id) => ({
+      id,
+      file: null,
+      line: null,
+      status: 'open',
+      body: 'thread',
+    })),
+    actions,
+    progress: { phase: 'completed', currentStep: null },
+  };
+}
+
+describe('SPEC-196 least-privilege platform token (acceptance)', () => {
+  describe('AC1 — dedicated service token, fail-closed', () => {
+    it('refuses to construct the executor environment when the token is absent (zero file writes)', () => {
+      const fileWriter = new RecordingFileWriter();
+      expect(() =>
+        buildScopedExecutorEnvironment({
+          parentEnv: { PATH: '/usr/bin' },
+          isolatedDir: TEMP_ROOT,
+          fileWriter,
+        }),
+      ).toThrow(MissingExecutorTokenError);
+      expect(fileWriter.writes).toHaveLength(0);
+      expect(fileWriter.ensuredDirs).toHaveLength(0);
+    });
+  });
+
+  describe('AC2/AC3 — env built by allowlist, token never in env', () => {
+    it('keeps the child env keyset within the allowlist, drops the canary, and never carries the token', () => {
+      const fileWriter = new RecordingFileWriter();
+      const { env } = buildScopedExecutorEnvironment({
+        parentEnv: {
+          REVIEWFLOW_EXECUTOR_TOKEN: TOKEN,
+          PATH: '/usr/bin',
+          LANG: 'en_US.UTF-8',
+          AMBIENT_ADMIN_TOKEN: 'canary',
+        },
+        isolatedDir: TEMP_ROOT,
+        fileWriter,
+      });
+
+      for (const key of Object.keys(env)) {
+        expect(ENV_ALLOWLIST).toContain(key);
+      }
+      expect('AMBIENT_ADMIN_TOKEN' in env).toBe(false);
+      for (const value of Object.values(env)) {
+        expect(value).not.toBe(TOKEN);
+      }
+      expect(fileWriter.writes[0]?.contents).toContain(TOKEN);
+      expect(fileWriter.writes[0]?.path.startsWith(TEMP_ROOT)).toBe(true);
+    });
+  });
+
+  describe('AC5 — minimal role frozen per action', () => {
+    it('locks the auto-executor capability set to exactly {readMr, postComment}', () => {
+      expect([...AUTO_EXECUTOR_CAPABILITIES].toSorted()).toEqual(['postComment', 'readMr']);
+      expect(EXECUTOR_CAPABILITY_TABLE.threadResolve.autoPath).toBe(false);
+      expect(EXECUTOR_CAPABILITY_TABLE.revoke.autoPath).toBe(false);
+    });
+  });
+
+  describe('AC6/AC7 — removed write verbs are inert, postComment still fires', () => {
+    it('through the stdout chokepoint: postComment fires once, THREAD_RESOLVE records zero write calls, no throw', async () => {
+      const executor = new RecordingExecutor();
+      const postGateway = new RecordingPostGateway();
+      const inventory = new StubInventoryGateway();
+      inventory.setPages([{ page: 1, totalPages: 1, threadIds: ['10'] }]);
+
+      const actions: ReviewAction[] = [
+        { type: 'POST_COMMENT', body: 'review summary' },
+        { type: 'THREAD_RESOLVE', threadId: '10' },
+        { type: 'FETCH_THREADS' },
+      ];
+
+      await dispatchConstrainedActions(actions, {
+        context: dispatchContext,
+        provenance: 'untrusted',
+        inventoryGateway: inventory,
+        logger: new RecordingLogger(),
+        executor: executor.run,
+        postGateway,
+      });
+
+      expect(postGateway.posts).toHaveLength(1);
+      expect(postGateway.posts[0]?.body).toBe('review summary');
+      expect(resolveDiscussionWrites(executor)).toHaveLength(0);
+    });
+
+    it('through the context-file path: a THREAD_RESOLVE on an empty authenticated inventory records zero write calls', async () => {
+      const executor = new RecordingCliExecutor();
+      const context = buildContextWith([{ type: 'THREAD_RESOLVE', threadId: '10' }], []);
+
+      await executeActionsFromContext(context, '/tmp/repo', new RecordingLogger(), executor.run);
+
+      expect(executor.commands).toHaveLength(0);
+    });
+  });
+
+  describe('AC9 — action-target identity pinned to trusted provenance, fail-closed', () => {
+    it('an unrecognized projectPath resolves to no target (fail-closed)', () => {
+      const target = resolvePinnedThreadFetchTarget({
+        payloadProjectPath: 'attacker/unknown',
+        payloadMrNumber: 5,
+        findRepository: () => null,
+        gatedMrNumber: 5,
+      });
+      expect(target).toBeNull();
+    });
+
+    it('the followup path never calls fetchThreads for an unrecognized project (empty action surface)', () => {
+      const fetch = new RecordingThreadFetch();
+      const logger = new RecordingLogger();
+
+      const threads = resolvePinnedThreads({
+        payloadProjectPath: 'attacker/unknown',
+        payloadMrNumber: 5,
+        findRepository: () => null,
+        gatedMrNumber: 5,
+        fetchThreads: fetch.fetchThreads,
+        logger,
+      });
+
+      expect(threads).toEqual([]);
+      expect(fetch.calls).toHaveLength(0);
+    });
+  });
+});

--- a/src/tests/units/modules/platform-integration/services/pinnedThreadFetchTarget.test.ts
+++ b/src/tests/units/modules/platform-integration/services/pinnedThreadFetchTarget.test.ts
@@ -1,12 +1,27 @@
 import { describe, it, expect } from 'vitest';
 
-import { resolvePinnedThreadFetchTarget } from '@/modules/platform-integration/services/pinnedThreadFetchTarget.js';
+import {
+  resolvePinnedThreadFetchTarget,
+  resolvePinnedThreads,
+} from '@/modules/platform-integration/services/pinnedThreadFetchTarget.js';
+import type { ReviewContextThread } from '@/modules/review-execution/entities/reviewContext/reviewContext.js';
 
 class RecordingThreadFetch {
   public readonly calls: Array<{ projectPath: string; mrNumber: number }> = [];
+  private result: ReviewContextThread[] = [];
+  setResult(threads: ReviewContextThread[]): void {
+    this.result = threads;
+  }
   fetchThreads = (projectPath: string, mrNumber: number) => {
     this.calls.push({ projectPath, mrNumber });
-    return [];
+    return this.result;
+  };
+}
+
+class RecordingLogger {
+  public readonly warnings: string[] = [];
+  warn = (_obj: object, message: string): void => {
+    this.warnings.push(message);
   };
 }
 
@@ -82,5 +97,44 @@ describe('pinned thread-fetch target provenance (AC9)', () => {
     if (target) fetch.fetchThreads(target.projectPath, target.mrNumber);
 
     expect(fetch.calls).toEqual([{ projectPath: 'group/proj-canonical', mrNumber: 5 }]);
+  });
+});
+
+describe('pinned thread resolution at a call site (AC9 — used by review + followup processors)', () => {
+  it('fetches threads through the pinned target when the project is configured', () => {
+    const fetch = new RecordingThreadFetch();
+    fetch.setResult([{ id: '1', file: null, line: null, status: 'open', body: 'thread' }]);
+    const logger = new RecordingLogger();
+
+    const threads = resolvePinnedThreads({
+      payloadProjectPath: 'group/proj',
+      payloadMrNumber: 5,
+      findRepository: () => ({ projectPath: 'group/proj' }),
+      gatedMrNumber: 5,
+      fetchThreads: fetch.fetchThreads,
+      logger,
+    });
+
+    expect(threads).toHaveLength(1);
+    expect(fetch.calls).toEqual([{ projectPath: 'group/proj', mrNumber: 5 }]);
+    expect(logger.warnings).toHaveLength(0);
+  });
+
+  it('fails closed to an empty surface and never calls fetchThreads for an unrecognized project', () => {
+    const fetch = new RecordingThreadFetch();
+    const logger = new RecordingLogger();
+
+    const threads = resolvePinnedThreads({
+      payloadProjectPath: 'attacker/unknown',
+      payloadMrNumber: 5,
+      findRepository: () => null,
+      gatedMrNumber: 5,
+      fetchThreads: fetch.fetchThreads,
+      logger,
+    });
+
+    expect(threads).toEqual([]);
+    expect(fetch.calls).toHaveLength(0);
+    expect(logger.warnings).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Closes the AC9 followup gap for SPEC-196 (least-privilege executor): the followup processor's thread-fetch now routes through `resolvePinnedThreads` (live project recognition, fail-closed to empty on unrecognized project), matching the review path.

Adds the SPEC-196 SDD acceptance test (7 cases, Detroit-school recording stubs): fail-closed token, allowlist env + token-not-in-env, capability set `{readMr, postComment}`, inert removed write verbs, pinned-target fail-closed.

Production code for AC1–AC8 already lived on master; this PR closes the one remaining wiring gap and pins the contract end-to-end. `yarn verify` green (3698 tests).

Spec/plan/tracker intentionally kept out of this PR (private until P0 ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)