### PR TITLE
test(provenance): close SPEC-197 SDD loop (acceptance + gaps)

### DIFF
--- a/docs/feature-tracker.md
+++ b/docs/feature-tracker.md
@@ -63,3 +63,4 @@
 | Run the real review when a parked request is confirmed | [202-confirm-pending-review-runs-review](specs/202-confirm-pending-review-runs-review.md) — [plan](plans/202-confirm-pending-review-runs-review.plan.md) — [report](reports/202-confirm-pending-review-runs-review.report.md) | implemented | 2026-06-01 |
 | Webhook event idempotency & replay protection | [200-webhook-event-idempotency](specs/200-webhook-event-idempotency.md) | implemented | 2026-06-10 |
 | Transport and source provenance hardening | [201-transport-provenance-hardening](specs/201-transport-provenance-hardening.md) — [plan](plans/201-transport-provenance-hardening.plan.md) | implemented | 2026-06-10 |
+| Trusted-actor trigger provenance gate | [197-trusted-actor-provenance-gate](specs/197-trusted-actor-provenance-gate.md) — [plan](plans/197-trusted-actor-provenance-gate.plan.md) — [report](reports/197-trusted-actor-provenance-gate.report.md) | implemented | 2026-06-10 |

--- a/docs/plans/197-trusted-actor-provenance-gate.plan.md
+++ b/docs/plans/197-trusted-actor-provenance-gate.plan.md
@@ -1,0 +1,145 @@
+# SPEC-197 — Trusted-actor trigger provenance gate — Implementation Audit & Plan
+
+> Spec: `docs/specs/197-trusted-actor-provenance-gate.md` (status: `draft`)
+> Branch base: `8d337bc` (includes the SPEC-201 merge)
+> Audit date: 2026-06-17
+> All file:line citations below were read directly, not inferred.
+
+## VERDICT
+
+**SUBSTANTIALLY IMPLEMENTED — close the SDD loop, do NOT rebuild the gate.**
+
+The full vertical slice exists and its unit tests pass: entity (`memberAccess.ts`), gateway
+contract + cached fail-closed CLI adapter (per-username key, TTL), `IsTrustedActorUseCase`,
+the `actorTrusted` park branch in `gateClaudeInvocation.usecase.ts`, all three webhook trigger
+entry points gated in `gitlab.controller.ts`, and DI wiring in `routes.ts`. AC1, AC2, AC3, AC5
+are COVERED by passing unit tests. AC4 is PARTIAL (only reviewer-added park-on-throw is asserted
+at the controller; followup + note fail-closed not directly asserted there — though the shared
+`resolveActorTrust` helper makes them structurally identical). AC6 is PARTIAL (ordering is
+structurally guaranteed but no test wires a recording membership stub + invalid token to prove
+the gateway is never called).
+
+**Two artifacts are missing and constitute the only build work:**
+
+1. The **outer-loop SDD acceptance test** `src/tests/acceptance/197-trusted-actor-provenance-gate.acceptance.test.ts` — does not exist (confirmed: no `197-*` file in `src/tests/acceptance/`). This is the spec's deliverable evidence; it should exercise all six ACs through the controller chokepoint with a `StubMemberAccessGateway`.
+2. **SDD bookkeeping**: spec status is still `draft`; SPEC-197 is **absent from `docs/feature-tracker.md`** entirely (rows stop at 200/201 at lines 64-65). Add the row and flip to `planned` (then `implemented` once the acceptance test is GREEN).
+
+No new entity, use case, gateway, or controller code is required. Adding the two AC4/AC6 sub-cases
+(below) is small TDD hardening within the existing test files, not new production code.
+
+## AC COVERAGE MATRIX
+
+| AC | Concern | Status | Artifact + test (file:line) |
+|----|---------|--------|------------------------------|
+| **AC1** | Reviewer-added gate (Reporter → park, Developer+ → proceed) | **COVERED** | Prod: `gitlab.controller.ts:978-1027` (gate via `resolveActorTrust` → `gateClaudeInvocation` with `actorTrusted`). Test: `gitlab.controller.test.ts:576-613` — "parks pending and never enqueues when the actor is a Reporter" (asserts `enqueueReview` not called, `pendingGateway.saveCount === 1`, and `memberAccess.calls` keyed on username) + "enqueues when the actor is a Developer". |
+| **AC2** | Followup / MR-update gate | **COVERED** | Prod: `gitlab.controller.ts:837-872`. Test: `gitlab.controller.test.ts:615-669` — "parks pending and never enqueues a followup from a non-trusted actor" + "enqueues a followup from a Developer actor". Two payloads differing only by `event.user.username`. State-based. |
+| **AC3** | Note / comment gate | **COVERED** | Prod: `gitlab.controller.ts:173-187` (`handleGitLabNoteHook`, parks at 202 `pending-confirmation` / `untrusted-actor`). Test: `gitlab.controller.test.ts:884-900` — "parks a note trigger from a non-trusted actor" (asserts 202, `untrusted-actor`, `mockGateway.update` not called). Positive (Developer note proceeds) sub-case is NOT asserted at controller level — see gap G3. |
+| **AC4** | Fail-closed membership resolution (error/timeout/ambiguous/unknown → park) for **every** trigger type | **PARTIAL** | Gateway-level fail-closed exhaustively covered: `memberAccess.gitlab.cli.gateway.test.ts:99-145` (throw, ambiguous, unknown/empty, non-member throw, out-of-scale level → all `null`). Use-case fail-closed: `isTrustedActor.usecase.test.ts:33-45`. Controller park-on-throw covered **only for reviewer-added**: `gitlab.controller.test.ts:671-688`. **Missing**: explicit controller park-on-throw for followup and note triggers — see gap G1. |
+| **AC5** | Cache does not widen trust (per-username keying) | **COVERED** | Cache impl: `memberAccess.gitlab.cli.gateway.ts:51,63-73` (key `${projectPath} ${username}`). Test: `memberAccess.gitlab.cli.gateway.test.ts:74-84` — "does not apply a cached result for one username to another (AC5)" (primes `alice → developer`, queries unprimed `mallory`, asserts `null`). |
+| **AC6** | Token-boundary ordering — gate runs strictly after verifier; membership gateway never called on invalid token | **PARTIAL** | Ordering is structurally guaranteed: `verifyGitLabSignature` is the first statement of `handleGitLabWebhook` (`gitlab.controller.ts:255`) returning 401 before any gate. Existing test `gitlab.controller.test.ts:713-724` asserts 401 + `enqueueReview` not called on invalid token — **but uses `defaultDeps`, which does NOT wire `isTrustedActor`** (`createDefaultDeps` at line 177 omits it), so it does **not** prove `memberAccess.calls.length === 0`. **Missing**: a test wiring a recording `StubMemberAccessGateway` + invalid token asserting zero membership calls — see gap G2. |
+
+### Amendment compliance (username keying)
+
+CONFIRMED. The implementation keys on `event.user.username`, never `id`:
+- Note path passes `parseResult.data.user.username` (`gitlab.controller.ts:178`); MR/followup paths pass `event.user.username` (`:841`, `:982`).
+- Gateway resolves Users API → numeric id → Members API: `memberAccess.gitlab.cli.gateway.ts:83-95` (`glab api users?username=`), then `:97-109` (`glab api projects/<encoded>/members/all/<userId>`). Both via the injected authenticated executor.
+- Contract documents username keying + fail-closed: `memberAccess.gateway.ts:3-13`.
+
+### NOTE — the two files named "*Provenance.test.ts" do NOT cover SPEC-197 ACs
+
+`gitlabProcessorProvenance.test.ts` and `githubProcessorProvenance.test.ts` pin a *different*
+concern: "an unconfigured `projectPath` never reaches `fetchThreads`" (labelled `AC9`, processor
+read fail-closed — sibling-spec territory, `gitlabProcessorProvenance.test.ts:65-92`). They do
+**not** feed a non-trusted `event.user.username` nor assert park-pending, and must not be counted
+toward AC1–AC6.
+
+## EXISTING ARTIFACTS (verified file:line)
+
+| Layer | File | Key lines |
+|-------|------|-----------|
+| Entity | `src/modules/platform-integration/entities/memberAccess/memberAccess.ts` | levels map `:8-16`; `isDeveloperOrAbove` `:30-32` |
+| Entity test | `src/tests/units/modules/platform-integration/entities/memberAccess/memberAccess.test.ts` | (present) |
+| Gateway contract | `src/modules/platform-integration/entities/memberAccess/memberAccess.gateway.ts` | `resolve(projectPath, username)` `:11-13` |
+| Gateway impl | `src/modules/platform-integration/interface-adapters/gateways/memberAccess.gitlab.cli.gateway.ts` | cache `:51`, TTL default `:17`, `resolve` `:63-73`, Users API `:83-95`, Members API `:97-109` |
+| Gateway test | `src/tests/units/modules/platform-integration/gateways/memberAccess.gitlab.cli.gateway.test.ts` | 9 cases `:53-145` (resolve, cache, AC5, TTL expiry, 5 fail-closed) — all green |
+| Stub | `src/tests/stubs/memberAccess.stub.ts` | `setAccess` `:23`, `setShouldFail` `:27`, records `calls` `:19` |
+| Use case | `src/modules/platform-integration/usecases/isTrustedActor.usecase.ts` | `execute` try/catch fail-closed `:18-25` |
+| Use case test | `src/tests/units/modules/platform-integration/usecases/isTrustedActor.usecase.test.ts` | 4 cases `:16-45` |
+| Park chokepoint | `src/modules/review-execution/usecases/gateClaudeInvocation.usecase.ts` | `actorTrusted` field `:39`; `actorParks` `:64`; full-auto gate `:66`; park branch `:81-99` |
+| Park test | `src/tests/units/modules/review-execution/usecases/gateClaudeInvocation.usecase.test.ts` | "non-trusted actor parks pending even in full-auto (SPEC-197)" `:190-234` |
+| Controller (gate) | `src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts` | `resolveActorTrust` helper `:143-152`; AC3 note `:173-187`; AC2 followup `:837-872`; AC1 reviewer `:978-1027`; verifier-first `:255` |
+| Controller test (SPEC-197 block) | `src/tests/units/interface-adapters/controllers/webhook/gitlab.controller.test.ts` | block `:557-689` (AC1/AC2/AC4) + note `:884-900` (AC3) |
+| DI wiring | `src/main/routes.ts` | gateway+use case instantiation `:314-317`; injected into deps `:546` |
+
+## GAPS TO BUILD (small TDD hardening — no new production code)
+
+**G1 — AC4 fail-closed for followup + note triggers (controller).** Add two `it` cases inside the
+existing `describe('AC4 - fail-closed membership resolution')` block (`gitlab.controller.test.ts:671`):
+one MR-update payload and one note payload with `memberAccess.setShouldFail(true)`, asserting
+park (no enqueue / `pendingGateway.saveCount === 1` for followup; 202 `untrusted-actor` for note).
+Production code already handles this via the shared `resolveActorTrust` helper — these are pins.
+
+**G2 — AC6 explicit "membership gateway never called on invalid token".** Add an `it` to the
+`describe('request gating before payload parsing')` block (`gitlab.controller.test.ts:713`): build
+deps with a recording `StubMemberAccessGateway` + `isTrustedActor`, mock `verifyGitLabSignature →
+{ valid: false }`, call `handleGitLabWebhook`, assert 401 **and** `memberAccess.calls.length === 0`.
+This converts the structural guarantee into a regression-proof assertion.
+
+**G3 — AC3 positive path (optional, completeness).** Add a Developer-note `it` asserting the note
+proceeds past the gate (e.g. `recordBypass.execute` reached / no 202 untrusted park). The spec's
+AC3 test text calls for flipping the username to a Developer and asserting the invocation path is
+reached. Low priority — gate symmetry already proven by AC1/AC2 positive cases.
+
+**G4 — Outer-loop acceptance test (the SDD deliverable).** See ACCEPTANCE_TEST below.
+
+**G5 — SDD bookkeeping.** Flip spec front-matter `status: draft → planned`; add a `docs/feature-tracker.md`
+row after line 65 (`| Trusted-actor trigger provenance gate | [197-trusted-actor-provenance-gate](specs/197-trusted-actor-provenance-gate.md) — [plan](plans/197-trusted-actor-provenance-gate.plan.md) | planned | 2026-06-17 |`). Flip to `implemented` once G4 is GREEN.
+
+## ACCEPTANCE_TEST (outer-loop artifact to add)
+
+```
+file: src/tests/acceptance/197-trusted-actor-provenance-gate.acceptance.test.ts
+note: "SDD outer loop — written first, RED until the gate is exercised end-to-end, GREEN once all six ACs assert through the controller chokepoint."
+```
+
+### Shape (mirrors the single-chokepoint convention of 198 / 201)
+
+The SPEC-197 chokepoint is the webhook controller `handleGitLabWebhook` + `handleGitLabNoteHook`
+wired with a real `IsTrustedActorUseCase(StubMemberAccessGateway)` and a real
+`GateClaudeInvocationUseCase`. Assert **observable job state** (enqueue called vs pending saved /
+202 untrusted), never model output. Detroit style — real stubs, no `vi.fn` for the gateway itself.
+Reuse the wiring already proven in `gitlab.controller.test.ts:557-574` (`buildGatedDeps`) as the
+acceptance harness shape.
+
+**Fixtures (one per trigger entry point, so a failure names the exact gate):**
+- `GitLabEventFactory.createWithReviewerAdded('claude-bot')` with `event.user.username` overridden — reviewer-added (factory `:75`).
+- `GitLabEventFactory.createMrUpdate()` with `event.user.username` overridden — followup (factory `:125`), backed by a `TrackedMrFactory` followup MR (`gitlab.controller.test.ts:616-628`).
+- local `buildNoteEvent('/bypass-quality "reason"')` with `user.username` overridden — note (pattern at `gitlab.controller.test.ts:884-890`).
+
+**Stub membership gateway:** `StubMemberAccessGateway` — `setAccess('dev-actor', MEMBER_ACCESS_LEVELS.developer)`, `setAccess('reporter-actor', MEMBER_ACCESS_LEVELS.reporter)`, `setShouldFail(true)` for AC4. Records `calls` for AC5/AC6 keying assertions.
+
+**Cases (six ACs):**
+- AC1: reviewer-added + Reporter → `enqueueReview` not called, `pendingGateway.saveCount === 1`; + Developer → enqueued.
+- AC2: MR-update + Reporter → park; + Developer → enqueued (two payloads differing only by username).
+- AC3: note + Reporter → 202 `{ status: 'pending-confirmation', reason: 'untrusted-actor' }`; + Developer → proceeds (no untrusted park).
+- AC4: `setShouldFail(true)` → park for **all three** trigger fixtures.
+- AC5: prime `dev-actor → developer`, then a second trigger from an unprimed `mallory` → park (per-username keying; gateway-level test already proves cache non-widening, acceptance re-proves at controller).
+- AC6: mock `verifyGitLabSignature → { valid: false }` for a reviewer-added trigger → 401 **and** `memberAccess.calls.length === 0` (gate strictly behind the token boundary).
+
+**Job-state assertions:** `enqueueReview` (or the deps' enqueue spy) call count, `StubPendingReviewRequestGateway.saveCount`, and `mockReply.status` / `mockReply.send` for the 202/401 outcomes — exactly the assertions already used at `gitlab.controller.test.ts:590-594, 646-648, 685-686, 895-899, 721-723`.
+
+## REFERENCE_FILES
+
+- `docs/specs/197-trusted-actor-provenance-gate.md` — the six ACs + the username-keying amendment.
+- `src/tests/acceptance/198-constrained-action-surface.acceptance.test.ts` — single-chokepoint acceptance convention (service-level, real stub, state assertions).
+- `src/tests/acceptance/201-transport-provenance-hardening.acceptance.test.ts` — sibling chokepoint convention (`next()` vs 403, no model output).
+- `src/tests/units/interface-adapters/controllers/webhook/gitlab.controller.test.ts:557-689,884-900` — the existing SPEC-197 controller block to mirror/lift into the acceptance harness; `buildGatedDeps` `:558-574`.
+- `src/tests/stubs/memberAccess.stub.ts` — the membership stub for all acceptance cases.
+- `src/main/routes.ts:314-317,546` — production wiring (proves the gate is live, not dead code).
+
+## IMPLEMENTATION_ORDER (close-loop only)
+
+1. `src/tests/acceptance/197-trusted-actor-provenance-gate.acceptance.test.ts` — write FIRST (SDD outer loop). It will pass immediately against the existing gate (no RED on production), which is the intended evidence that the shipped code satisfies the spec.
+2. G1 + G2 (+ optional G3) sub-cases in the two existing unit test files — close the AC4-per-trigger and AC6-no-call gaps. No production edits expected; if any sub-case fails, that is a real defect to fix under TDD.
+3. `yarn verify` (typecheck + lint + test:ci) — confirm green.
+4. G5 bookkeeping: spec `status → planned`; add the tracker row → flip to `implemented` once green.

--- a/docs/reports/197-trusted-actor-provenance-gate.report.md
+++ b/docs/reports/197-trusted-actor-provenance-gate.report.md
@@ -1,0 +1,89 @@
+# SPEC-197 — Trusted-actor trigger provenance gate — Close-Loop Report
+
+> Task: CLOSE-LOOP (test-only + doc bookkeeping). The gate already shipped on `master`
+> (landed 2026-06-10 with the provenance cluster) and its unit tests pass. No new
+> production code was expected — and **none was written**.
+> Report date: 2026-06-17.
+
+## VERDICT
+
+**Loop closed — GREEN.** The outer-loop acceptance test exercises all six ACs through
+the controller chokepoint and passes immediately against the existing gate, which is the
+intended SDD evidence that the shipped code satisfies the spec. The AC4-per-trigger and
+AC6-no-call gaps are now pinned by controller unit sub-cases. `yarn verify` is fully green.
+**Production code changed: none.** **Defects found: none.**
+
+## FILES CREATED
+
+| File | Description |
+|------|-------------|
+| `src/tests/acceptance/197-trusted-actor-provenance-gate.acceptance.test.ts` | G4 — outer-loop SDD acceptance test. Six `it` cases (AC1–AC6) across the three trigger fixtures (reviewer-added, MR-update/followup, note), single chokepoint `handleGitLabWebhook` wired with a real `IsTrustedActorUseCase(StubMemberAccessGateway)` + real full-auto `GateClaudeInvocationUseCase`. Asserts observable job state only (`enqueueReview` count, `StubPendingReviewRequestGateway.saveCount`, `mockReply.status`/`send` for 202/401, `memberAccess.calls`). Never asserts model output. |
+| `docs/reports/197-trusted-actor-provenance-gate.report.md` | This report. |
+
+## FILES MODIFIED
+
+| File | Change |
+|------|--------|
+| `src/tests/units/interface-adapters/controllers/webhook/gitlab.controller.test.ts` | G1 — added 2 `it` cases inside `describe('AC4 - fail-closed membership resolution')`: followup (MR-update) park-on-throw (`saveCount===1`, no enqueue) and note park-on-throw (202 `untrusted-actor`, no `update`). G2 — added 1 `it` to `describe('request gating before payload parsing')`: invalid token with a recording `StubMemberAccessGateway` + `isTrustedActor` wired, asserts 401 **and** `memberAccess.calls.length === 0`. G3 — added 1 `it` to `describe('Note Hook handling')`: Developer note proceeds past the gate (no 202, `status: 'bypass-recorded'`). |
+| `docs/specs/197-trusted-actor-provenance-gate.md` | G5 — front-matter `status: draft → implemented`; added `## Status: implemented` + `## Implementation` section (AC→artifact→test matrix, mirroring SPEC-201's style). |
+| `docs/feature-tracker.md` | G5 — SPEC-197 row flipped `planned → implemented`, date `2026-06-17 → 2026-06-10`, added `[report]` link. |
+
+## TEST COUNTS
+
+| Suite | Tests | Result |
+|-------|-------|--------|
+| `197-trusted-actor-provenance-gate.acceptance.test.ts` (new) | 6 | all pass |
+| `gitlab.controller.test.ts` (modified) | 47 (was 43; +4: G1×2, G2×1, G3×1) | all pass |
+| **`yarn verify` full suite (`vitest --run`)** | **3717 tests / 446 files** | **all pass** |
+
+`yarn verify` = typecheck (pass) + oxlint (only pre-existing warnings in unrelated
+`src/dashboard/` & `src/frameworks/` files; **zero** in SPEC-197 files; zero errors) +
+oxfmt `--check` (clean) + `vitest --run` (3717 pass).
+
+## AC → TEST COVERAGE CONFIRMATION
+
+| AC | Acceptance test case | Unit-test pin | Status |
+|----|----------------------|---------------|--------|
+| **AC1** reviewer-added gate | `AC1 — reviewer-added gate` (Reporter parks, `saveCount===1`; Developer enqueues) | `gitlab.controller.test.ts` `AC1 - reviewer-added gate` (pre-existing) | OK |
+| **AC2** followup / MR-update gate | `AC2 — followup / MR-update gate` (two payloads differ only by username) | `gitlab.controller.test.ts` `AC2 - followup / MR-update gate` (pre-existing) | OK |
+| **AC3** note / comment gate | `AC3 — note / comment gate` (Reporter → 202 `untrusted-actor`; Developer → `bypass-recorded`) | `gitlab.controller.test.ts` note park (pre-existing) + **new** Developer-note positive (G3) | OK |
+| **AC4** fail-closed for every trigger | `AC4 — fail-closed membership resolution` (`setShouldFail(true)` parks reviewer + followup + note) | gateway/use-case fail-closed (pre-existing) + **new** controller followup + note park-on-throw (G1) | OK |
+| **AC5** cache does not widen trust | `AC5 — cache does not widen trust` (primed `dev-actor`, unprimed `mallory` parks; `memberAccess.calls` keyed per-username) | `memberAccess.gitlab.cli.gateway.test.ts` AC5 (pre-existing) | OK |
+| **AC6** token-boundary ordering | `AC6 — token-boundary ordering` (invalid token → 401 **and** `memberAccess.calls.length === 0`) | **new** `never queries the membership gateway when the token is invalid` (G2) | OK |
+
+## DEFECTS FOUND
+
+**None.** Every test written passed against the existing production code on first run
+(after one fix to my own *test wiring* — see below — never a production change).
+
+- During authoring, the AC5 acceptance case initially asserted `saveCount` on a
+  `StubPendingReviewRequestGateway` that was not the one wired into the
+  `GateClaudeInvocationUseCase` actually handling Mallory's trigger (I had reused a stale
+  gate instance bound to a different pending gateway). The gate behaviour was correct —
+  Mallory was parked (enqueue stayed at 1), and `memberAccess.calls` correctly recorded
+  both usernames — but my assertion observed the wrong gateway. Fixed by sharing a single
+  `pendingGateway` across both triggers and asserting its `saveCount` transitions 0 → 1.
+  This was a test-harness error, **not** a production defect; no `src/` code was touched.
+
+## PRODUCTION CODE CHANGED
+
+**None** (as expected). All work is test files + documentation bookkeeping.
+
+## SELF-REVIEW (Phase 3)
+
+| Criterion | Result |
+|-----------|--------|
+| Naming | full words, camelCase test file with `.acceptance.test.ts` / `.test.ts` suffix |
+| Imports | 100% `@/` alias + `.js`; zero relative imports (grep-verified); no barrel |
+| TypeScript | no `any`; the only `as` usages are `as const` (literal narrowing) and the project-sanctioned `as unknown as FastifyRequest/FastifyReply` test-double pattern (identical to the sibling `gitlab.controller.test.ts`) |
+| Architecture | dependency rule respected — acceptance imports use cases + stubs, no outward leaks |
+| Tests | Detroit style — real `StubMemberAccessGateway` (no `vi.fn` on the gateway), factories (`GitLabEventFactory`, `TrackedMrFactory`), state-based assertions only, never model output |
+| Clean Code | zero superfluous comments; one JSDoc on `buildGatedDeps` explaining the chokepoint wiring |
+| Domain | `null` for absence (`getById` returns `null`), no `undefined` in domain values |
+
+Review-fix iterations: 1 (the AC5 harness fix above). No outstanding violations.
+
+## ESCALATIONS
+
+None. Loop closed GREEN within the constraints; no production code modified; no defect
+surfaced.

--- a/docs/specs/197-trusted-actor-provenance-gate.md
+++ b/docs/specs/197-trusted-actor-provenance-gate.md
@@ -1,6 +1,6 @@
 ---
 title: "SPEC-197: Trusted-actor trigger provenance gate"
-status: draft
+status: implemented
 labels: [gitlab, webhook, provenance, trigger-gate]
 visibility: PRIVATE-UNTIL-P0-SHIPPED
 depends_on: [SPEC-201]
@@ -8,6 +8,23 @@ sibling_specs: [SPEC-196, SPEC-198, SPEC-199, SPEC-174]
 ---
 
 # SPEC-197: Trusted-actor trigger provenance gate
+
+## Status: implemented
+
+## Implementation
+
+Shipped on `master` (landed 2026-06-10 with the provenance cluster); SDD outer-loop acceptance test added 2026-06-17 to close the loop. The gate keys on `event.user.username` (per the amendment below), resolving Users API → numeric id → Members API through the authenticated service token, cached per-username and fail-closed. Non-trusted actors never auto-run: the job parks at the existing `gateClaudeInvocation` chokepoint (SPEC-174 `triggerMode`).
+
+| AC | Artifact | Test |
+|----|----------|------|
+| AC1 — reviewer-added gate | `interface-adapters/controllers/webhook/gitlab.controller.ts` (`resolveActorTrust` → `gateClaudeInvocation` with `actorTrusted`) | `units/.../gitlab.controller.test.ts` (`AC1 - reviewer-added gate`: Reporter parks / Developer enqueues) |
+| AC2 — followup / MR-update gate | `interface-adapters/controllers/webhook/gitlab.controller.ts` (followup branch) | `units/.../gitlab.controller.test.ts` (`AC2 - followup / MR-update gate`: two payloads differing only by username) |
+| AC3 — note / comment gate | `interface-adapters/controllers/webhook/gitlab.controller.ts` (`handleGitLabNoteHook`, parks 202 `untrusted-actor`) | `units/.../gitlab.controller.test.ts` (`parks a note trigger from a non-trusted actor` + `lets a note trigger from a Developer actor proceed`) |
+| AC4 — fail-closed membership resolution | `interface-adapters/gateways/memberAccess.gitlab.cli.gateway.ts` (throw/ambiguous/unknown → `null`); `usecases/isTrustedActor.usecase.ts` (try/catch → false) | `units/.../memberAccess.gitlab.cli.gateway.test.ts`; `units/.../isTrustedActor.usecase.test.ts`; `units/.../gitlab.controller.test.ts` (`AC4 - fail-closed membership resolution`: reviewer + followup + note park on throw) |
+| AC5 — cache does not widen trust | `interface-adapters/gateways/memberAccess.gitlab.cli.gateway.ts` (cache key `${projectPath} ${username}`) | `units/.../memberAccess.gitlab.cli.gateway.test.ts` (`does not apply a cached result for one username to another`) |
+| AC6 — token-boundary ordering | `interface-adapters/controllers/webhook/gitlab.controller.ts` (`verifyGitLabSignature` is the first statement, returns 401 before any gate) | `units/.../gitlab.controller.test.ts` (`never queries the membership gateway when the token is invalid`) |
+
+Supporting: `entities/memberAccess/memberAccess.ts` (access-level scale + `isDeveloperOrAbove`), `entities/memberAccess/memberAccess.gateway.ts` (contract), `usecases/isTrustedActor.usecase.ts`, `usecases/gateClaudeInvocation.usecase.ts` (`actorTrusted` park branch), `tests/stubs/memberAccess.stub.ts`. DI wiring: `src/main/routes.ts`. Outer-loop acceptance: `src/tests/acceptance/197-trusted-actor-provenance-gate.acceptance.test.ts` (six ACs through the controller chokepoint, observable job state only).
 
 ## Context
 

--- a/src/tests/acceptance/197-trusted-actor-provenance-gate.acceptance.test.ts
+++ b/src/tests/acceptance/197-trusted-actor-provenance-gate.acceptance.test.ts
@@ -1,0 +1,578 @@
+import type { FastifyRequest, FastifyReply } from 'fastify';
+import { vi } from 'vitest';
+
+import type { RepositoryConfig } from '@/config/loader.js';
+
+const mockConfig = {
+  server: { port: 3000 },
+  user: { gitlabUsername: 'claude-bot', githubUsername: 'claude-bot' },
+  queue: { maxConcurrent: 1, deduplicationWindowMs: 60000 },
+  repositories: [],
+};
+
+const mockRepoConfig: RepositoryConfig = {
+  name: 'test-project',
+  platform: 'gitlab',
+  localPath: '/home/user/projects/test-project',
+  remoteUrl: 'https://gitlab.com/test-org/test-project.git',
+  skill: 'review-front',
+  enabled: true,
+};
+
+vi.mock('@/config/loader.js', () => ({
+  loadConfig: vi.fn(() => mockConfig),
+  findRepositoryByProjectPath: vi.fn(() => mockRepoConfig),
+}));
+
+vi.mock('@/security/verifier.js', () => ({
+  verifyGitLabSignature: vi.fn(() => ({ valid: true })),
+  getGitLabEventType: vi.fn(() => 'Merge Request Hook'),
+  getGitLabEventUuid: vi.fn(() => undefined),
+}));
+
+vi.mock('@/frameworks/queue/pQueueAdapter.js', () => ({
+  createJobId: vi.fn(() => 'gitlab-test-org/test-project-42'),
+  enqueueReview: vi.fn(() => Promise.resolve(true)),
+  updateJobProgress: vi.fn(),
+  cancelJob: vi.fn(),
+}));
+
+vi.mock('@/claude/invoker.js', () => ({
+  invokeClaudeReview: vi.fn(),
+  sendNotification: vi.fn(),
+}));
+
+vi.mock('@/main/websocket.js', () => ({
+  startWatchingReviewContext: vi.fn(),
+  stopWatchingReviewContext: vi.fn(),
+}));
+
+vi.mock('@/config/projectConfig.js', () => ({
+  loadProjectConfig: vi.fn(() => null),
+  getProjectAgents: vi.fn(() => null),
+  getProjectAgentsOrFocusDefaults: vi.fn(() => null),
+  getFollowupAgents: vi.fn(() => null),
+  getProjectLanguage: vi.fn(() => 'en'),
+}));
+
+vi.mock(
+  '@/modules/review-execution/interface-adapters/gateways/reviewContext.fileSystem.gateway.js',
+  () => ({
+    ReviewContextFileSystemGateway: vi.fn().mockImplementation(() => ({
+      create: vi.fn(),
+      read: vi.fn(() => null),
+      delete: vi.fn(() => ({ deleted: true })),
+      updateProgress: vi.fn(),
+    })),
+  }),
+);
+
+vi.mock(
+  '@/modules/platform-integration/interface-adapters/gateways/threadFetch.gitlab.gateway.js',
+  () => ({
+    GitLabThreadFetchGateway: vi.fn().mockImplementation(() => ({
+      fetchThreads: vi.fn(() => []),
+    })),
+    defaultGitLabExecutor: vi.fn(),
+  }),
+);
+
+vi.mock(
+  '@/modules/platform-integration/interface-adapters/gateways/diffMetadataFetch.gitlab.gateway.js',
+  () => ({
+    GitLabDiffMetadataFetchGateway: vi.fn().mockImplementation(() => ({
+      fetchDiffMetadata: vi.fn(() => undefined),
+    })),
+  }),
+);
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { enqueueReview } from '@/frameworks/queue/pQueueAdapter.js';
+import { MEMBER_ACCESS_LEVELS } from '@/modules/platform-integration/entities/memberAccess/memberAccess.js';
+import { handleGitLabWebhook } from '@/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.js';
+import { IsTrustedActorUseCase } from '@/modules/platform-integration/usecases/isTrustedActor.usecase.js';
+import { GateClaudeInvocationUseCase } from '@/modules/review-execution/usecases/gateClaudeInvocation.usecase.js';
+import type { TrackedMr } from '@/modules/tracking/entities/tracking/trackedMr.js';
+import { CheckFollowupNeededUseCase } from '@/modules/tracking/usecases/tracking/checkFollowupNeeded.usecase.js';
+import { HandlePlatformApprovalUseCase } from '@/modules/tracking/usecases/tracking/handlePlatformApproval.usecase.js';
+import { RecordBypassUseCase } from '@/modules/tracking/usecases/tracking/recordBypass.usecase.js';
+import { RecordPushUseCase } from '@/modules/tracking/usecases/tracking/recordPush.usecase.js';
+import { RecordReviewCompletionUseCase } from '@/modules/tracking/usecases/tracking/recordReviewCompletion.usecase.js';
+import { SyncThreadsUseCase } from '@/modules/tracking/usecases/tracking/syncThreads.usecase.js';
+import { TrackAssignmentUseCase } from '@/modules/tracking/usecases/tracking/trackAssignment.usecase.js';
+import { TransitionStateUseCase } from '@/modules/tracking/usecases/tracking/transitionState.usecase.js';
+import { verifyGitLabSignature, getGitLabEventType } from '@/security/verifier.js';
+import { GitLabEventFactory } from '@/tests/factories/gitLabEvent.factory.js';
+import { TrackedMrFactory } from '@/tests/factories/trackedMr.factory.js';
+import { StubApprovalRevocationGateway } from '@/tests/stubs/approvalRevocation.stub.js';
+import { createStubLogger } from '@/tests/stubs/logger.stub.js';
+import { StubMemberAccessGateway } from '@/tests/stubs/memberAccess.stub.js';
+import { StubNoteCommentPostGateway } from '@/tests/stubs/noteCommentPost.stub.js';
+import { StubPendingReviewRequestGateway } from '@/tests/stubs/pendingReviewRequest.stub.js';
+
+const logger = createStubLogger();
+
+const TRACKED_MR_ID = 'gitlab-test-org/test-project-42';
+const PROJECT_PATH = 'test-org/test-project';
+
+function createMockTrackingGateway(initialMr: TrackedMr | null) {
+  return {
+    getById: vi.fn((): TrackedMr | null => initialMr),
+    getByNumber: vi.fn((): TrackedMr | null => null),
+    create: vi.fn(),
+    update: vi.fn(),
+    getByState: vi.fn(() => []),
+    getActiveMrs: vi.fn(() => []),
+    remove: vi.fn(() => true),
+    archive: vi.fn(() => true),
+    recordReviewEvent: vi.fn(),
+    recordPush: vi.fn((): TrackedMr | null => null),
+    loadTracking: vi.fn(() => null),
+    saveTracking: vi.fn(),
+  };
+}
+
+function createStubContextGateway() {
+  return {
+    create: vi.fn(() => ({ success: true, filePath: '' })),
+    read: vi.fn(() => null),
+    delete: vi.fn(() => ({ success: true, deleted: true })),
+    exists: vi.fn(() => false),
+    getFilePath: vi.fn(() => ''),
+    appendAction: vi.fn(() => ({ success: true })),
+    updateProgress: vi.fn(() => ({ success: true })),
+    setResult: vi.fn(() => ({ success: true })),
+    listAll: vi.fn(() => []),
+  };
+}
+
+function createAcceptAllEnforceBudget() {
+  return {
+    execute: vi.fn(async () => ({
+      accepted: true,
+      status: {
+        limitUsd: 200,
+        consumedUsd: 0,
+        remainingUsd: 200,
+        percentUsed: 0,
+        exceeded: false,
+        periodStart: '2026-05-01T00:00:00.000Z',
+      },
+    })),
+  };
+}
+
+function buildBaseDeps(trackingGateway: ReturnType<typeof createMockTrackingGateway>) {
+  const threadFetchGateway = { fetchThreads: vi.fn(() => []) };
+  return {
+    reviewContextGateway: createStubContextGateway(),
+    threadFetchGateway,
+    diffMetadataFetchGateway: {
+      fetchDiffMetadata: vi.fn(() => ({ baseSha: 'abc', headSha: 'def', startSha: 'ghi' })),
+    },
+    diffStatsFetchGateway: { fetchDiffStats: vi.fn(() => null) },
+    trackAssignment: new TrackAssignmentUseCase(trackingGateway),
+    recordCompletion: new RecordReviewCompletionUseCase(trackingGateway),
+    recordPush: new RecordPushUseCase(trackingGateway),
+    transitionState: new TransitionStateUseCase(trackingGateway),
+    checkFollowupNeeded: new CheckFollowupNeededUseCase(trackingGateway),
+    syncThreads: new SyncThreadsUseCase(trackingGateway, threadFetchGateway),
+    enforceBudget: createAcceptAllEnforceBudget(),
+    broadcastBudgetExceeded: vi.fn(),
+    getRepositories: vi.fn(() => []),
+    removeWorktree: vi.fn(async () => ({ status: 'removed' as const })),
+    recordBypass: new RecordBypassUseCase(trackingGateway),
+    noteCommentPostGateway: new StubNoteCommentPostGateway(),
+    handlePlatformApproval: new HandlePlatformApprovalUseCase(trackingGateway),
+    approvalRevocationGateway: new StubApprovalRevocationGateway(),
+    getQualityThreshold: (): number | null => null,
+    now: (): string => '2026-05-26T12:00:00.000Z',
+  };
+}
+
+/**
+ * Wires the SPEC-197 chokepoint: a real IsTrustedActorUseCase backed by the recording
+ * StubMemberAccessGateway, and a real full-auto GateClaudeInvocationUseCase whose park
+ * branch saves into the StubPendingReviewRequestGateway. Observable job state is the only
+ * thing asserted — enqueue call count, pending saveCount, and the HTTP reply.
+ */
+function buildGatedDeps(
+  trackingGateway: ReturnType<typeof createMockTrackingGateway>,
+  memberAccess: StubMemberAccessGateway,
+  pendingGateway: StubPendingReviewRequestGateway,
+) {
+  const gateClaudeInvocation = new GateClaudeInvocationUseCase({
+    getTriggerMode: () => 'full-auto',
+    pendingReviewRequestGateway: pendingGateway,
+    enqueue: enqueueReview,
+    broadcastPendingChanged: () => {},
+    logger,
+  });
+  return {
+    ...buildBaseDeps(trackingGateway),
+    gateClaudeInvocation,
+    isTrustedActor: new IsTrustedActorUseCase(memberAccess),
+  };
+}
+
+function buildFollowupMr(): TrackedMr {
+  return TrackedMrFactory.create({
+    id: TRACKED_MR_ID,
+    mrNumber: 42,
+    platform: 'gitlab',
+    project: PROJECT_PATH,
+    state: 'pending-review',
+    openThreads: 3,
+    autoFollowup: true,
+    lastPushAt: '2026-05-26T12:00:00.000Z',
+    lastReviewAt: '2026-05-25T12:00:00.000Z',
+  });
+}
+
+function buildNoteEvent(note: string) {
+  return {
+    object_kind: 'note',
+    event_type: 'note',
+    user: { username: 'note-author', name: 'Note Author' },
+    project: {
+      id: 1,
+      name: 'test-project',
+      path_with_namespace: PROJECT_PATH,
+      web_url: 'https://gitlab.com/test-org/test-project',
+      git_http_url: 'https://gitlab.com/test-org/test-project.git',
+    },
+    object_attributes: {
+      id: 7,
+      note,
+      noteable_type: 'MergeRequest',
+      noteable_id: 99,
+    },
+    merge_request: {
+      iid: 42,
+      title: 'Test MR',
+      state: 'opened',
+      source_branch: 'feature/test',
+      target_branch: 'main',
+      url: 'https://gitlab.com/test-org/test-project/-/merge_requests/42',
+    },
+  };
+}
+
+function asRequest(body: unknown): FastifyRequest {
+  return { body, headers: {} } as unknown as FastifyRequest;
+}
+
+describe('SPEC-197 trusted-actor trigger provenance gate (acceptance — full chokepoint handleGitLabWebhook)', () => {
+  let mockReply: FastifyReply;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReply = {
+      status: vi.fn().mockReturnThis(),
+      send: vi.fn().mockReturnThis(),
+    } as unknown as FastifyReply;
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('AC1 — reviewer-added gate', () => {
+    it('parks a reviewer-added trigger from a Reporter and enqueues one from a Developer', async () => {
+      const reporterTracking = createMockTrackingGateway(null);
+      const reporterMembers = new StubMemberAccessGateway();
+      reporterMembers.setAccess('reporter-actor', MEMBER_ACCESS_LEVELS.reporter);
+      const reporterPending = new StubPendingReviewRequestGateway();
+      const reporterDeps = buildGatedDeps(reporterTracking, reporterMembers, reporterPending);
+
+      const reporterEvent = GitLabEventFactory.createWithReviewerAdded('claude-bot');
+      reporterEvent.user = { username: 'reporter-actor', name: 'Reporter Actor' };
+
+      await handleGitLabWebhook(
+        asRequest(reporterEvent),
+        mockReply,
+        logger,
+        reporterTracking,
+        reporterDeps,
+      );
+
+      expect(enqueueReview).not.toHaveBeenCalled();
+      expect(reporterPending.saveCount).toBe(1);
+
+      const developerTracking = createMockTrackingGateway(null);
+      const developerMembers = new StubMemberAccessGateway();
+      developerMembers.setAccess('dev-actor', MEMBER_ACCESS_LEVELS.developer);
+      const developerPending = new StubPendingReviewRequestGateway();
+      const developerDeps = buildGatedDeps(developerTracking, developerMembers, developerPending);
+
+      const developerEvent = GitLabEventFactory.createWithReviewerAdded('claude-bot');
+      developerEvent.user = { username: 'dev-actor', name: 'Dev Actor' };
+
+      await handleGitLabWebhook(
+        asRequest(developerEvent),
+        mockReply,
+        logger,
+        developerTracking,
+        developerDeps,
+      );
+
+      expect(enqueueReview).toHaveBeenCalledTimes(1);
+      expect(developerPending.saveCount).toBe(0);
+    });
+  });
+
+  describe('AC2 — followup / MR-update gate', () => {
+    it('parks a followup from a Reporter and enqueues one from a Developer (payloads differ only by username)', async () => {
+      const reporterTracking = createMockTrackingGateway(buildFollowupMr());
+      reporterTracking.getByNumber.mockReturnValue(buildFollowupMr());
+      reporterTracking.recordPush.mockReturnValue(buildFollowupMr());
+      const reporterMembers = new StubMemberAccessGateway();
+      reporterMembers.setAccess('reporter-actor', MEMBER_ACCESS_LEVELS.reporter);
+      const reporterPending = new StubPendingReviewRequestGateway();
+      const reporterDeps = buildGatedDeps(reporterTracking, reporterMembers, reporterPending);
+
+      const reporterEvent = GitLabEventFactory.createMrUpdate();
+      reporterEvent.user = { username: 'reporter-actor', name: 'Reporter Actor' };
+
+      await handleGitLabWebhook(
+        asRequest(reporterEvent),
+        mockReply,
+        logger,
+        reporterTracking,
+        reporterDeps,
+      );
+
+      expect(enqueueReview).not.toHaveBeenCalled();
+      expect(reporterPending.saveCount).toBe(1);
+
+      const developerTracking = createMockTrackingGateway(buildFollowupMr());
+      developerTracking.getByNumber.mockReturnValue(buildFollowupMr());
+      developerTracking.recordPush.mockReturnValue(buildFollowupMr());
+      const developerMembers = new StubMemberAccessGateway();
+      developerMembers.setAccess('dev-actor', MEMBER_ACCESS_LEVELS.developer);
+      const developerPending = new StubPendingReviewRequestGateway();
+      const developerDeps = buildGatedDeps(developerTracking, developerMembers, developerPending);
+
+      const developerEvent = GitLabEventFactory.createMrUpdate();
+      developerEvent.user = { username: 'dev-actor', name: 'Dev Actor' };
+
+      await handleGitLabWebhook(
+        asRequest(developerEvent),
+        mockReply,
+        logger,
+        developerTracking,
+        developerDeps,
+      );
+
+      expect(enqueueReview).toHaveBeenCalledTimes(1);
+      expect(developerPending.saveCount).toBe(0);
+    });
+  });
+
+  describe('AC3 — note / comment gate', () => {
+    it('parks a note from a Reporter with 202 untrusted-actor and lets a Developer note proceed', async () => {
+      vi.mocked(getGitLabEventType).mockReturnValue('Note Hook');
+
+      const reporterTracking = createMockTrackingGateway(
+        TrackedMrFactory.create({
+          id: TRACKED_MR_ID,
+          mrNumber: 42,
+          platform: 'gitlab',
+          project: PROJECT_PATH,
+        }),
+      );
+      const reporterMembers = new StubMemberAccessGateway();
+      reporterMembers.setAccess('note-author', MEMBER_ACCESS_LEVELS.reporter);
+      const reporterPending = new StubPendingReviewRequestGateway();
+      const reporterDeps = buildGatedDeps(reporterTracking, reporterMembers, reporterPending);
+
+      await handleGitLabWebhook(
+        asRequest(buildNoteEvent('/bypass-quality "reason here"')),
+        mockReply,
+        logger,
+        reporterTracking,
+        reporterDeps,
+      );
+
+      expect(mockReply.status).toHaveBeenCalledWith(202);
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'pending-confirmation', reason: 'untrusted-actor' }),
+      );
+      expect(reporterTracking.update).not.toHaveBeenCalled();
+
+      const developerTracking = createMockTrackingGateway(
+        TrackedMrFactory.create({
+          id: TRACKED_MR_ID,
+          mrNumber: 42,
+          platform: 'gitlab',
+          project: PROJECT_PATH,
+        }),
+      );
+      const developerMembers = new StubMemberAccessGateway();
+      developerMembers.setAccess('note-author', MEMBER_ACCESS_LEVELS.developer);
+      const developerPending = new StubPendingReviewRequestGateway();
+      const developerDeps = buildGatedDeps(developerTracking, developerMembers, developerPending);
+      const developerReply = {
+        status: vi.fn().mockReturnThis(),
+        send: vi.fn().mockReturnThis(),
+      } as unknown as FastifyReply;
+
+      await handleGitLabWebhook(
+        asRequest(buildNoteEvent('/bypass-quality "reason here"')),
+        developerReply,
+        logger,
+        developerTracking,
+        developerDeps,
+      );
+
+      expect(developerReply.status).not.toHaveBeenCalledWith(202);
+      expect(developerReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'bypass-recorded' }),
+      );
+    });
+  });
+
+  describe('AC4 — fail-closed membership resolution', () => {
+    it('parks every trigger type when membership resolution throws', async () => {
+      const reviewerTracking = createMockTrackingGateway(null);
+      const reviewerMembers = new StubMemberAccessGateway();
+      reviewerMembers.setShouldFail(true);
+      const reviewerPending = new StubPendingReviewRequestGateway();
+      const reviewerDeps = buildGatedDeps(reviewerTracking, reviewerMembers, reviewerPending);
+
+      const reviewerEvent = GitLabEventFactory.createWithReviewerAdded('claude-bot');
+      reviewerEvent.user = { username: 'dev-actor', name: 'Dev Actor' };
+
+      await handleGitLabWebhook(
+        asRequest(reviewerEvent),
+        mockReply,
+        logger,
+        reviewerTracking,
+        reviewerDeps,
+      );
+
+      expect(enqueueReview).not.toHaveBeenCalled();
+      expect(reviewerPending.saveCount).toBe(1);
+
+      const followupTracking = createMockTrackingGateway(buildFollowupMr());
+      followupTracking.getByNumber.mockReturnValue(buildFollowupMr());
+      followupTracking.recordPush.mockReturnValue(buildFollowupMr());
+      const followupMembers = new StubMemberAccessGateway();
+      followupMembers.setShouldFail(true);
+      const followupPending = new StubPendingReviewRequestGateway();
+      const followupDeps = buildGatedDeps(followupTracking, followupMembers, followupPending);
+
+      const followupEvent = GitLabEventFactory.createMrUpdate();
+      followupEvent.user = { username: 'dev-actor', name: 'Dev Actor' };
+
+      await handleGitLabWebhook(
+        asRequest(followupEvent),
+        mockReply,
+        logger,
+        followupTracking,
+        followupDeps,
+      );
+
+      expect(enqueueReview).not.toHaveBeenCalled();
+      expect(followupPending.saveCount).toBe(1);
+
+      vi.mocked(getGitLabEventType).mockReturnValue('Note Hook');
+      const noteTracking = createMockTrackingGateway(
+        TrackedMrFactory.create({
+          id: TRACKED_MR_ID,
+          mrNumber: 42,
+          platform: 'gitlab',
+          project: PROJECT_PATH,
+        }),
+      );
+      const noteMembers = new StubMemberAccessGateway();
+      noteMembers.setShouldFail(true);
+      const notePending = new StubPendingReviewRequestGateway();
+      const noteDeps = buildGatedDeps(noteTracking, noteMembers, notePending);
+      const noteReply = {
+        status: vi.fn().mockReturnThis(),
+        send: vi.fn().mockReturnThis(),
+      } as unknown as FastifyReply;
+
+      await handleGitLabWebhook(
+        asRequest(buildNoteEvent('/bypass-quality "reason here"')),
+        noteReply,
+        logger,
+        noteTracking,
+        noteDeps,
+      );
+
+      expect(noteReply.status).toHaveBeenCalledWith(202);
+      expect(noteReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'pending-confirmation', reason: 'untrusted-actor' }),
+      );
+      expect(noteTracking.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('AC5 — cache does not widen trust', () => {
+    it('parks a trigger from an unprimed username even after another username resolved Developer', async () => {
+      const memberAccess = new StubMemberAccessGateway();
+      memberAccess.setAccess('dev-actor', MEMBER_ACCESS_LEVELS.developer);
+      const pendingGateway = new StubPendingReviewRequestGateway();
+
+      const trustedTracking = createMockTrackingGateway(null);
+      const trustedDeps = buildGatedDeps(trustedTracking, memberAccess, pendingGateway);
+      const trustedEvent = GitLabEventFactory.createWithReviewerAdded('claude-bot');
+      trustedEvent.user = { username: 'dev-actor', name: 'Dev Actor' };
+
+      await handleGitLabWebhook(
+        asRequest(trustedEvent),
+        mockReply,
+        logger,
+        trustedTracking,
+        trustedDeps,
+      );
+
+      expect(enqueueReview).toHaveBeenCalledTimes(1);
+      expect(pendingGateway.saveCount).toBe(0);
+
+      const malloryTracking = createMockTrackingGateway(null);
+      const malloryDeps = buildGatedDeps(malloryTracking, memberAccess, pendingGateway);
+      const malloryEvent = GitLabEventFactory.createWithReviewerAdded('claude-bot');
+      malloryEvent.user = { username: 'mallory', name: 'Mallory' };
+
+      await handleGitLabWebhook(
+        asRequest(malloryEvent),
+        mockReply,
+        logger,
+        malloryTracking,
+        malloryDeps,
+      );
+
+      expect(enqueueReview).toHaveBeenCalledTimes(1);
+      expect(pendingGateway.saveCount).toBe(1);
+      expect(memberAccess.calls).toEqual([
+        { projectPath: PROJECT_PATH, username: 'dev-actor' },
+        { projectPath: PROJECT_PATH, username: 'mallory' },
+      ]);
+    });
+  });
+
+  describe('AC6 — token-boundary ordering', () => {
+    it('rejects an invalid-token trigger with 401 and never queries the membership gateway', async () => {
+      vi.mocked(verifyGitLabSignature).mockReturnValueOnce({ valid: false, error: 'bad-token' });
+      const tracking = createMockTrackingGateway(null);
+      const memberAccess = new StubMemberAccessGateway();
+      memberAccess.setAccess('dev-actor', MEMBER_ACCESS_LEVELS.developer);
+      const pendingGateway = new StubPendingReviewRequestGateway();
+      const deps = buildGatedDeps(tracking, memberAccess, pendingGateway);
+
+      const event = GitLabEventFactory.createWithReviewerAdded('claude-bot');
+      event.user = { username: 'dev-actor', name: 'Dev Actor' };
+
+      await handleGitLabWebhook(asRequest(event), mockReply, logger, tracking, deps);
+
+      expect(mockReply.status).toHaveBeenCalledWith(401);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'bad-token' });
+      expect(enqueueReview).not.toHaveBeenCalled();
+      expect(memberAccess.calls.length).toBe(0);
+    });
+  });
+});

--- a/src/tests/units/interface-adapters/controllers/webhook/gitlab.controller.test.ts
+++ b/src/tests/units/interface-adapters/controllers/webhook/gitlab.controller.test.ts
@@ -669,6 +669,49 @@ describe('handleGitLabWebhook', () => {
     });
 
     describe('AC4 - fail-closed membership resolution', () => {
+      function buildFollowupMr(): TrackedMr {
+        return TrackedMrFactory.create({
+          id: 'gitlab-test-org/test-project-42',
+          mrNumber: 42,
+          platform: 'gitlab',
+          project: 'test-org/test-project',
+          state: 'pending-review',
+          openThreads: 3,
+          autoFollowup: true,
+          lastPushAt: '2026-05-26T12:00:00.000Z',
+          lastReviewAt: '2026-05-25T12:00:00.000Z',
+        });
+      }
+
+      function buildNoteEvent(note: string) {
+        return {
+          object_kind: 'note',
+          event_type: 'note',
+          user: { username: 'note-author', name: 'Note Author' },
+          project: {
+            id: 1,
+            name: 'test-project',
+            path_with_namespace: 'test-org/test-project',
+            web_url: 'https://gitlab.com/test-org/test-project',
+            git_http_url: 'https://gitlab.com/test-org/test-project.git',
+          },
+          object_attributes: {
+            id: 7,
+            note,
+            noteable_type: 'MergeRequest',
+            noteable_id: 99,
+          },
+          merge_request: {
+            iid: 42,
+            title: 'Test MR',
+            state: 'opened',
+            source_branch: 'feature/test',
+            target_branch: 'main',
+            url: 'https://gitlab.com/test-org/test-project/-/merge_requests/42',
+          },
+        };
+      }
+
       it('parks a reviewer-added trigger when membership resolution throws', async () => {
         mockGateway.getById.mockReturnValue(null);
         const memberAccess = new StubMemberAccessGateway();
@@ -684,6 +727,47 @@ describe('handleGitLabWebhook', () => {
 
         expect(enqueueReview).not.toHaveBeenCalled();
         expect(pendingGateway.saveCount).toBe(1);
+      });
+
+      it('parks a followup trigger when membership resolution throws', async () => {
+        const followupMr = buildFollowupMr();
+        mockGateway.getById.mockImplementation(() => followupMr);
+        mockGateway.getByNumber.mockImplementation(() => followupMr);
+        mockGateway.recordPush.mockImplementation(() => followupMr);
+        const memberAccess = new StubMemberAccessGateway();
+        memberAccess.setShouldFail(true);
+        const pendingGateway = new StubPendingReviewRequestGateway();
+        const deps = buildGatedDeps(memberAccess, pendingGateway);
+
+        const event = GitLabEventFactory.createMrUpdate();
+        event.user = { username: 'dev-actor', name: 'Dev Actor' };
+        const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+        await handleGitLabWebhook(request, mockReply, logger, mockGateway, deps);
+
+        expect(enqueueReview).not.toHaveBeenCalled();
+        expect(pendingGateway.saveCount).toBe(1);
+      });
+
+      it('parks a note trigger when membership resolution throws', async () => {
+        vi.mocked(getGitLabEventType).mockReturnValueOnce('Note Hook');
+        const memberAccess = new StubMemberAccessGateway();
+        memberAccess.setShouldFail(true);
+        const pendingGateway = new StubPendingReviewRequestGateway();
+        const deps = buildGatedDeps(memberAccess, pendingGateway);
+
+        const request = {
+          body: buildNoteEvent('/bypass-quality "reason here"'),
+          headers: {},
+        } as unknown as FastifyRequest;
+
+        await handleGitLabWebhook(request, mockReply, logger, mockGateway, deps);
+
+        expect(mockReply.status).toHaveBeenCalledWith(202);
+        expect(mockReply.send).toHaveBeenCalledWith(
+          expect.objectContaining({ status: 'pending-confirmation', reason: 'untrusted-actor' }),
+        );
+        expect(mockGateway.update).not.toHaveBeenCalled();
       });
     });
   });
@@ -721,6 +805,22 @@ describe('handleGitLabWebhook', () => {
       expect(mockReply.status).toHaveBeenCalledWith(401);
       expect(mockReply.send).toHaveBeenCalledWith({ error: 'bad-token' });
       expect(enqueueReview).not.toHaveBeenCalled();
+    });
+
+    it('never queries the membership gateway when the token is invalid (SPEC-197 AC6)', async () => {
+      vi.mocked(verifyGitLabSignature).mockReturnValueOnce({ valid: false, error: 'bad-token' });
+      const memberAccess = new StubMemberAccessGateway();
+      memberAccess.setAccess('dev-actor', MEMBER_ACCESS_LEVELS.developer);
+      const deps = { ...defaultDeps, isTrustedActor: new IsTrustedActorUseCase(memberAccess) };
+
+      const event = GitLabEventFactory.createWithReviewerAdded('claude-bot');
+      event.user = { username: 'dev-actor', name: 'Dev Actor' };
+      const request = { body: event, headers: {} } as unknown as FastifyRequest;
+
+      await handleGitLabWebhook(request, mockReply, logger, mockGateway, deps);
+
+      expect(mockReply.status).toHaveBeenCalledWith(401);
+      expect(memberAccess.calls.length).toBe(0);
     });
 
     it('ignores events that are neither Note Hook nor Merge Request Hook', async () => {
@@ -897,6 +997,23 @@ describe('handleGitLabWebhook', () => {
         expect.objectContaining({ status: 'pending-confirmation', reason: 'untrusted-actor' }),
       );
       expect(mockGateway.update).not.toHaveBeenCalled();
+    });
+
+    it('lets a note trigger from a Developer actor proceed past the provenance gate (AC3 positive)', async () => {
+      const memberAccess = new StubMemberAccessGateway();
+      memberAccess.setAccess('note-author', MEMBER_ACCESS_LEVELS.developer);
+      const deps = { ...defaultDeps, isTrustedActor: new IsTrustedActorUseCase(memberAccess) };
+      const request = {
+        body: buildNoteEvent('/bypass-quality "reason here"'),
+        headers: {},
+      } as unknown as FastifyRequest;
+
+      await handleGitLabWebhook(request, mockReply, logger, mockGateway, deps);
+
+      expect(mockReply.status).not.toHaveBeenCalledWith(202);
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'bypass-recorded' }),
+      );
     });
   });
 


### PR DESCRIPTION
## What

Closes the SDD outer loop for **SPEC-197 — Trusted-actor trigger provenance gate**.

The gate itself was already implemented and wired live on `master` (membership gateway, `IsTrustedActorUseCase`, `actorTrusted` park branch, all three trigger entry points gated in `gitlab.controller.ts`). Only the SDD artifacts were missing. **No production code touched** — test-only + small gap hardening + bookkeeping.

## Changes

- `src/tests/acceptance/197-trusted-actor-provenance-gate.acceptance.test.ts` — outer-loop acceptance test, 6 AC cases through the `handleGitLabWebhook` chokepoint (real `IsTrustedActorUseCase(StubMemberAccessGateway)` + real `GateClaudeInvocationUseCase`), state-based. GREEN 6/6.
- `gitlab.controller.test.ts` — gap hardening: G1 (AC4 followup + note fail-closed park-on-throw), G2 (AC6 membership gateway never called on invalid token), G3 (AC3 positive Developer-note proceeds). 43 → 47 tests.
- `docs/specs/197-...md` — `status: draft → implemented` + `## Implementation` AC matrix.
- `docs/feature-tracker.md` — SPEC-197 row → `implemented`.
- `docs/plans/` + `docs/reports/` — plan & report persisted.

## Verification

`yarn verify` GREEN — 3717 tests (446 files). No `src/` production file changed. No defect found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)