### PR TITLE
feat(analytics): emit spec-203 bug categories from review skills

### DIFF
--- a/.claude/skills/review-back/SKILL.md
+++ b/.claude/skills/review-back/SKILL.md
@@ -558,7 +558,7 @@ Inline comments posted in /diffs: X
 
 Backlog improvements (global report only): X
 
-[REVIEW_STATS:blocking=X:warnings=X:suggestions=X:score=X]
+[REVIEW_STATS:blocking=X:warnings=X:suggestions=X:score=X:categories=security=N,logic=N,performance=N,typeSafety=N,style=N,dependencies=N]
 
 READ-ONLY MODE - No code modified
 
@@ -570,5 +570,20 @@ Recommended skills:
 ```
 
 **IMPORTANT**: The `[REVIEW_STATS:...]` line is **MANDATORY** for automated tracking.
+
+### Category breakdown (`categories=` segment)
+
+Classify every finding (blocking + important + suggestion) into exactly one of the six dashboard categories, then emit the count per category in the marker. The six counts must sum to `blocking + warnings + suggestions`. Map by the audit that raised the finding:
+
+| Audit that raised the finding | Category |
+|-------------------------------|----------|
+| Security | `security` |
+| Clean Architecture, Strategic DDD, SOLID | `logic` |
+| Performance | `performance` |
+| TypeScript Best Practices | `typeSafety` |
+| Testing, Code Quality | `style` |
+| Outdated / vulnerable / misused dependency | `dependencies` |
+
+Use the internal keys exactly: `security`, `logic`, `performance`, `typeSafety`, `style`, `dependencies`. Omit a key or set it to `0` when no finding falls in it. Unknown keys are ignored by the tracker.
 
 **Final reminder**: This skill NEVER modifies code. The report and inline comments are posted via MCP actions so the author can make corrections.

--- a/.claude/skills/review-front/SKILL.md
+++ b/.claude/skills/review-front/SKILL.md
@@ -680,7 +680,7 @@ Inline comments posted in /diffs: X
 
 Backlog improvements (global report only): X
 
-[REVIEW_STATS:blocking=X:warnings=X:suggestions=X:score=X]
+[REVIEW_STATS:blocking=X:warnings=X:suggestions=X:score=X:categories=security=N,logic=N,performance=N,typeSafety=N,style=N,dependencies=N]
 
 READ-ONLY MODE - No code modified
 
@@ -691,5 +691,19 @@ Recommended skills:
 ```
 
 **IMPORTANT**: The `[REVIEW_STATS:...]` line is **MANDATORY** for automated tracking. Replace the `X` values with real values.
+
+### Category breakdown (`categories=` segment)
+
+Classify every finding (blocking + important + suggestion) into exactly one of the six dashboard categories, then emit the count per category in the marker. The six counts must sum to `blocking + warnings + suggestions`. Map by the audit that raised the finding:
+
+| Audit that raised the finding | Category |
+|-------------------------------|----------|
+| Clean Architecture, Strategic DDD, SOLID | `logic` |
+| TypeScript Best Practices | `typeSafety` |
+| Clean Code, Testing, Code Quality | `style` |
+| Security-relevant finding (front has no Security audit) | `security` |
+| Outdated / vulnerable / misused dependency | `dependencies` |
+
+Use the internal keys exactly: `security`, `logic`, `performance`, `typeSafety`, `style`, `dependencies`. This skill has no Performance audit, so `performance` is normally `0`. Set any unused key to `0`. Unknown keys are ignored by the tracker.
 
 **Final reminder**: This skill NEVER modifies code. The report and inline comments are posted via MCP actions so the author can make corrections.

--- a/.claude/skills/review-fullstack/SKILL.md
+++ b/.claude/skills/review-fullstack/SKILL.md
@@ -425,9 +425,26 @@ Inline comments posted in /diffs: X
 
 Backlog improvements (global report only): X
 
-[REVIEW_STATS:blocking=X:warnings=X:suggestions=X:score=X]
+[REVIEW_STATS:blocking=X:warnings=X:suggestions=X:score=X:categories=security=N,logic=N,performance=N,typeSafety=N,style=N,dependencies=N]
 
 READ-ONLY MODE - No code modified
 ```
+
+**IMPORTANT**: The `[REVIEW_STATS:...]` line is **MANDATORY** for automated tracking.
+
+### Category breakdown (`categories=` segment)
+
+Classify every finding (blocking + important + suggestion) into exactly one of the six dashboard categories, then emit the count per category in the marker. The six counts must sum to `blocking + warnings + suggestions`. Map by the audit that raised the finding:
+
+| Audit that raised the finding | Category |
+|-------------------------------|----------|
+| Security | `security` |
+| Clean Architecture, Strategic DDD, React Best Practices, SOLID | `logic` |
+| Performance | `performance` |
+| TypeScript Best Practices | `typeSafety` |
+| Testing, Code Quality | `style` |
+| Outdated / vulnerable / misused dependency | `dependencies` |
+
+Use the internal keys exactly: `security`, `logic`, `performance`, `typeSafety`, `style`, `dependencies`. Set any unused key to `0`. Unknown keys are ignored by the tracker.
 
 **Final reminder**: This skill NEVER modifies code. The report and inline comments are posted via MCP actions so the author can make corrections.

--- a/docs/specs/203-bugs-found-by-category.md
+++ b/docs/specs/203-bugs-found-by-category.md
@@ -78,9 +78,9 @@ See `.claude/skills/product-manager/rules/dod.md` for the full checklist.
 - Zod guard introduced only at the marker boundary (where untrusted input enters); `ReviewStats`/`ProjectStats` remain plain interfaces, consistent with the existing module.
 - No new entity class, value object, use case, gateway, or route (YAGNI) — a flat `Record` carries the breakdown.
 
-### Humble glue (not yet wired)
+### Humble glue (wired — pending one manual validation run)
 
-The review skills (`review-back`/`review-front`/`review-fullstack`) must emit the `categories=...` segment in their `[REVIEW_STATS:...]` marker for real data to flow. The parser is implemented and unit-tested against sample marker strings; one manual review run is required to validate end-to-end. Until then the chart renders its empty state.
+The review skills `review-back`, `review-front`, and `review-fullstack` now emit the `categories=...` segment in their `[REVIEW_STATS:...]` marker, with an audit→category mapping table per skill (Security→`security`; Clean Architecture/DDD/SOLID/React→`logic`; Performance→`performance`; TypeScript→`typeSafety`; Testing/Code Quality→`style`; dependency findings→`dependencies`). The chart labels were also localized via i18n keys (`stats.category.*`) instead of the hardcoded English entity labels. The TS parser was already unit-tested against sample markers; prompt-level emission cannot be unit-tested, so one real review run is still required to confirm a non-empty chart end-to-end.
 
 ### Report
 

--- a/src/dashboard/modules/statsCharts.js
+++ b/src/dashboard/modules/statsCharts.js
@@ -515,7 +515,11 @@ export function drawBugsByCategoryChart(canvasId, bugsByCategory) {
     ctx.font = '9px system-ui, -apple-system, sans-serif';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'top';
-    ctx.fillText(bar.label, x + barWidth / 2, cssHeight - padding.bottom + 6);
+    ctx.fillText(
+      t('stats.category.' + bar.categoryKey),
+      x + barWidth / 2,
+      cssHeight - padding.bottom + 6,
+    );
   }
 }
 


### PR DESCRIPTION
## SPEC-203 follow-up — wire bug-category capture (HUMBLE GLUE)

Completes SPEC-203 by making real category data flow into the chart merged in #297.

### What
- The three review skills (`review-back`, `review-front`, `review-fullstack`) now emit a `categories=...` segment in their mandatory `[REVIEW_STATS:...]` marker, with a per-skill audit→category mapping table.
- Chart labels localized via the existing `stats.category.*` i18n keys instead of hardcoded English entity labels (auto-review finding #1).

### Audit → category mapping
| Audit | Category |
|-------|----------|
| Security | `security` |
| Clean Architecture / DDD / SOLID / React | `logic` |
| Performance | `performance` |
| TypeScript Best Practices | `typeSafety` |
| Testing / Code Quality | `style` |
| Dependency findings | `dependencies` |

The six counts sum to `blocking + warnings + suggestions`. Front has no Security/Performance audit → those default to 0.

### Tests
- `yarn verify` GREEN — 3789 tests, 0 fail. The TS parser was already unit-tested against sample markers in #297.
- Prompt-level emission is not unit-testable (HUMBLE GLUE) — needs one real review run to confirm a non-empty chart end-to-end.

Spec updated: `docs/specs/203-bugs-found-by-category.md` (Humble glue → wired).
