### PR TITLE
fix(egress): scan recovery-path output + close SPEC-199 SDD loop

### DIFF
--- a/docs/feature-tracker.md
+++ b/docs/feature-tracker.md
@@ -64,3 +64,4 @@
 | Webhook event idempotency & replay protection | [200-webhook-event-idempotency](specs/200-webhook-event-idempotency.md) | implemented | 2026-06-10 |
 | Transport and source provenance hardening | [201-transport-provenance-hardening](specs/201-transport-provenance-hardening.md) — [plan](plans/201-transport-provenance-hardening.plan.md) | implemented | 2026-06-10 |
 | Trusted-actor trigger provenance gate | [197-trusted-actor-provenance-gate](specs/197-trusted-actor-provenance-gate.md) — [plan](plans/197-trusted-actor-provenance-gate.plan.md) — [report](reports/197-trusted-actor-provenance-gate.report.md) | implemented | 2026-06-10 |
+| Review output egress scan before posting | [199-review-output-egress-scan](specs/199-review-output-egress-scan.md) — [plan](plans/199-review-output-egress-scan.plan.md) — [report](reports/199-review-output-egress-scan.report.md) | implemented | 2026-06-10 |

--- a/docs/plans/199-review-output-egress-scan.plan.md
+++ b/docs/plans/199-review-output-egress-scan.plan.md
@@ -1,0 +1,191 @@
+# PLAN: SPEC-199 — Review output egress scan before posting
+
+> Audit + SDD close-loop plan.
+> Base branch: `ca2c0c9` (includes SPEC-201, SPEC-197, SPEC-196, SPEC-198 merges).
+> Spec: `docs/specs/199-review-output-egress-scan.md` (status: `draft`).
+
+## Verdict
+
+**SUBSTANTIALLY IMPLEMENTED — close the SDD loop, with ONE real wiring gap to fix.**
+
+All of the spec's deterministic machinery already exists, is wired into the four
+production review paths (`src/main/routes.ts:425, 438, 549, 602`), and has passing
+unit + service-level tests. The egress decorator is a genuine shared chokepoint:
+both executors funnel public-output verbs (`POST_COMMENT`, `THREAD_REPLY`) through
+`executePublicOutput` → the injected `NoteCommentPostGateway`, which in production is
+always the `EgressScannedNoteCommentPostGateway`.
+
+Two things are missing to honestly close the SDD loop:
+
+1. **GAP-1 (real bug, AC9 violation on a live path).** The boot-time review-recovery
+   path calls `executeActionsFromContext` **without** the post gateway
+   (`src/main/server.ts:238-243`, only 4 args). Because `postGateway` defaults to
+   `null` (`contextActionsExecutor.ts:65`), the `postGateway === null` branch
+   (`contextActionsExecutor.ts:93-95`) routes **all** actions — including LLM-derived
+   `POST_COMMENT` / `THREAD_REPLY` bodies persisted in the recovered `ReviewContext` —
+   straight through the raw CLI primitive, bypassing the egress scan. This is exactly
+   the class of bypass AC9 forbids ("no public-output verb may reach the note/comment
+   primitive without passing the decorator"), on a non-test code path.
+
+2. **GAP-2 (SDD outer-loop artifact).** No `src/tests/acceptance/199-*.acceptance.test.ts`
+   exists, and SPEC-199 is absent from `docs/feature-tracker.md`. The spec is still
+   `draft`. The outer-loop acceptance test that proves the chokepoint across the full
+   auto-path verb set has not been written.
+
+Everything else (AC1–AC8) is COVERED by existing artifacts + passing tests.
+
+## AC coverage matrix
+
+| AC | Verdict | Artifact (file:line) | Test (file → name) |
+|----|---------|----------------------|--------------------|
+| **AC1** — single enforcement point on the post sink | COVERED | `egressScanned.noteCommentPost.gateway.ts:15-42` (decorator wraps `postComment`, scans before sink) | `egressScanned.noteCommentPost.gateway.test.ts:9-70` — "AC1 — single enforcement point" (pass/redact/block, secret never reaches sink) |
+| **AC2** — secret-shape scan allow/redact/block | COVERED | `egressScan.scanner.ts:18-19` (`SECRET_SHAPE_PATTERN`: glpat/ghp/sk-/AKIA/JWT), `:39-48` (mode branch) | `egressScan.scanner.test.ts:16-75` — "secret-shape scan (AC2)" (4 cases: clean pass, redact marker, block no-body, allow untouched) |
+| **AC3** — deterministic length cap | COVERED | `egressScan.scanner.ts:65-75` (truncate with `truncationMarker` or block) | `egressScan.scanner.test.ts:77-110` — "length cap (AC3)" (truncate ≤ cap + marker; block mode) |
+| **AC4** — out-of-scope reference scan | COVERED | `egressScan.scanner.ts:21,27-29,50-63` (`PROJECT_REFERENCE_PATTERN` + `isOutOfScope` vs `projectPath`) | `egressScan.scanner.test.ts:112-152` — "out-of-scope reference scan (AC4)" (in-scope pass, foreign redact, foreign block) |
+| **AC5** — fail-closed on scanner error | COVERED | `egressScanned.noteCommentPost.gateway.ts:22-23` (scanner called first; any throw propagates **before** `sink.postComment`, so the sink is never reached — fail-closed by construction) | `egressScanned.noteCommentPost.gateway.test.ts:72-85` — "AC5 — fail-closed on scanner error" (scanner `setShouldFail(true)` → rejects, `sink.calls` length 0) |
+| **AC6** — trace without secret | COVERED | `egressScan.scanner.ts:79-92` (trace = channel + mode + `matchCategoryCounts`, never the matched value); `egressScanned.noteCommentPost.gateway.ts:30,35` (records on block/redact only); `loggerEgressTrace.gateway.ts:9-18` (logs counts, not body) | `egressScan.scanner.test.ts:154-171` — "trace metadata carries no secret (AC6)"; `egressScanned.noteCommentPost.gateway.test.ts:87-148` — "AC6 — trace without secret" (redact/block record; clean pass records none; `JSON.stringify(trace)` excludes secret) |
+| **AC7** — `THREAD_REPLY` egress is scanned | COVERED | `publicOutputExecutor.ts:11-24` (`THREAD_REPLY` body → `executePublicOutput`); `threadActionsExecutor.ts:93-100` + `contextActionsExecutor.ts:97-104` route public-output through the injected decorated gateway | `threadActionsExecutor.egress.test.ts:49-69` — "routes a THREAD_REPLY body through the decorated sink, never the raw CLI primitive"; `contextActionsExecutor.egress.test.ts:79-104` — same for context path |
+| **AC8** — revoke accompanying-comment (out-of-scope-by-design for auto path) | COVERED (by design, no auto-path obligation) | `autoExecutorActionFilter.ts:26-46` (auto path admits only `readMr`+`postComment`; `revoke`/`threadResolve`/`addLabel` dropped → no auto revoke exists) — matches SPEC-196 AC6 | No deterministic auto-path test required per spec AC8. Indirectly evidenced by `contextActionsExecutor.egress.test.ts:140-166` and `threadActionsExecutor.egress.test.ts:108-120` (SPEC-196 unwire drops `THREAD_RESOLVE`/`ADD_LABEL`) |
+| **AC9** — channel exhaustiveness (no unscanned public-output verb) | **PARTIAL** | Table-driven coverage exists for **executor-level** routing of `{POST_COMMENT, THREAD_REPLY}` via the decorated sink while other verbs use the CLI primitive — BUT the **recovery path bypasses it entirely** (`server.ts:238-243` omits the post gateway). The chokepoint guarantee is not exhaustive across all live callers. | `threadActionsExecutor.egress.test.ts:122-142` — "AC9 — every auto-path public-output verb reaches only the decorated sink"; `contextActionsExecutor.egress.test.ts:106-138` — "AC9 — public-output verbs reach the decorated sink…". **Missing:** a test asserting the recovery path scans (or an end-to-end acceptance test over all callers). |
+
+### AC9 PARTIAL — exact gap
+
+The two AC9 unit tests prove the **executor** is a chokepoint *when a post gateway is
+injected*. They do not prove **every production caller injects it**. The recovery
+caller does not. So the "no public-output verb may reach the note/comment primitive
+without passing the decorator" guarantee is violated on the recovery path. The
+acceptance test (below) plus the GAP-1 fix close this.
+
+## Existing artifacts inventory
+
+Domain (entities):
+- `egressScan.gateway.ts` — `EgressScanGateway` port, `EgressScanInput/Result/Trace`, `EgressChannel` = `'postComment' | 'THREAD_REPLY' | 'POST_COMMENT'`, `EgressMatchCategory`.
+- `egressScan.scanner.ts` — pure `createEgressScanner(config)`; secret-shape + out-of-scope + length-cap with allow/redact/block.
+- `egressScan.defaults.ts` — `defaultEgressScanConfig` (secret=redact, length=redact, **out-of-scope=allow**, cap 65536).
+- `egressTrace.gateway.ts` — `EgressTraceGateway` port (`record(trace)`).
+
+Interface-adapters (gateways):
+- `egressScanned.noteCommentPost.gateway.ts` — `EgressScannedNoteCommentPostGateway implements NoteCommentPostGateway` (the decorator) + `EgressBlockedError`.
+- `loggerEgressTrace.gateway.ts` — `LoggerEgressTraceGateway` (Pino `warn`, counts only).
+
+Services (the routing glue):
+- `publicOutputExecutor.ts` — `isPublicOutputAction` + `executePublicOutput` (the single fan-in to `postGateway.postComment`).
+- `contextActionsExecutor.ts` / `threadActionsExecutor.ts` — split public-output vs CLI, route the former through the injected gateway.
+
+Test doubles:
+- `egressScan.stub.ts` — `StubEgressScanGateway` (`setResult`, `setShouldFail`), `StubEgressTraceGateway` (records traces).
+- `noteCommentPost.stub.ts` — `StubNoteCommentPostGateway` (records `calls`).
+
+Production wiring (composition root):
+- `routes.ts:409-410` builds `egressScanner` + `egressTraceGateway`.
+- `routes.ts:425, 438, 549, 602` inject `EgressScannedNoteCommentPostGateway` into the GitLab/GitHub processor deps and both webhook controllers.
+
+## Wiring / chokepoint analysis
+
+Single fan-in point: every public-output body converges on
+`executePublicOutput` (`publicOutputExecutor.ts:26-42`) → `postGateway.postComment(...)`.
+In production that `postGateway` is the `EgressScannedNoteCommentPostGateway`. The
+decorator scans, then either throws `EgressBlockedError` (block), records a trace and
+posts the redacted body (redact), or posts unchanged (pass). Non-public-output verbs
+(`POST_INLINE_COMMENT`, and — pre-SPEC-196-drop — `THREAD_RESOLVE`/`ADD_LABEL`) go to
+the CLI gateway, never the note/comment primitive used for public comments.
+
+Callers that correctly inject the decorated gateway:
+- `gitlab.controller.ts:732-738, 767, 1167-1173, 1199` and direct `deps.noteCommentPostGateway.postComment` at `:209, :459`.
+- `github.controller.ts:635-641, 658-668, 1021-1031, 1042-1048` and direct posts at `:207, :288`.
+- `dispatchConstrainedActions.ts:42-52` (SPEC-198 chokepoint) forwards `postGateway`.
+
+Caller that **bypasses** the decorated gateway (GAP-1):
+- `server.ts:238-243` — recovery calls `executeActionsFromContext(context, localPath, logger, defaultCommandExecutor)` with no 5th `postGateway` arg → `null` → raw CLI for public output.
+
+## Test suite run results
+
+Run command (worktree node_modules must be linked first — see Memory note "Worktree node_modules"):
+
+```
+yarn vitest run \
+  src/tests/units/entities/egressScan/egressScan.scanner.test.ts \
+  src/tests/units/interface-adapters/gateways/egressScanned.noteCommentPost.gateway.test.ts \
+  src/tests/units/services/contextActionsExecutor.egress.test.ts \
+  src/tests/units/services/threadActionsExecutor.egress.test.ts
+```
+
+> NOTE: not executed in this planning pass (read-only audit; this is a planner agent,
+> not the implementer, and the worktree `node_modules` link/`yarn install` is a
+> precondition the implementer must satisfy first). The implementer MUST run the
+> command above and paste the real pass/fail counts into the report before claiming
+> GREEN. Expected from static reading: all four suites pass (they assert only on
+> observable stub state and use the real scanner/decorator). Do not claim GREEN
+> without running.
+
+## Gaps to build (close-loop work, via TDD)
+
+### GAP-1 — fix the recovery bypass (RED test first, then 1-line wiring)
+- **Scope**: `src/main/server.ts:237-244`. Thread the production decorated gateway into the recovery `executeActions` closure so recovered `POST_COMMENT`/`THREAD_REPLY` bodies are scanned.
+- **Where the decorated gateway lives**: it is currently built inside `registerRoutes` (`routes.ts:409-443`). The recovery closure is in `startServer` (`server.ts`). The implementer must decide the minimal seam — either (a) build a `noteCommentPostGateway` per platform at the recovery site mirroring `routes.ts:425/438`, or (b) hoist the egress scanner/trace construction so `server.ts` can build the decorator. Prefer the smallest change that does NOT duplicate config; do NOT introduce a new abstraction (YAGNI). **Note**: recovery has no single platform in scope per call — `reviewRecovery.service.ts` iterates repositories and passes `context` (which carries `context.platform`). The wiring must pick the GitLab- or GitHub-backed CLI sink per `context.platform`, matching the processor-deps split.
+- **RED test**: extend `contextActionsExecutor.egress.test.ts` is NOT enough (it already passes a gateway). Add a focused test that the **recovery wiring** passes a decorated gateway — most honestly expressed as an assertion in the acceptance test (below) driving the recovery entrypoint, or a `server`-level test. Minimal viable: a unit test on the recovery `executeActions` closure proving it forwards a post gateway. The implementer chooses the cheapest seam that fails RED before the fix.
+- **Constraint**: do NOT change scanner/decorator behaviour; this is pure wiring.
+
+### GAP-2 — SDD outer-loop acceptance test + tracker (see ACCEPTANCE_TEST)
+
+## ACCEPTANCE_TEST (SDD outer loop)
+
+```
+ACCEPTANCE_TEST:
+  file: src/tests/acceptance/199-review-output-egress-scan.acceptance.test.ts
+  note: "SDD outer loop — written first by the implementer, RED until GAP-1 wiring lands, GREEN at the end"
+```
+
+Shape (mirror `198-constrained-action-surface.acceptance.test.ts` and
+`196-least-privilege-platform-token.acceptance.test.ts` style — Detroit, real stub
+sink + real scanner, zero `vi.fn`):
+
+- **Doubles**:
+  - real `createEgressScanner(redactConfig)` (secret=redact, out-of-scope=redact, length=redact, small cap) — the REAL scanner, not a stub, to exercise true detection.
+  - real `StubNoteCommentPostGateway` as the underlying sink (records `calls`).
+  - real `StubEgressTraceGateway` (records `traces`).
+  - decorator under test: `new EgressScannedNoteCommentPostGateway(sink, scanner, trace)`.
+  - a `RecordingExecutor` (CLI) capturing `args` to assert the raw note primitive is never hit with a secret (the "guard counter on the raw sink reads zero" from spec AC9 / test strategy).
+  - a fixed `SECRET = 'glpat-abcdefghij1234567890'`.
+
+- **Scenarios** (table-driven over the auto-path verb set `{POST_COMMENT, THREAD_REPLY}`):
+  1. **AC9 chokepoint via `executeThreadActions`** — drive each public-output verb with a secret-shape body through `executeThreadActions(actions, gitlabContext, logger, recordingExecutor, decoratedGateway)`; assert: `sink.calls` count equals the number of public-output verbs, every `sink.calls[].body` excludes `SECRET` and contains `[REDACTED]`, the raw executor recorded zero args containing `SECRET`, and a trace was recorded per redacted body.
+  2. **AC9 chokepoint via `executeActionsFromContext`** — same verbs persisted in a `ReviewContext.actions`; same assertions. Proves both executors share the enforcement point.
+  3. **AC2/AC5 block + fail-closed end-to-end** — with a block-mode scanner config, a secret body raises `EgressBlockedError` and `sink.calls` is empty; with the `StubEgressScanGateway.setShouldFail(true)`, the post is never made and an error is raised.
+  4. **GAP-1 recovery path is scanned (the loop-closing assertion)** — drive the recovery entrypoint (or its `executeActions` closure as wired in `server.ts`) with a recovered `ReviewContext` whose actions carry a secret-shape `POST_COMMENT`; assert the secret never reaches the raw CLI primitive (recording executor has zero secret-bearing args) and the decorated sink received a redacted body. **This case is RED until GAP-1 is fixed.**
+  5. **AC8 out-of-scope-by-design guard** — a recovered/auto context containing `THREAD_RESOLVE` + a `revoke`-class action records zero CLI writes for those verbs (proving no auto revoke whose comment could egress), referencing SPEC-196 unwire.
+
+- **Observable assertions only** (never model obedience): sink called/not, body transformed, error raised, trace recorded, raw-executor secret-arg counter == 0.
+
+## Out of scope for this close-loop (per spec "Out of scope")
+
+- Authorization / target validation of write verbs → SPEC-198 (already merged).
+- Provenance / actor identity → SPEC-197 / SPEC-201 (already merged).
+- Diff sanitization + ambient token scoping → SPEC-196 / SPEC-174.
+- `revoke` and its accompanying comment on any future write-executor path (AC8 closes out-of-scope-by-design here).
+- Any ML / semantic content classification (YAGNI — spec bounds shapes + volume only).
+- Changing scanner detection rules or default config (no new threat categories — the amendment is a coverage extension only).
+
+## IMPLEMENTATION_ORDER (close-loop)
+
+1. `src/tests/acceptance/199-review-output-egress-scan.acceptance.test.ts` — write the outer-loop acceptance test FIRST; scenarios 1–3 + 5 GREEN immediately (machinery exists), scenario 4 (recovery) RED. Proves the spec and exposes GAP-1 deterministically.
+2. `src/main/server.ts:237-244` — minimal wiring fix so the recovery path posts public output through the decorated gateway (per-platform sink chosen by `context.platform`). Turns scenario 4 GREEN. No behaviour change to scanner/decorator.
+3. Run the 4 existing egress unit/service suites + the new acceptance test (`yarn vitest run …`); paste real pass counts into the report.
+4. `docs/feature-tracker.md` — add the SPEC-199 row (status `implemented`, link spec + this plan + report) mirroring the SPEC-197/200/201 rows at lines 64-66.
+5. `docs/specs/199-review-output-egress-scan.md` — flip front-matter `status: draft` → `status: implemented` (closes the SDD loop; satisfies the `verify-spec-updated` commit hook).
+6. `docs/reports/199-review-output-egress-scan.report.md` — implementer writes the AC matrix outcome + test run evidence.
+
+## REFERENCE_FILES
+
+- `src/modules/platform-integration/entities/egressScan/egressScan.gateway.ts` — port + channel/category/result types (the contract everything binds to).
+- `src/modules/platform-integration/entities/egressScan/egressScan.scanner.ts` — the deterministic detection logic (AC2/AC3/AC4).
+- `src/modules/platform-integration/entities/egressScan/egressScan.defaults.ts` — production config (note out-of-scope=allow by default).
+- `src/modules/platform-integration/interface-adapters/gateways/egressScanned.noteCommentPost.gateway.ts` — the chokepoint decorator (AC1/AC5/AC6) + `EgressBlockedError`.
+- `src/modules/review-execution/services/publicOutputExecutor.ts` — the single fan-in to the sink (where AC7/AC9 routing is decided).
+- `src/modules/review-execution/services/contextActionsExecutor.ts` + `threadActionsExecutor.ts` — the two executors and their `postGateway === null` bypass branch (GAP-1 root).
+- `src/main/routes.ts:409-443, 549-606` — production wiring of the decorator (the 4 correct injection sites).
+- `src/main/server.ts:232-256` — the recovery caller that omits the gateway (GAP-1).
+- `src/modules/platform-integration/services/autoExecutorActionFilter.ts` — SPEC-196 capability filter that makes AC8 out-of-scope-by-design.
+- `src/tests/acceptance/198-constrained-action-surface.acceptance.test.ts` + `196-least-privilege-platform-token.acceptance.test.ts` — the acceptance-test style to mirror.
+- `src/tests/stubs/egressScan.stub.ts` + `noteCommentPost.stub.ts` — the doubles to reuse.
+```

--- a/docs/reports/199-review-output-egress-scan.report.md
+++ b/docs/reports/199-review-output-egress-scan.report.md
@@ -1,0 +1,71 @@
+# SPEC-199 — Review output egress scan before posting — Implementation Report
+
+> Base branch: `ca2c0c9` (includes SPEC-196/198/200/201/197 merges).
+> Close-loop work: outer-loop acceptance test + one real security wiring fix + bookkeeping.
+> Spec: `docs/specs/199-review-output-egress-scan.md` — Plan: `docs/plans/199-review-output-egress-scan.plan.md`.
+
+## Outcome
+
+**SUBSTANTIALLY IMPLEMENTED on arrival → loop closed GREEN.** The egress-scan machinery
+(scanner, decorator, trace, executor routing) already existed and was wired into the four
+production review paths. This task added the missing SDD outer-loop acceptance test, fixed
+the one real bypass (GAP-1), and updated spec + tracker.
+
+## GAP-1 fix (production, security)
+
+**Bug:** the boot-time review-recovery path (`src/main/server.ts`) called
+`executeActionsFromContext` with only 4 args, so `postGateway` defaulted to `null` and the
+`postGateway === null` branch (`contextActionsExecutor.ts:93-95`) routed recovered
+LLM-derived `POST_COMMENT`/`THREAD_REPLY` bodies straight through the raw CLI primitive,
+**bypassing the egress scan** at boot.
+
+**Seam chosen:** extracted the recovery closure into an exported, testable factory
+`buildRecoveryExecuteActions(logger, egressTraceGateway, executors?)` in `src/main/server.ts`.
+It builds the per-platform note sink (`GitLabNoteCommentPostCliGateway` /
+`GitHubNoteCommentPostCliGateway`, selected by `context.platform`), wraps it in
+`EgressScannedNoteCommentPostGateway` with `createEgressScanner(defaultEgressScanConfig)` and a
+`LoggerEgressTraceGateway`, and passes it as the 6th `postGateway` arg. This reuses the exact
+scanner config + decorator the production routes use (`routes.ts:409-443`) — no config
+duplication, no new abstraction. Call site wired at `server.ts:300-302`.
+
+**Rationale for the factory seam:** the recovery closure lives in `startServer`, while the
+decorator was previously only built inside `registerRoutes`. Extracting a named factory is the
+smallest change that (a) makes the recovery path scan and (b) is directly unit/acceptance
+testable, vs. inlining (untestable) or hoisting the whole routes-level construction (larger diff).
+No scanner/decorator behaviour changed — pure wiring.
+
+## Files
+
+**Created**
+- `src/tests/acceptance/199-review-output-egress-scan.acceptance.test.ts` — outer-loop acceptance, 5 scenarios over `{POST_COMMENT, THREAD_REPLY}` (real `createEgressScanner` + `StubNoteCommentPostGateway` sink + `StubEgressTraceGateway` + `RecordingExecutor`, fixed `SECRET='glpat-abcdefghij1234567890'`). Scenario 4 drives `buildRecoveryExecuteActions` directly — RED before the fix, GREEN after.
+- `docs/reports/199-review-output-egress-scan.report.md` — this report.
+
+**Modified**
+- `src/main/server.ts` — GAP-1 fix (factory + wiring).
+- `docs/specs/199-review-output-egress-scan.md` — `status: draft → implemented` + `## Implementation` AC matrix.
+- `docs/feature-tracker.md` — SPEC-199 row → `implemented` (2026-06-10).
+
+## AC coverage
+
+| AC | Status | Evidence |
+|----|--------|----------|
+| AC1 single enforcement point | COVERED (pre-existing) | `egressScanned.noteCommentPost.gateway.ts:15-42` + test |
+| AC2 secret-shape scan | COVERED | `egressScan.scanner.ts:18-48` + scanner test |
+| AC3 length cap | COVERED | `egressScan.scanner.ts:65-75` + scanner test |
+| AC4 out-of-scope reference | COVERED | `egressScan.scanner.ts:21,27-29,50-63` + scanner test |
+| AC5 fail-closed on scanner error | COVERED | decorator scans before sink; acceptance scenario 3 |
+| AC6 trace without secret | COVERED | `egressScan.scanner.ts:79-92` + `loggerEgressTrace.gateway.ts` + tests |
+| AC7 THREAD_REPLY scanned | COVERED | `publicOutputExecutor.ts` + both `*.egress.test.ts` + acceptance scenarios 1–2 |
+| AC8 revoke comment (out-of-scope-by-design) | COVERED | SPEC-196 capability filter drops auto revoke; acceptance scenario 5 |
+| AC9 channel exhaustiveness (no unscanned public-output verb) | **CLOSED** | executor chokepoint tests + **GAP-1 recovery fix** + acceptance scenario 4 |
+
+## Verification
+
+- `yarn vitest run` (acceptance 199 + 4 egress suites): **34 tests pass** (5 files).
+- `yarn typecheck`: pass (server.ts composition-root change clean).
+- Scenario 4 (recovery scanned) confirmed RED-before / GREEN-after the GAP-1 fix.
+
+## Production code changed
+
+Yes — `src/main/server.ts` only (the GAP-1 security wiring fix). No scanner/decorator/executor
+behaviour changed. No other production file touched.

--- a/docs/specs/199-review-output-egress-scan.md
+++ b/docs/specs/199-review-output-egress-scan.md
@@ -1,12 +1,32 @@
 ---
 title: "SPEC-199: Review output egress scan before posting"
-status: draft
+status: implemented
 labels: [egress, defense-in-depth, reviewflow]
 visibility: PRIVATE-UNTIL-P0-SHIPPED
 depends_on: [SPEC-196]
 ---
 
 # SPEC-199: Review output egress scan before posting
+
+## Status: implemented
+
+## Implementation
+
+The deterministic egress machinery (scanner, decorator, single fan-in executor, per-platform wiring) shipped with the SPEC-196/198 cluster (landed 2026-06-10). The SDD outer-loop acceptance test was added 2026-06-17 to close the loop, and that pass uncovered **GAP-1**: the boot-time review-recovery path (`src/main/server.ts`) called `executeActionsFromContext` without the post gateway, so the `postGateway === null` branch routed recovered LLM-derived `POST_COMMENT` / `THREAD_REPLY` bodies straight through the raw CLI primitive, **bypassing the egress scan** — the exact class of bypass AC9 forbids, on a live (non-test) path. The fix threads the production decorated gateway into the recovery closure (per-platform CLI sink chosen by `context.platform`, wrapped in `EgressScannedNoteCommentPostGateway` with the same `defaultEgressScanConfig` + `LoggerEgressTraceGateway` the four webhook/processor sites use). Pure wiring — no scanner or decorator behaviour changed.
+
+| AC | Artifact | Test |
+|----|----------|------|
+| AC1 — single enforcement point on the post sink | `platform-integration/interface-adapters/gateways/egressScanned.noteCommentPost.gateway.ts` (decorator wraps `postComment`, scans before sink) | `units/.../egressScanned.noteCommentPost.gateway.test.ts` (`AC1 — single enforcement point`) |
+| AC2 — secret-shape scan allow/redact/block | `platform-integration/entities/egressScan/egressScan.scanner.ts` (`SECRET_SHAPE_PATTERN` + mode branch) | `units/.../egressScan.scanner.test.ts` (`secret-shape scan (AC2)`); acceptance `AC2 / AC5 — block and fail-closed end-to-end` |
+| AC3 — deterministic length cap | `platform-integration/entities/egressScan/egressScan.scanner.ts` (truncate-with-marker / block) | `units/.../egressScan.scanner.test.ts` (`length cap (AC3)`) |
+| AC4 — out-of-scope reference scan | `platform-integration/entities/egressScan/egressScan.scanner.ts` (`PROJECT_REFERENCE_PATTERN` + `isOutOfScope`) | `units/.../egressScan.scanner.test.ts` (`out-of-scope reference scan (AC4)`) |
+| AC5 — fail-closed on scanner error | `platform-integration/interface-adapters/gateways/egressScanned.noteCommentPost.gateway.ts` (scanner first; throw propagates before the sink) | `units/.../egressScanned.noteCommentPost.gateway.test.ts` (`AC5 — fail-closed on scanner error`); acceptance `fails closed when the scanner throws` |
+| AC6 — trace without secret | `platform-integration/entities/egressScan/egressScan.scanner.ts` (trace = channel + mode + counts); `loggerEgressTrace.gateway.ts` | `units/.../egressScan.scanner.test.ts` (`trace metadata carries no secret (AC6)`); `units/.../egressScanned.noteCommentPost.gateway.test.ts` (`AC6 — trace without secret`) |
+| AC7 — `THREAD_REPLY` egress is scanned | `review-execution/services/publicOutputExecutor.ts` + `threadActionsExecutor.ts` + `contextActionsExecutor.ts` (route public output through the injected decorated gateway) | `units/.../threadActionsExecutor.egress.test.ts`; `units/.../contextActionsExecutor.egress.test.ts`; acceptance `AC9 — every auto-path public-output verb is scanned` (table-driven over `{POST_COMMENT, THREAD_REPLY}`) |
+| AC8 — revoke accompanying-comment (out-of-scope-by-design for auto path) | `platform-integration/services/autoExecutorActionFilter.ts` (auto path admits only `readMr`+`postComment`; `revoke`/`threadResolve`/`addLabel` dropped → no auto revoke exists) | acceptance `AC8 — out-of-scope-by-design: no auto revoke whose comment could egress` (zero CLI writes for dropped verbs) |
+| AC9 — channel exhaustiveness (no unscanned public-output verb) | `review-execution/services/publicOutputExecutor.ts` (single fan-in); **GAP-1 fix** `src/main/server.ts` (`buildRecoveryExecuteActions` threads the decorated gateway into the recovery closure) | acceptance `199-review-output-egress-scan.acceptance.test.ts` — table-driven over both executors **plus the recovery path** (`the boot-time recovery path is scanned (GAP-1 close-loop)`); raw-executor secret-arg counter == 0 |
+
+DI wiring: `src/main/routes.ts:409-443` (four webhook/processor sites) and `src/main/server.ts` (`buildRecoveryExecuteActions`, GAP-1 fix). Doubles reused: `tests/stubs/egressScan.stub.ts`, `tests/stubs/noteCommentPost.stub.ts`. Outer-loop acceptance: `src/tests/acceptance/199-review-output-egress-scan.acceptance.test.ts` (8 scenarios, observable post-gateway/executor state only). Report: `docs/reports/199-review-output-egress-scan.report.md`.
 
 ## Context
 

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -10,11 +10,27 @@ import {
   loadSettingsFromDisk,
 } from '@/frameworks/settings/runtimeSettings.js';
 import { InMemorySupervisorHealthGateway } from '@/modules/claude-invocation/interface-adapters/gateways/supervisorHealth.memory.gateway.js';
+import { defaultEgressScanConfig } from '@/modules/platform-integration/entities/egressScan/egressScan.defaults.js';
+import { createEgressScanner } from '@/modules/platform-integration/entities/egressScan/egressScan.scanner.js';
+import type { EgressTraceGateway } from '@/modules/platform-integration/entities/egressScan/egressTrace.gateway.js';
+import { GitHubNoteCommentPostCliGateway } from '@/modules/platform-integration/interface-adapters/gateways/cli/noteCommentPost.github.cli.gateway.js';
+import { GitLabNoteCommentPostCliGateway } from '@/modules/platform-integration/interface-adapters/gateways/cli/noteCommentPost.gitlab.cli.gateway.js';
+import { EgressScannedNoteCommentPostGateway } from '@/modules/platform-integration/interface-adapters/gateways/egressScanned.noteCommentPost.gateway.js';
+import { LoggerEgressTraceGateway } from '@/modules/platform-integration/interface-adapters/gateways/loggerEgressTrace.gateway.js';
+import { defaultGitHubExecutor } from '@/modules/platform-integration/interface-adapters/gateways/threadFetch.github.gateway.js';
+import {
+  defaultGitLabExecutor,
+  type CommandExecutor as NoteCliExecutor,
+} from '@/modules/platform-integration/interface-adapters/gateways/threadFetch.gitlab.gateway.js';
 import type { JobRecord } from '@/modules/review-execution/entities/job/jobRecord.schema.js';
 import type { JobStatus } from '@/modules/review-execution/entities/job/reviewJob.js';
+import type { ReviewContext } from '@/modules/review-execution/entities/reviewContext/reviewContext.js';
 import { JobHistoryFileSystemGateway } from '@/modules/review-execution/interface-adapters/gateways/fileSystem/jobHistory.fileSystem.gateway.js';
 import { executeActionsFromContext } from '@/modules/review-execution/services/contextActionsExecutor.js';
-import { runReviewRecovery } from '@/modules/review-execution/services/reviewRecovery.service.js';
+import {
+  runReviewRecovery,
+  type ExecuteActionsOutcome,
+} from '@/modules/review-execution/services/reviewRecovery.service.js';
 import { defaultCommandExecutor } from '@/modules/review-execution/services/threadActionsExecutor.js';
 import { LoadRecentJobHistoryUseCase } from '@/modules/review-execution/usecases/jobHistory/loadRecentJobHistory.usecase.js';
 import { PersistJobRecordUseCase } from '@/modules/review-execution/usecases/jobHistory/persistJobRecord.usecase.js';
@@ -30,6 +46,7 @@ import {
   getDefaultSupervisorLockFilePath,
 } from '@/modules/supervisor-management/interface-adapters/gateways/supervisorLock.fileSystem.gateway.js';
 import { transportTrustProxyValue } from '@/security/transportGuardConfig.js';
+import type { CommandExecutor } from '@/shared/foundation/executionGateway.base.js';
 
 import { loadConfig, type Config } from '../config/loader.js';
 import {
@@ -95,6 +112,52 @@ function reviveJobStatusFromRecord(record: JobRecord): JobStatus {
     startedAt: new Date(record.startedAt),
     completedAt: new Date(record.completedAt),
     error: record.exitReason ?? undefined,
+  };
+}
+
+interface RecoveryExecuteActionsLogger {
+  info: (obj: object, msg: string) => void;
+  warn: (obj: object, msg: string) => void;
+  error: (obj: object, msg: string) => void;
+  debug: (obj: object, msg: string) => void;
+}
+
+export interface RecoveryExecuteActionsExecutors {
+  cliExecutor?: CommandExecutor;
+  gitLabNoteExecutor?: NoteCliExecutor;
+  gitHubNoteExecutor?: NoteCliExecutor;
+}
+
+export function buildRecoveryExecuteActions(
+  logger: RecoveryExecuteActionsLogger,
+  egressTraceGateway: EgressTraceGateway,
+  executors: RecoveryExecuteActionsExecutors = {},
+): (context: ReviewContext, localPath: string) => Promise<ExecuteActionsOutcome> {
+  const egressScanner = createEgressScanner(defaultEgressScanConfig);
+  const cliExecutor = executors.cliExecutor ?? defaultCommandExecutor;
+  const gitLabNoteExecutor = executors.gitLabNoteExecutor ?? defaultGitLabExecutor;
+  const gitHubNoteExecutor = executors.gitHubNoteExecutor ?? defaultGitHubExecutor;
+
+  return async (context, localPath) => {
+    const noteSink =
+      context.platform === 'gitlab'
+        ? new GitLabNoteCommentPostCliGateway(gitLabNoteExecutor)
+        : new GitHubNoteCommentPostCliGateway(gitHubNoteExecutor);
+    const noteCommentPostGateway = new EgressScannedNoteCommentPostGateway(
+      noteSink,
+      egressScanner,
+      egressTraceGateway,
+    );
+
+    const result = await executeActionsFromContext(
+      context,
+      localPath,
+      logger,
+      cliExecutor,
+      null,
+      noteCommentPostGateway,
+    );
+    return { posted: result.succeeded, failed: result.failed };
   };
 }
 
@@ -234,15 +297,10 @@ export async function startServer(options: ServerOptions = {}): Promise<FastifyI
       const summary = await runReviewRecovery({
         repositories: config.repositories.filter((repo) => repo.enabled),
         reviewContextGateway: deps.reviewContextGateway,
-        executeActions: async (context, localPath) => {
-          const result = await executeActionsFromContext(
-            context,
-            localPath,
-            deps.logger,
-            defaultCommandExecutor,
-          );
-          return { posted: result.succeeded, failed: result.failed };
-        },
+        executeActions: buildRecoveryExecuteActions(
+          deps.logger,
+          new LoggerEgressTraceGateway(deps.logger),
+        ),
         now: () => Date.now(),
         logger: deps.logger,
       });

--- a/src/tests/acceptance/199-review-output-egress-scan.acceptance.test.ts
+++ b/src/tests/acceptance/199-review-output-egress-scan.acceptance.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from 'vitest';
+
+import { buildRecoveryExecuteActions } from '@/main/server.js';
+import { defaultEgressScanConfig } from '@/modules/platform-integration/entities/egressScan/egressScan.defaults.js';
+import { createEgressScanner } from '@/modules/platform-integration/entities/egressScan/egressScan.scanner.js';
+import type { EgressScanConfig } from '@/modules/platform-integration/entities/egressScan/egressScan.scanner.js';
+import {
+  EgressBlockedError,
+  EgressScannedNoteCommentPostGateway,
+} from '@/modules/platform-integration/interface-adapters/gateways/egressScanned.noteCommentPost.gateway.js';
+import type { ReviewAction } from '@/modules/review-execution/entities/reviewAction/reviewAction.js';
+import type { ReviewContext } from '@/modules/review-execution/entities/reviewContext/reviewContext.js';
+import { executeActionsFromContext } from '@/modules/review-execution/services/contextActionsExecutor.js';
+import {
+  executeThreadActions,
+  type ExecutionContext,
+} from '@/modules/review-execution/services/threadActionsExecutor.js';
+import type { CommandExecutor } from '@/shared/foundation/executionGateway.base.js';
+import { StubEgressScanGateway, StubEgressTraceGateway } from '@/tests/stubs/egressScan.stub.js';
+import { StubNoteCommentPostGateway } from '@/tests/stubs/noteCommentPost.stub.js';
+
+const SECRET = 'glpat-abcdefghij1234567890';
+
+const redactConfig: EgressScanConfig = {
+  secretShapeMode: 'redact',
+  lengthMode: 'redact',
+  outOfScopeMode: 'redact',
+  maxBodyLength: 10000,
+  redactionMarker: '[REDACTED]',
+  truncationMarker: '…[TRUNCATED]',
+};
+
+const blockConfig: EgressScanConfig = {
+  ...redactConfig,
+  secretShapeMode: 'block',
+};
+
+const silentLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+class RecordingExecutor {
+  readonly calls: string[][] = [];
+  run: CommandExecutor = (_command, args) => {
+    this.calls.push(args);
+  };
+
+  secretBearingArgs(): string[][] {
+    return this.calls.filter((args) => args.some((arg) => arg.includes(SECRET)));
+  }
+}
+
+function buildDecoratedSink(config: EgressScanConfig = redactConfig) {
+  const sink = new StubNoteCommentPostGateway();
+  const trace = new StubEgressTraceGateway();
+  const scanner = createEgressScanner(config);
+  const gateway = new EgressScannedNoteCommentPostGateway(sink, scanner, trace);
+  return { sink, trace, gateway };
+}
+
+const gitlabExecutionContext: ExecutionContext = {
+  platform: 'gitlab',
+  projectPath: 'group/app',
+  mrNumber: 7,
+  localPath: '/tmp/repo',
+};
+
+const baseContext: ReviewContext = {
+  version: '1.0',
+  mergeRequestId: 'gitlab-group/app-7',
+  platform: 'gitlab',
+  projectPath: 'group/app',
+  mergeRequestNumber: 7,
+  createdAt: '2026-02-02T10:00:00Z',
+  threads: [],
+  actions: [],
+  progress: { phase: 'completed', currentStep: null },
+};
+
+const publicOutputVerbs: Array<{ name: string; action: ReviewAction }> = [
+  { name: 'POST_COMMENT', action: { type: 'POST_COMMENT', body: `## Review\ntoken ${SECRET}` } },
+  {
+    name: 'THREAD_REPLY',
+    action: { type: 'THREAD_REPLY', threadId: 'abc', message: `fixed ${SECRET}` },
+  },
+];
+
+describe('SPEC-199 review output egress scan (acceptance — shared chokepoint across all callers)', () => {
+  describe('AC9 — every auto-path public-output verb is scanned before reaching the sink', () => {
+    for (const { name, action } of publicOutputVerbs) {
+      it(`scans a ${name} body driven through executeThreadActions, never the raw note primitive`, async () => {
+        const { sink, trace, gateway } = buildDecoratedSink();
+        const executor = new RecordingExecutor();
+
+        await executeThreadActions(
+          [action],
+          gitlabExecutionContext,
+          silentLogger,
+          executor.run,
+          gateway,
+        );
+
+        expect(sink.calls).toHaveLength(1);
+        expect(sink.calls[0].body).toContain('[REDACTED]');
+        expect(sink.calls[0].body).not.toContain(SECRET);
+        expect(executor.secretBearingArgs()).toHaveLength(0);
+        expect(trace.traces).toHaveLength(1);
+      });
+
+      it(`scans a ${name} body persisted in a ReviewContext through executeActionsFromContext`, async () => {
+        const { sink, trace, gateway } = buildDecoratedSink();
+        const executor = new RecordingExecutor();
+        const context: ReviewContext = { ...baseContext, actions: [action] };
+
+        await executeActionsFromContext(
+          context,
+          '/tmp/repo',
+          silentLogger,
+          executor.run,
+          null,
+          gateway,
+        );
+
+        expect(sink.calls).toHaveLength(1);
+        expect(sink.calls[0].body).toContain('[REDACTED]');
+        expect(sink.calls[0].body).not.toContain(SECRET);
+        expect(executor.secretBearingArgs()).toHaveLength(0);
+        expect(trace.traces).toHaveLength(1);
+      });
+    }
+  });
+
+  describe('AC2 / AC5 — block and fail-closed end-to-end', () => {
+    it('raises EgressBlockedError and never reaches the sink for a secret body in block mode', async () => {
+      const { sink, gateway } = buildDecoratedSink(blockConfig);
+      const executor = new RecordingExecutor();
+
+      await expect(
+        executeThreadActions(
+          [{ type: 'POST_COMMENT', body: `summary ${SECRET}` }],
+          gitlabExecutionContext,
+          silentLogger,
+          executor.run,
+          gateway,
+        ),
+      ).rejects.toBeInstanceOf(EgressBlockedError);
+
+      expect(sink.calls).toHaveLength(0);
+      expect(executor.secretBearingArgs()).toHaveLength(0);
+    });
+
+    it('fails closed when the scanner throws — no post, error raised', async () => {
+      const sink = new StubNoteCommentPostGateway();
+      const trace = new StubEgressTraceGateway();
+      const scanner = new StubEgressScanGateway();
+      scanner.setShouldFail(true);
+      const gateway = new EgressScannedNoteCommentPostGateway(sink, scanner, trace);
+      const executor = new RecordingExecutor();
+
+      await expect(
+        executeThreadActions(
+          [{ type: 'POST_COMMENT', body: `summary ${SECRET}` }],
+          gitlabExecutionContext,
+          silentLogger,
+          executor.run,
+          gateway,
+        ),
+      ).rejects.toThrow();
+
+      expect(sink.calls).toHaveLength(0);
+    });
+  });
+
+  describe('AC9 — the boot-time recovery path is scanned (GAP-1 close-loop)', () => {
+    it('scans a recovered POST_COMMENT so the secret never reaches the raw CLI note primitive', async () => {
+      const cliCalls: string[][] = [];
+      const noteCommands: string[] = [];
+      const trace = new StubEgressTraceGateway();
+      const recoveredContext: ReviewContext = {
+        ...baseContext,
+        actions: [{ type: 'POST_COMMENT', body: `## Recovered review\ntoken ${SECRET}` }],
+      };
+
+      const executeActions = buildRecoveryExecuteActions(silentLogger, trace, {
+        cliExecutor: (_command, args) => {
+          cliCalls.push(args);
+        },
+        gitLabNoteExecutor: (command) => {
+          noteCommands.push(command);
+          return '';
+        },
+      });
+      await executeActions(recoveredContext, '/tmp/repo');
+
+      expect(noteCommands).toHaveLength(1);
+      expect(noteCommands[0]).toContain('[redacted]');
+      expect(noteCommands[0]).not.toContain(SECRET);
+      expect(cliCalls.some((args) => args.some((arg) => arg.includes(SECRET)))).toBe(false);
+      expect(trace.traces).toHaveLength(1);
+    });
+  });
+
+  describe('AC8 — out-of-scope-by-design: no auto revoke whose comment could egress (SPEC-196 unwire)', () => {
+    it('drops THREAD_RESOLVE / ADD_LABEL from the auto path, recording zero CLI writes for them', async () => {
+      const { sink, gateway } = buildDecoratedSink();
+      const executor = new RecordingExecutor();
+      const context: ReviewContext = {
+        ...baseContext,
+        actions: [
+          { type: 'POST_COMMENT', body: 'clean summary' },
+          { type: 'THREAD_RESOLVE', threadId: 't1' },
+          { type: 'ADD_LABEL', label: 'approved' },
+        ],
+      };
+
+      await executeActionsFromContext(
+        context,
+        '/tmp/repo',
+        silentLogger,
+        executor.run,
+        null,
+        gateway,
+      );
+
+      expect(sink.calls).toHaveLength(1);
+      expect(executor.calls.some((args) => args.includes('resolved=true'))).toBe(false);
+      expect(defaultEgressScanConfig.secretShapeMode).toBe('redact');
+    });
+  });
+});


### PR DESCRIPTION
## What

Closes the SDD outer loop for **SPEC-199 — Review output egress scan before posting**, and fixes one real security bypass found during the audit.

The egress-scan machinery (scanner, decorator, trace, executor routing) was already implemented and wired into the 4 production review paths. Missing: the outer-loop acceptance test, and a fix for the boot-time recovery bypass.

## Security fix (GAP-1)

The boot-time review-recovery path (`server.ts`) called `executeActionsFromContext` with only 4 args → `postGateway` defaulted to `null` → recovered LLM-derived `POST_COMMENT`/`THREAD_REPLY` bodies egressed through the **raw CLI primitive, bypassing the egress scan** at boot. The 4 webhook/processor sites wired it correctly; only recovery bypassed.

**Fix:** extracted `buildRecoveryExecuteActions(logger, egressTraceGateway, executors?)` that builds the per-platform note sink (by `context.platform`), wraps it in `EgressScannedNoteCommentPostGateway` with the same `defaultEgressScanConfig` scanner + `LoggerEgressTraceGateway` the production routes use, and passes it as the `postGateway` arg. Pure wiring — no scanner/decorator behaviour change.

## Changes

- `src/tests/acceptance/199-review-output-egress-scan.acceptance.test.ts` — 5 scenarios over `{POST_COMMENT, THREAD_REPLY}`, real scanner + stub sink. Scenario 4 drives `buildRecoveryExecuteActions` directly — RED before the fix, GREEN after.
- `src/main/server.ts` — GAP-1 fix.
- `docs/specs/199-...md` — `status: draft → implemented` + `## Implementation` AC matrix.
- `docs/feature-tracker.md` — SPEC-199 row → `implemented`.
- `docs/plans/` + `docs/reports/` — persisted.

## Verification

`yarn verify` GREEN — 3725 tests (447 files), format + lint clean. AC9 channel-exhaustiveness now closed (recovery scanned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)