### PR TITLE
refactor(webhook): processWebhook orchestrator + WebhookEvent union (spec-073 stage 3)

### DIFF
--- a/docs/feature-tracker.md
+++ b/docs/feature-tracker.md
@@ -22,7 +22,7 @@
 | Skill catalog system | [61-skill-catalog-system](specs/61-skill-catalog-system.md) | drafted | 2026-03-14 |
 | Skill create command | [62-skill-create-command](specs/62-skill-create-command.md) | drafted | 2026-03-14 |
 | Extract dashboard domain modules | [72-extract-dashboard-domain-modules](specs/72-extract-dashboard-domain-modules.md) | implemented | 2026-03-14 |
-| Extract webhook processing usecase | [73-extract-webhook-processing-usecase](specs/73-extract-webhook-processing-usecase.md) — [plan (Stage 1)](plans/73-execute-review-usecase.plan.md) — [report (Stage 1)](reports/73-execute-review-usecase.report.md) — [plan (Stage 2)](plans/73-handle-close.plan.md) — [report (Stage 2)](reports/73-handle-close.report.md) | implementing | 2026-06-20 |
+| Extract webhook processing usecase | [73-extract-webhook-processing-usecase](specs/73-extract-webhook-processing-usecase.md) — [plan (Stage 1)](plans/73-execute-review-usecase.plan.md) — [report (Stage 1)](reports/73-execute-review-usecase.report.md) — [plan (Stage 2)](plans/73-handle-close.plan.md) — [report (Stage 2)](reports/73-handle-close.report.md) — [plan (Stage 3)](plans/73-process-webhook.plan.md) — [report (Stage 3)](reports/73-process-webhook.report.md) | implementing (Stage 3 done, Stage 4 remaining) | 2026-06-20 |
 | Standardize MR vocabulary | [77-standardize-mr-vocabulary](specs/77-standardize-mr-vocabulary.md) | implemented | 2026-03-14 |
 | Remove old progress tracking | [79-remove-old-progress-tracking](specs/79-remove-old-progress-tracking.md) | implemented | 2026-03-15 |
 | Split stats service | [80-split-stats-service](specs/80-split-stats-service.md) — [plan](plans/80-split-stats-service.plan.md) — [report](reports/80-split-stats-service.report.md) | implemented | 2026-06-19 |

--- a/docs/plans/73-process-webhook.plan.md
+++ b/docs/plans/73-process-webhook.plan.md
@@ -1,0 +1,399 @@
+# Plan — SPEC-073 Stage 3: ProcessWebhook orchestrator + WebhookEvent union
+
+## STAGE 3 DECISION LOCK (user-validated — overrides any approve detail below)
+
+The `approve` path STAYS 100% controller-side in Stage 3 (folded into Stage 4). The orchestrator
+routes ONLY: `close`, `merge`, `followup-push` (eligibility), `ignored`. Concretely:
+
+- **`WebhookEvent` union**: defines all 6 variants per spec (`review-requested | followup-push |
+  close | merge | approve | ignored`). `review-requested` and `approve` are present for
+  completeness/Stage-4 but are NOT routed by the orchestrator — controllers handle them inline,
+  unchanged, and simply never pass them to `processWebhook`.
+- **`processWebhook` switch** is total: `close`/`merge`/`followup-push`/`ignored` route as below;
+  the `review-requested` and `approve` branches return `{ type: 'ignored', reason: '<variant>-handled-by-controller' }`
+  (defensive — controllers never send them, but the switch stays exhaustive without a `never` throw).
+- **`ProcessWebhookResult`** = `closed | merged | followup-eligible | followup-skipped | ignored`.
+  DROP `approved` / `approval-revoked` / `approval-ignored` (§2).
+- **`ProcessWebhookDependencies`** = `handleClose`, `transitionState`, `recordPush`,
+  `checkFollowupNeeded`, `removeWorktree`, `logger`. DROP `handlePlatformApproval` and
+  `getQualityThreshold` (§3) — those were approve-only.
+- **Controllers**: approve branch untouched (no mapping to `WebhookEvent`, no `processWebhook` call).
+- **Tests**: drop all approve cases from the acceptance + unit plan (§6).
+
+Everything else in the plan stands. Sections below that still mention approve routing are
+superseded by this lock.
+
+---
+
+> Scope: Stage 3 ONLY. Stages 1-2 (`executeReview`, `handleClose`) are DONE. Stage 4
+> (full controller thinning + HTTP response-shape unification) is OUT OF SCOPE — not planned here.
+> The spec (`docs/specs/73-extract-webhook-processing-usecase.md`) is STALE on structure:
+> flat `src/usecases/` paths and all line numbers are pre-modular-monolith. All paths below
+> are verified against the real `src/modules/<context>/...` tree.
+
+```
+PLAN:
+  scope: ProcessWebhook orchestrator + platform-neutral WebhookEvent union (synchronous routing only)
+  is_new_module: false  (adds a webhook entity folder + one usecase in existing modules)
+```
+
+---
+
+## 0. Headline decision (read this first)
+
+**The orchestrator owns ONLY the synchronous, platform-neutral routing: `close`, `merge`,
+`approve`, `ignored`, and the followup *eligibility* decision (recordPush + checkFollowupNeeded).
+It does NOT own the enqueue closure that captures `executeReview`.** The asynchronous
+enqueue path (budget gate → processor closure → `gateClaudeInvocation`/`enqueueReview` →
+distinct 202 reply shapes) STAYS controller-side for Stage 3. Rationale in §4.
+
+This makes Stage 3 a small, honest increment: it introduces the platform-neutral seam
+(`WebhookEvent` in the entity layer) and lifts the genuinely shared synchronous handlers
+(close/merge/approve) behind one orchestrator, without dragging queue/budget/gate
+infrastructure inward (which is Stage 4's job).
+
+---
+
+## 1. WebhookEvent union (ENTITY layer)
+
+### Location + Dependency Rule justification
+
+File: `src/modules/platform-integration/entities/webhookEvent/webhookEvent.ts`  (new folder)
+
+Why the entity layer, not interface-adapters: **both** webhook controllers (interface-adapters)
+AND `processWebhook.usecase.ts` (application) import this type. Per the Dependency Rule
+(`entities ← usecases ← interface-adapters`), a type shared by a usecase and a controller must
+live at or below the usecase layer. Placing it in `interface-adapters/` would force the usecase
+to import outward — forbidden. The `platform-integration` context owns webhook ingress vocabulary,
+so its `entities/` is the correct home (sibling to `gitlab/`, `github/`, `threadFetch/`).
+
+It is a pure type module (a discriminated union of plain data) — no Zod schema/guard needed:
+the data is already validated upstream by the platform guards (`gitLabMergeRequestEventGuard`,
+`gitHubPullRequestEventGuard`); `WebhookEvent` is an internal mapping target, not a trust
+boundary. (Anti-overengineering: no guard for a type that never crosses an untrusted boundary.)
+
+### Definition (verified real field names)
+
+`Platform` = `'gitlab' | 'github'` from
+`@/modules/tracking/entities/tracking/reviewRequestTracking.gateway.js`.
+`Language` = `'en' | 'fr'` from
+`@/modules/shared-kernel/entities/language/language.schema.js`.
+Controllers already resolve `localPath` (via `findRepositoryByProjectPath` /
+`findRepositoryByRemoteUrl`) BEFORE mapping — so every non-ignored variant carries it (spec line 488).
+
+```typescript
+import type { Language } from '@/modules/shared-kernel/entities/language/language.schema.js';
+import type { Platform } from '@/modules/tracking/entities/tracking/reviewRequestTracking.gateway.js';
+
+export interface WebhookEventBase {
+  platform: Platform;
+  projectPath: string;
+  localPath: string;
+  mergeRequestNumber: number;
+}
+
+export type WebhookEvent =
+  | ({ type: 'review-requested';
+      mergeRequestUrl: string;
+      sourceBranch: string;
+      targetBranch: string;
+      title: string;
+      description: string | null;
+      assignedBy: { username: string; displayName: string | null };
+      skill: string;
+      language: Language | null } & WebhookEventBase)
+  | ({ type: 'followup-push';
+      mergeRequestUrl: string;
+      sourceBranch: string;
+      targetBranch: string } & WebhookEventBase)
+  | ({ type: 'close' } & WebhookEventBase)
+  | ({ type: 'merge' } & WebhookEventBase)
+  | ({ type: 'approve' } & WebhookEventBase)
+  | { type: 'ignored'; reason: string };
+```
+
+Notes on field choices (verified against controllers):
+- `description: string | null` and `language: Language | null` use `null` not `undefined`
+  (domain rule). Controllers currently pass `event.object_attributes?.description` /
+  `getProjectLanguage(...)` which may be `undefined`; the controller mapper coalesces to `null`.
+- `assignedBy.displayName: string | null` — controllers build `displayName` from
+  `mrAssignee?.name || event.user?.name` (GitLab) / `prAssignee?.login || event.sender?.login`
+  (GitHub); both can be absent → `null`.
+- `skill` is per-repo (`repoConfig.skill`) — resolved controller-side, carried in the event.
+- The `review-requested` and `followup-push` variants are defined now (the union must be complete
+  and they are the controller's mapping target), but in Stage 3 the orchestrator does NOT consume
+  their async tail — see §3/§4.
+
+---
+
+## 2. ProcessWebhookResult union (what controllers need to format HTTP)
+
+Returned by `processWebhook`. Each variant carries exactly what the controller needs to reproduce
+its EXISTING reply (status code + body). HTTP shapes are unchanged in Stage 3 (Stage 4 unifies them).
+
+```typescript
+export type ProcessWebhookResult =
+  // close → reproduces the 200 { status:'cleaned', mrNumber/prNumber, jobCancelled, trackingArchived }
+  | { type: 'closed'; mergeRequestNumber: number; jobCancelled: boolean; trackingArchived: boolean }
+  // merge → 200 { status:'merged', mrNumber/prNumber }
+  | { type: 'merged'; mergeRequestNumber: number }
+  // approve happy path → 200 { status:'approved', ... }
+  | { type: 'approved'; mergeRequestNumber: number }
+  // approve quality-gate revoke → 200 { status:'unapproved', ..., reason }
+  | { type: 'approval-revoked'; mergeRequestNumber: number; reason: 'below-threshold' | 'blockers-present' }
+  // approve ignored (not tracked / verdict not reverted) → 200 { status:'ignored', ..., reason }
+  | { type: 'approval-ignored'; mergeRequestNumber: number; reason: string }
+  // followup eligible → controller proceeds to enqueue (KEEPS its async path)
+  | { type: 'followup-eligible'; mergeRequestNumber: number }
+  // followup not eligible (auto-followup disabled, no open threads, not pending-fix, not tracked)
+  | { type: 'followup-skipped'; mergeRequestNumber: number; reason: string }
+  // anything else → 200 { status:'ignored', reason }
+  | { type: 'ignored'; reason: string };
+```
+
+**Deliberate non-result: there is NO `review-requested` result variant in Stage 3.** A review
+request is not resolved synchronously by the orchestrator (it needs budget + gate + enqueue,
+which stay controller-side). The controller maps a parsed review-request event straight into its
+existing enqueue path and never calls `processWebhook` for it in Stage 3. The `review-requested`
+*event* variant exists in the union for completeness and Stage-4 use; the orchestrator's router
+treats it as out-of-its-scope (see §3 routing table).
+
+> Honesty flag: this asymmetry (event union is complete, result union + router only cover the
+> synchronous subset) is the price of keeping Stage 3 small. It is explicitly a transitional
+> shape; Stage 4 absorbs the async tail. See §8.
+
+---
+
+## 3. Orchestrator routing table (variant → existing usecase call)
+
+`processWebhook(event, deps)` switches on `event.type`:
+
+| `event.type` | Orchestrator action (composes EXISTING code) | Returns |
+|---|---|---|
+| `close` | `await deps.handleClose({ platform, projectPath, localPath, mergeRequestNumber })` | `{ type:'closed', mergeRequestNumber, jobCancelled, trackingArchived }` |
+| `merge` | `deps.transitionState.execute({ projectPath: localPath, mrId, targetState:'merged' })` then `await deps.removeWorktree({...})` best-effort | `{ type:'merged', mergeRequestNumber }` |
+| `approve` | `deps.transitionState.execute({ ..., targetState:'approved', qualityCheck })`; on `quality-gate` → `deps.handlePlatformApproval.execute(...)`; map verdict | `approved` \| `approval-revoked` \| `approval-ignored` |
+| `followup-push` | `deps.recordPush.execute({...})` then `deps.checkFollowupNeeded.execute({...})` + `autoFollowup` check | `followup-eligible` \| `followup-skipped` |
+| `review-requested` | NOT routed by orchestrator in Stage 3 — controller handles inline | (controller never calls processWebhook for it) |
+| `ignored` | none | `{ type:'ignored', reason }` |
+
+`mrId` is built inside the orchestrator as `` `${platform}-${projectPath}-${mergeRequestNumber}` ``
+(the exact format both controllers use today, e.g. gitlab.controller.ts:322,361).
+
+### `ProcessWebhookDependencies` (verified, function-style — second param)
+
+Mirrors `executeReview`/`handleClose` style: explicit `deps`, all imports inward-only.
+
+```typescript
+export interface ProcessWebhookDependencies {
+  handleClose: HandleClose;                    // @/modules/review-execution/usecases/handleClose.usecase.js
+  transitionState: Pick<TransitionStateUseCase, 'execute'>;       // tracking usecase
+  handlePlatformApproval: Pick<HandlePlatformApprovalUseCase, 'execute'>;
+  recordPush: Pick<RecordPushUseCase, 'execute'>;
+  checkFollowupNeeded: Pick<CheckFollowupNeededUseCase, 'execute'>;
+  removeWorktree: RemoveWorktreeAction;        // worktree entity
+  getQualityThreshold: (projectPath: string) => number | null;
+  logger: Logger;
+}
+```
+
+Dependency Rule audit — every import is inward-safe:
+- `HandleClose`, `RemoveWorktreeAction`, `TransitionStateUseCase`, `HandlePlatformApprovalUseCase`,
+  `RecordPushUseCase`, `CheckFollowupNeededUseCase` are usecases/entity types — the orchestrator
+  imports only `entities/` + sibling `usecases/`. **No `interface-adapters/`, no `frameworks/`,
+  no platform-specific type** (`GitLabMergeRequestEvent` / `GitHubPullRequestEvent` never appear).
+- `evaluateQualityGate` (entity, `@/modules/tracking/entities/qualityGate/qualityGate.js`) is used
+  to build the `qualityCheck` closure for the approve path — already entity-layer, inward-safe.
+- The approve path's *platform side effects* (`approvalRevocationGateway.revoke`,
+  `noteCommentPostGateway.postComment`) are platform/HTTP gateways → they STAY in the controller.
+  The orchestrator returns `approval-revoked` with the reason; the controller performs the
+  platform revoke + FR comment exactly as today. (This keeps the usecase free of platform gateways.)
+
+> Approve nuance: today the revoke+comment happen *inside* the controller's `quality-gate` branch.
+> Stage 3 splits it: orchestrator decides the verdict (tracked? gate passed? reverted?), controller
+> executes the platform I/O. The orchestrator returning `approval-revoked` is the signal to revoke.
+> This is the one place Stage 3 reshapes control flow; it is justified because the *decision* is
+> platform-neutral and shared, while the *I/O* is not. If this proves too invasive during TDD,
+> fall back to leaving the entire approve branch in the controller (orchestrator handles only
+> close/merge/followup-eligibility) — flagged as an acceptable de-scope.
+
+---
+
+## 4. Enqueue-ownership decision — orchestrator vs controller
+
+**Decision: the enqueue closure (which captures `executeReview`) STAYS controller-side in Stage 3.
+The orchestrator owns only synchronous routing + followup-eligibility.**
+
+### Why (smallest honest change preserving behavior)
+
+The `review-requested` / `followup-push` async tails in BOTH controllers are a dense knot of
+HTTP- and platform-coupled concerns that cannot move inward without Stage-4-scale surgery:
+
+1. **Budget gate** — `deps.enforceBudget.execute({ localPaths: listEnabledLocalPaths(...) })` then,
+   on rejection, `deps.broadcastBudgetExceeded({...})` (a WebSocket side-effect) and a
+   `200 { status:'rejected', reason:'budget-exceeded' }` reply. (gitlab.controller.ts:695-716,
+   github.controller.ts:614-635.)
+2. **Processor closure capturing `executeReview`** — built per-platform via
+   `buildGitLabReviewProcessor` / `buildGitHubReviewProcessor`, which capture repo config,
+   `getProjectAgentsOrFocusDefaults`, `extractBaseUrl(repoConfig.remoteUrl)` (GitLab) vs `null`
+   (GitHub), `loadProjectConfig(...).qualityThreshold`. These read `@/config/...` and live
+   platform-side. (gitlab.controller.ts:797-816, github.controller.ts:695-710.)
+3. **Trigger-actor provenance gate (SPEC-197)** — `resolveActorTrust(...)` + `actorTrusted` is
+   GitLab-only and uses `event.user.username`; wired into `gateClaudeInvocation`.
+   (gitlab.controller.ts:720-769.)
+4. **`gateClaudeInvocation` vs raw `enqueueReview`** — the gate decides park-pending vs enqueue and
+   produces THREE distinct 202/200 reply shapes (`pending-confirmation`, `queued`, `deduplicated`).
+   (gitlab.controller.ts:727-785, github.controller.ts:639-683.)
+
+Moving any of this into a platform-neutral usecase would force `enforceBudget`,
+`broadcastBudgetExceeded`, the processor-builder, `gateClaudeInvocation`, and HTTP reply-shape
+decisions across the boundary — i.e. it would BE Stage 4 (controller thinning + HTTP unification),
+which is explicitly out of scope. Doing it now would also be a large blast radius against the most
+behavior-sensitive path (review triggering), risking regressions the spec warns about.
+
+### Can the enqueue closure cleanly move into a platform-neutral usecase?
+
+Not cleanly in Stage 3. The closure captures (a) `executeReview` (already a usecase — fine), but
+also (b) per-platform agent/baseUrl/skill/quality config read from `@/config`, (c)
+`gateClaudeInvocation` + actor-trust, (d) budget + broadcast. (b)–(d) are platform/HTTP/config
+concerns. A platform-neutral `processReview` usecase would need all of them injected and would have
+to *return* the gate's 3-way verdict for the controller to format — which is precisely Stage 4's
+contract. **Conclusion: it must stay controller-side for Stage 3; flag it as the natural seam Stage 4
+will cut.** The `followup-push` eligibility *decision* (recordPush + checkFollowupNeeded +
+autoFollowup) IS platform-neutral and DOES move into the orchestrator; only the subsequent
+budget+gate+enqueue tail stays controller-side.
+
+---
+
+## 5. File list (create / modify) — verified real paths
+
+### Create
+| Path | Purpose |
+|---|---|
+| `src/modules/platform-integration/entities/webhookEvent/webhookEvent.ts` | `WebhookEvent` discriminated union (entity layer) |
+| `src/modules/platform-integration/usecases/processWebhook.usecase.ts` | Orchestrator: `processWebhook(event, deps)`, `ProcessWebhookResult`, `ProcessWebhookDependencies` |
+| `src/tests/units/modules/platform-integration/usecases/processWebhook.usecase.test.ts` | Unit tests (inside-out) for the orchestrator |
+| `src/tests/acceptance/73-process-webhook.acceptance.test.ts` | SDD outer loop (RED → GREEN) |
+
+> `WebhookEvent` is a pure type union → no `.test.ts` of its own (nothing to assert at runtime;
+> it is exercised through the orchestrator + controller-mapper tests). No guard/factory needed.
+
+### Modify
+| Path | Change |
+|---|---|
+| `src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts` | Map parsed close/merge/approve/followup events → `WebhookEvent`; call `deps.processWebhook`; map `ProcessWebhookResult` → existing reply. Review-request async path UNCHANGED. Add `processWebhook` to `GitLabWebhookDependencies`. |
+| `src/modules/platform-integration/interface-adapters/controllers/webhook/github.controller.ts` | Same mapping for close/approve(review-hook)/followup. Add `processWebhook` to `GitHubWebhookDependencies`. |
+| `src/main/routes.ts` | Instantiate `processWebhook` deps (compose existing usecases) and inject into both controller dep objects. |
+| `src/tests/units/.../webhook/gitlab.controller.test.ts` (+ github) | Update to assert delegation to `processWebhook` for the synchronous variants; preserve reply-shape assertions. (Existing files — locate the real mirror path before editing.) |
+
+> `eventFilter.ts` is NOT modified — its `filter*` functions stay and become the mappers the
+> controllers use to build `WebhookEvent` (spec "Out of Scope"). Confirmed: `FilterResult` already
+> exposes `mergeRequestNumber`, `projectPath`, `mergeRequestUrl`, `sourceBranch`, `targetBranch`,
+> `isFollowup` — the exact fields the union needs.
+
+---
+
+## 6. TDD test plan (outer loop SDD → inner loop inside-out)
+
+### Outer loop (write FIRST, stays RED during impl, GREEN at end)
+`src/tests/acceptance/73-process-webhook.acceptance.test.ts` — drives `processWebhook` directly
+(no HTTP fixtures), mirroring the Stage-2 acceptance style (harness builder + stub gateways):
+- close → `{ type:'closed', jobCancelled, trackingArchived }`, one shared path for both platforms.
+- merge → `{ type:'merged' }`, transitionState called with `targetState:'merged'`, worktree removal best-effort.
+- approve happy → `{ type:'approved' }`; quality-gate fail + reverted → `{ type:'approval-revoked', reason }`; not-tracked → `{ type:'approval-ignored' }`.
+- followup-push eligible (pending-fix + open threads + autoFollowup) → `{ type:'followup-eligible' }`.
+- followup-push skipped: auto-followup disabled / no open threads / not tracked → `{ type:'followup-skipped', reason }`.
+- ignored → `{ type:'ignored', reason }`.
+- **Platform-neutrality assertion**: the test imports NO `GitLab*`/`GitHub*` event type; it builds
+  `WebhookEvent` values directly — proving the usecase is platform-agnostic.
+
+### Inner loop (inside-out, Red→Green→Refactor per behavior)
+1. **Entity**: `WebhookEvent` union compiles + is consumed by a trivial exhaustive `switch`
+   (compile-time exhaustiveness via `never` in the default branch of the orchestrator). No separate
+   runtime test (pure type).
+2. **Usecase**: `processWebhook.usecase.test.ts` — one `describe` per variant, state-based asserts
+   on stub gateways (reuse `StubReviewContextGateway`, `InMemoryReviewRequestTrackingGateway`,
+   `createStubLogger`; add lightweight fn stubs for `transitionState`/`handlePlatformApproval`/
+   `recordPush`/`checkFollowupNeeded`/`removeWorktree`/`getQualityThreshold`). Mirrors the
+   `buildHarness(overrides?)` pattern from the Stage-2 test.
+3. **Controller mapping**: extend existing controller tests to assert (a) close/merge/approve/
+   followup now delegate to `processWebhook` and (b) the HTTP reply for each result variant is
+   byte-for-byte what the controller produced before (status code + body keys, incl. GitLab
+   `mrNumber` vs GitHub `prNumber`). Review-request tests stay green unchanged (path untouched).
+
+### Verification gate
+`yarn verify` (typecheck + lint + `test:ci`) green; acceptance GREEN at the end.
+(Worktree caveat from MEMORY: ensure `node_modules` is linked before running tests.)
+
+---
+
+## 7. Smallest honest change note — what I deliberately do NOT touch
+
+- **Review-request enqueue path** (budget gate, processor closure capturing `executeReview`,
+  `gateClaudeInvocation`, actor-trust, `enqueueReview`, 3-way reply): left 100% in the controllers.
+  This is the largest, most behavior-sensitive block — moving it is Stage 4.
+- **HTTP reply shapes**: preserved exactly (incl. the `mrNumber`/`prNumber` divergence and all
+  current status strings). No unification — that is Stage 4's named deliverable.
+- **`eventFilter.ts`**: untouched (out of scope per spec). It supplies the mapper inputs.
+- **Note/issue-comment/bypass hooks, idempotency guard, `enforceBudget`, `broadcastBudgetExceeded`,
+  `extractBaseUrl`, `_trackingGateway` param removal**: all untouched. The unused `_trackingGateway`
+  param removal is explicitly deferred to Stage 4 by the spec.
+- **`executeReview` / `handleClose` usecases**: consumed as-is, contracts unchanged.
+- **No new dependency, no `as Type`, no `undefined` in the new domain type, full words throughout.**
+
+---
+
+## 8. Anti-overengineering check (honest)
+
+**Is the orchestrator earning its place in Stage 3, or is it transitional scaffolding?**
+
+Partly transitional — and I am flagging it rather than hiding it.
+
+What it genuinely earns NOW:
+- **De-duplicates real shared logic**: close/merge/approve handling is structurally duplicated
+  across both controllers today (verified: gitlab.controller.ts:287-451 vs
+  github.controller.ts:355-383 + 120-240). One orchestrator collapses that duplication and makes
+  it testable without HTTP fixtures — concrete value, matching the spec's core motivation.
+- **Introduces the platform-neutral seam** (`WebhookEvent` in entities) that Stage 4 needs; doing it
+  now with the synchronous subset is a low-risk way to land the type and the import direction.
+
+Where it is scaffolding:
+- The `ProcessWebhookResult` → reply mapping in controllers is temporary glue that Stage 4 deletes
+  when HTTP shapes unify. The result union's shape is chosen to *minimize* that glue, not to be a
+  final contract.
+- The event union carries `review-requested` / `followup-push` async fields the Stage-3 orchestrator
+  does not consume — present for completeness/Stage-4, not yet load-bearing.
+
+Verdict: **proceed, but keep it minimal.** The orchestrator pays for itself on close/merge/approve
+de-duplication alone; the rest is a deliberately thin bridge to Stage 4. Guard against scope creep:
+do NOT add a `review-requested` result variant, do NOT move budget/gate/enqueue inward, do NOT touch
+reply shapes. If, during TDD, the approve verdict-vs-I/O split (§3) proves invasive, de-scope approve
+to stay controller-side and ship close/merge/followup-eligibility only — still a net win, still honest.
+
+```
+ACCEPTANCE_TEST:
+  file: src/tests/acceptance/73-process-webhook.acceptance.test.ts
+  note: "SDD outer loop — written first by implementer, RED during impl, GREEN at the end"
+```
+
+---
+
+## REFERENCE_FILES (read before implementing)
+
+- `src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts` — close (287-315), merge (317-354), approve (356-451), followup (470-628), review enqueue (630-786, STAYS); reply shapes to preserve.
+- `src/modules/platform-integration/interface-adapters/controllers/webhook/github.controller.ts` — close (355-383), approve via review-hook (120-240), followup (404-537), review enqueue (539-684, STAYS).
+- `src/modules/platform-integration/interface-adapters/controllers/webhook/eventFilter.ts` — `FilterResult` fields + `filter*` mappers (NOT modified; they build the union).
+- `src/modules/review-execution/usecases/handleClose.usecase.ts` — `HandleClose` signature consumed by orchestrator.
+- `src/modules/review-execution/usecases/executeReview.usecase.ts` — STAYS in the controller-owned processor closure (read to confirm it is not moved inward).
+- `src/modules/review-execution/usecases/triggerReview.usecase.ts` — function-style + `deps` template to mirror.
+- `src/modules/review-execution/usecases/handleReviewRequestPush.usecase.ts` — existing followup-eligibility logic to mirror/compose (recordPush + state + open-threads checks).
+- `src/modules/review-execution/usecases/gateClaudeInvocation.usecase.ts` — confirms the gate/enqueue knot that STAYS controller-side.
+- `src/modules/tracking/usecases/tracking/transitionState.usecase.ts` — `targetState:'merged'|'approved'`, `qualityCheck`, `TransitionStateResult` (`ok`/`reason`).
+- `src/modules/tracking/usecases/tracking/{recordPush,checkFollowupNeeded,handlePlatformApproval,syncThreads}.usecase.ts` — composed dependency signatures.
+- `src/modules/tracking/entities/tracking/reviewRequestTracking.gateway.ts` — `Platform` type source + `archive`/`getById`.
+- `src/modules/shared-kernel/entities/language/language.schema.ts` — `Language` = `'en'|'fr'`.
+- `src/modules/worktree-management/entities/worktree/worktree.schema.ts` — `RemoveWorktreeAction`, `RemoveResult`.
+- `src/tests/acceptance/73-handle-close.acceptance.test.ts` — harness/stub style to mirror for the new acceptance test.
+- `src/main/routes.ts` — composition root; wire `processWebhook` deps here (LAST step).
+```
+```

--- a/docs/reports/73-process-webhook.report.md
+++ b/docs/reports/73-process-webhook.report.md
@@ -1,0 +1,92 @@
+# Report — SPEC-073 Stage 3: ProcessWebhook orchestrator + WebhookEvent union
+
+Plan: `docs/plans/73-process-webhook.plan.md` (DECISION LOCK enforced) · Spec: `docs/specs/73-extract-webhook-processing-usecase.md`
+
+## Status: OK Clean — `yarn verify` green (473 files / 3921 tests), acceptance GREEN
+
+## What shipped (Stage 3 only)
+
+A platform-neutral `WebhookEvent` discriminated union (entity layer) plus a function-based
+`processWebhook(event, deps)` orchestrator that routes the **synchronous** webhook outcomes
+(`close`, `merge`, `followup-push` eligibility, `ignored`). Both webhook controllers now map their
+already-parsed close/merge/followup events into `WebhookEvent`, call `deps.processWebhook`, and map
+the `ProcessWebhookResult` back to their **exact** existing HTTP replies (status code + body keys
+byte-for-byte, incl. GitLab `mrNumber` vs GitHub `prNumber`). Wired in the composition root.
+
+Per the DECISION LOCK, the `approve` and `review-requested` paths stay 100% controller-side
+(folded into Stage 4): the union carries both variants for completeness, but the orchestrator does
+not route them — they return `{ type: 'ignored', reason: '<variant>-handled-by-controller' }` to
+keep the switch total without a `never` throw. Budget gate, processor closure capturing
+`executeReview`, `gateClaudeInvocation`, actor-trust, and `enqueueReview` all remain controller-side.
+
+## Files created
+
+- `src/modules/platform-integration/entities/webhookEvent/webhookEvent.ts` — `WebhookEvent`
+  discriminated union (6 variants), pure type module (no Zod guard; data already validated upstream).
+- `src/modules/platform-integration/usecases/processWebhook.usecase.ts` — `processWebhook(event, deps)`,
+  `ProcessWebhookResult`, `ProcessWebhookDependencies`, `ProcessWebhook` function type. Imports only
+  `entities/` + sibling `usecases/` (Dependency Rule respected; no `interface-adapters/`, no
+  `frameworks/`, no platform-specific event type).
+- `src/tests/units/modules/platform-integration/usecases/processWebhook.usecase.test.ts` — 13 unit
+  tests (one describe per routed variant, state-based on fn stubs).
+- `src/tests/acceptance/73-process-webhook.acceptance.test.ts` — 8 acceptance tests (SDD outer loop),
+  drives `processWebhook` directly, imports NO `GitLab*`/`GitHub*` type (platform-neutrality proof).
+
+## Files modified
+
+- `gitlab.controller.ts` — close/merge/followup mapped → `WebhookEvent` → `deps.processWebhook`;
+  reply shapes preserved exactly. `processWebhook` added to `GitLabWebhookDependencies`. Approve and
+  review-request paths untouched (`deps.transitionState` re-qualified in approve branch since
+  `transitionState`/`recordPush`/`checkFollowupNeeded` were dropped from the handler destructuring).
+- `github.controller.ts` — close/followup mapped the same way (GitHub has no merge branch — a merged
+  PR arrives as close). `processWebhook` added to `GitHubWebhookDependencies`.
+- `src/main/routes.ts` — `processWebhook` composed per-platform from existing usecases (shares the
+  per-platform `handleClose` closure, now extracted into `gitLabHandleClose`/`gitHubHandleClose`),
+  injected into both controller dep objects.
+- 5 controller/acceptance test files updated to provide `processWebhook` composed from the same
+  stub/mock sub-deps: `gitlab.controller.test.ts`, `github.controller.test.ts`,
+  `gitlabIdempotency.controller.test.ts`, `200-webhook-event-idempotency.acceptance.test.ts`,
+  `197-trusted-actor-provenance-gate.acceptance.test.ts`, `46-github-followup-review-on-push.acceptance.test.ts`.
+
+## Test counts
+
+| Suite | Tests |
+|---|---|
+| `processWebhook.usecase.test.ts` (unit) | 13 |
+| `73-process-webhook.acceptance.test.ts` | 8 |
+| `gitlab.controller.test.ts` + `github.controller.test.ts` | 91 (preserved, reply shapes intact) |
+| Full `yarn test:ci` | 3921 pass / 473 files |
+
+`yarn verify` (typecheck + lint + format:check + test:ci): **exit 0**.
+
+## Spec coverage (Stage 3 scope per DECISION LOCK)
+
+- OK `close` → `{ type:'closed', mergeRequestNumber, jobCancelled, trackingArchived }`; controller maps
+  to existing `200 { status:'cleaned', mrNumber/prNumber, ... }` — covered by acceptance + both controller tests.
+- OK `merge` → `transitionState(targetState:'merged')` + best-effort `removeWorktree`; `{ type:'merged' }`
+  → `200 { status:'merged', mrNumber }` — covered (GitLab only; GitHub has no merge branch).
+- OK `followup-push` eligible → `{ type:'followup-eligible' }`; controller proceeds to its unchanged
+  budget/gate/enqueue tail — covered by spec-46 + spec-197 acceptance.
+- OK `followup-push` skipped (not tracked / no followup needed / auto-followup off) →
+  `{ type:'followup-skipped', reason }`; controller maps `'Auto-followup disabled'` →
+  `200 { status:'ignored', reason:'Auto-followup disabled' }`, others fall through to
+  `200 { status:'ignored', reason: filterResult.reason }` — covered.
+- OK `ignored` → reason passthrough — covered.
+- OK Platform-neutrality: orchestrator + acceptance import no `GitLab*`/`GitHub*` type — asserted.
+- KO (out of scope, Stage 4) `approve`, `review-requested` async tail, HTTP reply-shape unification,
+  `_trackingGateway` param removal — explicitly deferred per DECISION LOCK.
+
+## Self-review
+
+- Naming: full words (`mergeRequestNumber`, `decideFollowupSkipReason`), camelCase files, domain suffixes. OK
+- Imports: `@/` alias + `.js` everywhere (source AND tests), no relative, no barrel. OK
+- TypeScript: zero `any`/`as Type`/`!` in production files. OK
+- Dependency Rule: usecase imports only entities + sibling usecases. OK
+- `null` (not `undefined`) in the domain union (`description`, `language`, `displayName`). OK
+- Anti-overengineering: no Zod guard for a type that never crosses an untrusted boundary; orchestrator
+  routes only the synchronous subset (transitional bridge to Stage 4, flagged in the plan). OK
+
+## Remaining issues
+
+None. Stage 4 (full controller thinning + HTTP reply-shape unification + approve/review-request
+inward move + `_trackingGateway` removal) remains as planned future work — out of scope here.

--- a/docs/specs/73-extract-webhook-processing-usecase.md
+++ b/docs/specs/73-extract-webhook-processing-usecase.md
@@ -8,7 +8,7 @@ milestone: "Architecture Cleanup"
 
 # SPEC-073: Extract Webhook Processing Use Case
 
-## Status: implementing (Stages 1-2 of 4 done)
+## Status: implementing (Stages 1-3 of 4 done)
 
 > The codebase was restructured into a modular monolith (`src/modules/<context>/...`) after
 > this spec was drafted; the original flat `src/usecases/` paths below are stale. See the
@@ -61,9 +61,42 @@ arrives as a close event and is archived, not recorded as `state:'merged'` (out 
 
 **Verification** — `yarn verify` green (467 files / 3879 tests pass); acceptance test GREEN.
 
-**Remaining (out of scope here, future runs):** Stage 3 `ProcessWebhook` orchestrator +
-`WebhookEvent` discriminated union, Stage 4 full controller thinning (incl. removing the
-now-unused `_trackingGateway` param and unifying HTTP reply shapes).
+## Implementation (Stage 3 — `ProcessWebhook` orchestrator + `WebhookEvent` union)
+
+Plan: `docs/plans/73-process-webhook.plan.md` · Report: `docs/reports/73-process-webhook.report.md`
+
+A platform-neutral `WebhookEvent` discriminated union (entity layer) plus a function-based
+`processWebhook(event, deps)` orchestrator that routes the **synchronous** webhook outcomes
+(`close`, `merge`, `followup-push` eligibility, `ignored`) to the existing extracted use cases.
+Both webhook controllers map their already-parsed close/merge/followup events into `WebhookEvent`,
+call `deps.processWebhook`, and map the `ProcessWebhookResult` back to their **exact** existing HTTP
+replies (status code + body keys byte-for-byte, incl. GitLab `mrNumber` vs GitHub `prNumber`).
+
+**Artefacts**
+- Entity: `src/modules/platform-integration/entities/webhookEvent/webhookEvent.ts` — `WebhookEvent`
+  discriminated union (6 variants), pure type module (no Zod guard; data validated upstream by the
+  platform guards). Imports only `Language` + `Platform` entity types.
+- Use case: `src/modules/platform-integration/usecases/processWebhook.usecase.ts` — `processWebhook`,
+  `ProcessWebhookResult`, `ProcessWebhookDependencies`, `ProcessWebhook` type. Imports only `entities/`
+  + sibling `usecases/` (Dependency Rule verified: no `interface-adapters/`, no `frameworks/`, no
+  platform-specific event type / gateway).
+- Composition root: `src/main/routes.ts` — `processWebhook` composed per-platform from existing use
+  cases, injected into both controller dependency objects.
+
+**Decisions** — Scope locked to the **synchronous** routing only. The `approve` and `review-requested`
+paths stay 100% controller-side (the union carries both variants for completeness, but the orchestrator
+returns `{ type:'ignored', reason:'<variant>-handled-by-controller' }` for them, keeping the switch total
+without a `never` throw). The async enqueue tail — budget gate, processor closure capturing
+`executeReview`, `gateClaudeInvocation`, actor-trust, `enqueueReview`, and the 3-way 202/200 reply shapes
+— remains controller-side: moving it inward IS Stage 4. HTTP reply shapes preserved exactly (unification
+deferred to Stage 4). `eventFilter.ts` untouched (its `filter*` functions are the controller-side mappers).
+
+**Verification** — `yarn verify` green (473 files / 3921 tests pass); 13 unit + 8 acceptance Stage-3
+tests GREEN; acceptance asserts platform-neutrality (imports no `GitLab*`/`GitHub*` type).
+
+**Remaining (out of scope here, future runs):** Stage 4 full controller thinning — move the
+`review-requested` enqueue path and `approve` verdict inward, unify HTTP reply shapes, and remove the
+now-unused `_trackingGateway` controller param.
 
 ## User Story
 

--- a/src/main/routes.ts
+++ b/src/main/routes.ts
@@ -105,6 +105,7 @@ import {
 } from '@/modules/platform-integration/interface-adapters/gateways/threadFetch.gitlab.gateway.js';
 import { ForwardedForClientIpResolver } from '@/modules/platform-integration/interface-adapters/gateways/transport/clientIpResolver.forwardedFor.gateway.js';
 import { IsTrustedActorUseCase } from '@/modules/platform-integration/usecases/isTrustedActor.usecase.js';
+import { processWebhook } from '@/modules/platform-integration/usecases/processWebhook.usecase.js';
 import { pendingReviewsRoutes } from '@/modules/review-execution/interface-adapters/controllers/http/pendingReviews.routes.js';
 import { reviewRoutes } from '@/modules/review-execution/interface-adapters/controllers/http/reviews.routes.js';
 import { PendingReviewRequestFileSystemGateway } from '@/modules/review-execution/interface-adapters/gateways/pendingReviewRequest.fileSystem.gateway.js';
@@ -115,7 +116,10 @@ import { ProcessorRegistry } from '@/modules/review-execution/services/processor
 import { ConfirmPendingReviewUseCase } from '@/modules/review-execution/usecases/confirmPendingReview.usecase.js';
 import { DismissPendingReviewUseCase } from '@/modules/review-execution/usecases/dismissPendingReview.usecase.js';
 import { GateClaudeInvocationUseCase } from '@/modules/review-execution/usecases/gateClaudeInvocation.usecase.js';
-import { handleClose } from '@/modules/review-execution/usecases/handleClose.usecase.js';
+import {
+  handleClose,
+  type HandleClose,
+} from '@/modules/review-execution/usecases/handleClose.usecase.js';
 import { ListPendingReviewsUseCase } from '@/modules/review-execution/usecases/listPendingReviews.usecase.js';
 import { setupWizardRoutes } from '@/modules/setup-wizard/interface-adapters/controllers/http/setupWizard.routes.js';
 import { SetupProcessChildProcessGateway } from '@/modules/setup-wizard/interface-adapters/gateways/setupProcess.childProcess.gateway.js';
@@ -560,6 +564,15 @@ export async function registerRoutes(app: FastifyInstance, deps: Dependencies): 
     if (!proceed) {
       return;
     }
+    const gitLabHandleClose: HandleClose = (input) =>
+      handleClose(input, {
+        trackingGateway: trackingGw,
+        reviewContextGateway: deps.reviewContextGateway,
+        cancelJob,
+        buildJobId: createJobId,
+        removeWorktree: removeWorktreeAction,
+        logger: deps.logger,
+      });
     await handleGitLabWebhook(request, reply, deps.logger, trackingGw, {
       reviewContextGateway: deps.reviewContextGateway,
       threadFetchGateway: threadFetchGw,
@@ -572,12 +585,13 @@ export async function registerRoutes(app: FastifyInstance, deps: Dependencies): 
       checkFollowupNeeded: new CheckFollowupNeededUseCase(trackingGw),
       syncThreads: new SyncThreadsUseCase(trackingGw, threadFetchGw),
       executeReview: gitLabExecuteReview,
-      handleClose: (input) =>
-        handleClose(input, {
-          trackingGateway: trackingGw,
-          reviewContextGateway: deps.reviewContextGateway,
-          cancelJob,
-          buildJobId: createJobId,
+      handleClose: gitLabHandleClose,
+      processWebhook: (event) =>
+        processWebhook(event, {
+          handleClose: gitLabHandleClose,
+          transitionState: new TransitionStateUseCase(trackingGw),
+          recordPush: new RecordPushUseCase(trackingGw),
+          checkFollowupNeeded: new CheckFollowupNeededUseCase(trackingGw),
           removeWorktree: removeWorktreeAction,
           logger: deps.logger,
         }),
@@ -624,6 +638,15 @@ export async function registerRoutes(app: FastifyInstance, deps: Dependencies): 
     if (!proceedGitHub) {
       return;
     }
+    const gitHubHandleClose: HandleClose = (input) =>
+      handleClose(input, {
+        trackingGateway: trackingGw,
+        reviewContextGateway: deps.reviewContextGateway,
+        cancelJob,
+        buildJobId: createJobId,
+        removeWorktree: removeWorktreeAction,
+        logger: deps.logger,
+      });
     await handleGitHubWebhook(request, reply, deps.logger, trackingGw, {
       reviewContextGateway: deps.reviewContextGateway,
       threadFetchGateway: gitHubThreadFetchGw,
@@ -636,12 +659,13 @@ export async function registerRoutes(app: FastifyInstance, deps: Dependencies): 
       checkFollowupNeeded: new CheckFollowupNeededUseCase(trackingGw),
       syncThreads: new SyncThreadsUseCase(trackingGw, gitHubThreadFetchGw),
       executeReview: gitHubExecuteReview,
-      handleClose: (input) =>
-        handleClose(input, {
-          trackingGateway: trackingGw,
-          reviewContextGateway: deps.reviewContextGateway,
-          cancelJob,
-          buildJobId: createJobId,
+      handleClose: gitHubHandleClose,
+      processWebhook: (event) =>
+        processWebhook(event, {
+          handleClose: gitHubHandleClose,
+          transitionState: new TransitionStateUseCase(trackingGw),
+          recordPush: new RecordPushUseCase(trackingGw),
+          checkFollowupNeeded: new CheckFollowupNeededUseCase(trackingGw),
           removeWorktree: removeWorktreeAction,
           logger: deps.logger,
         }),

--- a/src/modules/platform-integration/entities/webhookEvent/webhookEvent.ts
+++ b/src/modules/platform-integration/entities/webhookEvent/webhookEvent.ts
@@ -1,0 +1,37 @@
+import type { Language } from '@/modules/shared-kernel/entities/language/language.schema.js';
+import type { Platform } from '@/modules/tracking/entities/tracking/reviewRequestTracking.gateway.js';
+
+export interface WebhookEventBase {
+  platform: Platform;
+  projectPath: string;
+  localPath: string;
+  mergeRequestNumber: number;
+}
+
+export interface WebhookEventAssignedBy {
+  username: string;
+  displayName: string | null;
+}
+
+export type WebhookEvent =
+  | ({
+      type: 'review-requested';
+      mergeRequestUrl: string;
+      sourceBranch: string;
+      targetBranch: string;
+      title: string;
+      description: string | null;
+      assignedBy: WebhookEventAssignedBy;
+      skill: string;
+      language: Language | null;
+    } & WebhookEventBase)
+  | ({
+      type: 'followup-push';
+      mergeRequestUrl: string;
+      sourceBranch: string;
+      targetBranch: string;
+    } & WebhookEventBase)
+  | ({ type: 'close' } & WebhookEventBase)
+  | ({ type: 'merge' } & WebhookEventBase)
+  | ({ type: 'approve' } & WebhookEventBase)
+  | { type: 'ignored'; reason: string };

--- a/src/modules/platform-integration/interface-adapters/controllers/webhook/github.controller.ts
+++ b/src/modules/platform-integration/interface-adapters/controllers/webhook/github.controller.ts
@@ -26,6 +26,7 @@ import {
   filterGitHubIssueCommentEvent,
   filterGitHubPullRequestReviewEvent,
 } from '@/modules/platform-integration/interface-adapters/controllers/webhook/eventFilter.js';
+import type { ProcessWebhook } from '@/modules/platform-integration/usecases/processWebhook.usecase.js';
 import type { ReviewJob } from '@/modules/review-execution/entities/job/reviewJob.js';
 import {
   DEFAULT_AGENTS,
@@ -67,6 +68,7 @@ export interface GitHubWebhookDependencies {
   syncThreads: SyncThreadsUseCase;
   executeReview: ExecuteReview;
   handleClose: HandleClose;
+  processWebhook: ProcessWebhook;
   enforceBudget: Pick<EnforceBudgetUseCase, 'execute'>;
   broadcastBudgetExceeded: (payload: BudgetExceededPayload) => void;
   getRepositories: () => RepositoryConfig[];
@@ -315,7 +317,7 @@ export async function handleGitHubWebhook(
   _trackingGateway: ReviewRequestTrackingGateway,
   deps: GitHubWebhookDependencies,
 ): Promise<void> {
-  const { trackAssignment, recordPush, checkFollowupNeeded } = deps;
+  const { trackAssignment } = deps;
   // 1. Verify signature
   const verification = verifyGitHubSignature(request);
   if (!verification.valid) {
@@ -360,20 +362,23 @@ export async function handleGitHubWebhook(
 
     const repoConfig = findRepositoryByRemoteUrl(event.repository.clone_url);
     if (repoConfig) {
-      const cleanup = await deps.handleClose({
+      const result = await deps.processWebhook({
+        type: 'close',
         platform: 'github',
         projectPath,
         localPath: repoConfig.localPath,
         mergeRequestNumber: prNumber,
       });
 
-      reply.status(200).send({
-        status: cleanup.status,
-        prNumber,
-        jobCancelled: cleanup.jobCancelled,
-        trackingArchived: cleanup.trackingArchived,
-      });
-      return;
+      if (result.type === 'closed') {
+        reply.status(200).send({
+          status: 'cleaned',
+          prNumber,
+          jobCancelled: result.jobCancelled,
+          trackingArchived: result.trackingArchived,
+        });
+        return;
+      }
     }
 
     // No repo config, just acknowledge
@@ -408,41 +413,26 @@ export async function handleGitHubWebhook(
     if (updateResult.shouldProcess && updateResult.isFollowup) {
       const updateRepoConfig = findRepositoryByRemoteUrl(event.repository.clone_url);
       if (updateRepoConfig) {
-        const mr = recordPush.execute({
-          projectPath: updateRepoConfig.localPath,
-          mrNumber: updateResult.mergeRequestNumber,
+        const eligibility = await deps.processWebhook({
+          type: 'followup-push',
           platform: 'github',
+          projectPath: updateResult.projectPath,
+          localPath: updateRepoConfig.localPath,
+          mergeRequestNumber: updateResult.mergeRequestNumber,
+          mergeRequestUrl: updateResult.mergeRequestUrl,
+          sourceBranch: updateResult.sourceBranch,
+          targetBranch: updateResult.targetBranch,
         });
-        logger.info(
-          {
-            prNumber: updateResult.mergeRequestNumber,
-            mrFound: !!mr,
-            mrState: mr?.state,
-            lastPushAt: mr?.lastPushAt,
-            lastReviewAt: mr?.lastReviewAt,
-          },
-          'Push event recorded',
-        );
 
-        const needsFollowup =
-          mr &&
-          checkFollowupNeeded.execute({
-            projectPath: updateRepoConfig.localPath,
-            mrNumber: updateResult.mergeRequestNumber,
-            platform: 'github',
-          });
-        logger.info({ needsFollowup, mrState: mr?.state }, 'Followup check result');
+        if (
+          eligibility.type === 'followup-skipped' &&
+          eligibility.reason === 'Auto-followup disabled'
+        ) {
+          reply.status(200).send({ status: 'ignored', reason: 'Auto-followup disabled' });
+          return;
+        }
 
-        if (needsFollowup) {
-          if (mr.autoFollowup === false) {
-            logger.info(
-              { prNumber: updateResult.mergeRequestNumber, project: updateResult.projectPath },
-              'Auto-followup disabled for this PR, skipping',
-            );
-            reply.status(200).send({ status: 'ignored', reason: 'Auto-followup disabled' });
-            return;
-          }
-
+        if (eligibility.type === 'followup-eligible') {
           logger.info(
             { prNumber: updateResult.mergeRequestNumber, project: updateResult.projectPath },
             'Auto-triggering followup review after push',

--- a/src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts
+++ b/src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts
@@ -27,6 +27,7 @@ import {
   filterGitLabNoteEvent,
 } from '@/modules/platform-integration/interface-adapters/controllers/webhook/eventFilter.js';
 import type { IsTrustedActorUseCase } from '@/modules/platform-integration/usecases/isTrustedActor.usecase.js';
+import type { ProcessWebhook } from '@/modules/platform-integration/usecases/processWebhook.usecase.js';
 import type { ReviewJob } from '@/modules/review-execution/entities/job/reviewJob.js';
 import {
   DEFAULT_AGENTS,
@@ -104,6 +105,7 @@ export interface GitLabWebhookDependencies {
   syncThreads: SyncThreadsUseCase;
   executeReview: ExecuteReview;
   handleClose: HandleClose;
+  processWebhook: ProcessWebhook;
   enforceBudget: Pick<EnforceBudgetUseCase, 'execute'>;
   broadcastBudgetExceeded: (payload: BudgetExceededPayload) => void;
   getRepositories: () => RepositoryConfig[];
@@ -235,7 +237,7 @@ export async function handleGitLabWebhook(
   _trackingGateway: ReviewRequestTrackingGateway,
   deps: GitLabWebhookDependencies,
 ): Promise<void> {
-  const { trackAssignment, recordPush, transitionState, checkFollowupNeeded } = deps;
+  const { trackAssignment } = deps;
   // 1. Verify signature
   const verification = verifyGitLabSignature(request);
   if (!verification.valid) {
@@ -292,20 +294,23 @@ export async function handleGitLabWebhook(
 
     const repoConfig = findRepositoryByProjectPath(projectPath);
     if (repoConfig) {
-      const cleanup = await deps.handleClose({
+      const result = await deps.processWebhook({
+        type: 'close',
         platform: 'gitlab',
         projectPath,
         localPath: repoConfig.localPath,
         mergeRequestNumber: mrNumber,
       });
 
-      reply.status(200).send({
-        status: cleanup.status,
-        mrNumber,
-        jobCancelled: cleanup.jobCancelled,
-        trackingArchived: cleanup.trackingArchived,
-      });
-      return;
+      if (result.type === 'closed') {
+        reply.status(200).send({
+          status: 'cleaned',
+          mrNumber,
+          jobCancelled: result.jobCancelled,
+          trackingArchived: result.trackingArchived,
+        });
+        return;
+      }
     }
 
     // No repo config, just acknowledge
@@ -319,37 +324,19 @@ export async function handleGitLabWebhook(
   if (mergeResult.shouldProcess) {
     const repoConfig = findRepositoryByProjectPath(mergeResult.projectPath);
     if (repoConfig) {
-      const mrId = `gitlab-${mergeResult.projectPath}-${mergeResult.mergeRequestNumber}`;
-      transitionState.execute({ projectPath: repoConfig.localPath, mrId, targetState: 'merged' });
+      const result = await deps.processWebhook({
+        type: 'merge',
+        platform: 'gitlab',
+        projectPath: mergeResult.projectPath,
+        localPath: repoConfig.localPath,
+        mergeRequestNumber: mergeResult.mergeRequestNumber,
+      });
 
-      try {
-        const worktreeRemoval = await deps.removeWorktree({
-          identity: {
-            platform: 'gitlab',
-            projectPath: mergeResult.projectPath,
-            mrNumber: mergeResult.mergeRequestNumber,
-          },
-          sourceCheckoutPath: repoConfig.localPath,
-        });
-        if (worktreeRemoval.status === 'failed') {
-          logger.warn(
-            { mrNumber: mergeResult.mergeRequestNumber, warning: worktreeRemoval.warning },
-            'removeWorktree failed on merge',
-          );
-        }
-      } catch (error) {
-        logger.warn(
-          {
-            mrNumber: mergeResult.mergeRequestNumber,
-            error: error instanceof Error ? error.message : String(error),
-          },
-          'removeWorktree threw on merge',
-        );
+      if (result.type === 'merged') {
+        logger.info({ mrNumber: mergeResult.mergeRequestNumber }, 'MR marked as merged');
+        reply.status(200).send({ status: 'merged', mrNumber: mergeResult.mergeRequestNumber });
+        return;
       }
-
-      logger.info({ mrNumber: mergeResult.mergeRequestNumber }, 'MR marked as merged');
-      reply.status(200).send({ status: 'merged', mrNumber: mergeResult.mergeRequestNumber });
-      return;
     }
   }
 
@@ -360,7 +347,7 @@ export async function handleGitLabWebhook(
     if (repoConfig) {
       const mrId = `gitlab-${approveResult.projectPath}-${approveResult.mergeRequestNumber}`;
       const threshold = deps.getQualityThreshold(repoConfig.localPath);
-      const transitionResult = transitionState.execute({
+      const transitionResult = deps.transitionState.execute({
         projectPath: repoConfig.localPath,
         mrId,
         targetState: 'approved',
@@ -479,43 +466,26 @@ export async function handleGitLabWebhook(
       // Find repo config to get local path
       const updateRepoConfig = findRepositoryByProjectPath(updateResult.projectPath);
       if (updateRepoConfig) {
-        // Record the push event
-        const mr = recordPush.execute({
-          projectPath: updateRepoConfig.localPath,
-          mrNumber: updateResult.mergeRequestNumber,
+        const eligibility = await deps.processWebhook({
+          type: 'followup-push',
           platform: 'gitlab',
+          projectPath: updateResult.projectPath,
+          localPath: updateRepoConfig.localPath,
+          mergeRequestNumber: updateResult.mergeRequestNumber,
+          mergeRequestUrl: updateResult.mergeRequestUrl,
+          sourceBranch: updateResult.sourceBranch,
+          targetBranch: updateResult.targetBranch,
         });
-        logger.info(
-          {
-            mrNumber: updateResult.mergeRequestNumber,
-            mrFound: !!mr,
-            mrState: mr?.state,
-            lastPushAt: mr?.lastPushAt,
-            lastReviewAt: mr?.lastReviewAt,
-          },
-          'Push event recorded',
-        );
 
-        // Check if this MR needs a followup (has open threads and was pushed since last review)
-        const needsFollowup =
-          mr &&
-          checkFollowupNeeded.execute({
-            projectPath: updateRepoConfig.localPath,
-            mrNumber: updateResult.mergeRequestNumber,
-            platform: 'gitlab',
-          });
-        logger.info({ needsFollowup, mrState: mr?.state }, 'Followup check result');
+        if (
+          eligibility.type === 'followup-skipped' &&
+          eligibility.reason === 'Auto-followup disabled'
+        ) {
+          reply.status(200).send({ status: 'ignored', reason: 'Auto-followup disabled' });
+          return;
+        }
 
-        if (needsFollowup) {
-          if (mr.autoFollowup === false) {
-            logger.info(
-              { mrNumber: updateResult.mergeRequestNumber, project: updateResult.projectPath },
-              'Auto-followup disabled for this MR, skipping',
-            );
-            reply.status(200).send({ status: 'ignored', reason: 'Auto-followup disabled' });
-            return;
-          }
-
+        if (eligibility.type === 'followup-eligible') {
           logger.info(
             { mrNumber: updateResult.mergeRequestNumber, project: updateResult.projectPath },
             'Auto-triggering followup review after push',

--- a/src/modules/platform-integration/usecases/processWebhook.usecase.ts
+++ b/src/modules/platform-integration/usecases/processWebhook.usecase.ts
@@ -1,0 +1,158 @@
+import type { Logger } from 'pino';
+
+import type { WebhookEvent } from '@/modules/platform-integration/entities/webhookEvent/webhookEvent.js';
+import type { HandleClose } from '@/modules/review-execution/usecases/handleClose.usecase.js';
+import type { CheckFollowupNeededUseCase } from '@/modules/tracking/usecases/tracking/checkFollowupNeeded.usecase.js';
+import type { RecordPushUseCase } from '@/modules/tracking/usecases/tracking/recordPush.usecase.js';
+import type { TransitionStateUseCase } from '@/modules/tracking/usecases/tracking/transitionState.usecase.js';
+import type { RemoveWorktreeAction } from '@/modules/worktree-management/entities/worktree/worktree.schema.js';
+
+export type ProcessWebhookResult =
+  | { type: 'closed'; mergeRequestNumber: number; jobCancelled: boolean; trackingArchived: boolean }
+  | { type: 'merged'; mergeRequestNumber: number }
+  | { type: 'followup-eligible'; mergeRequestNumber: number }
+  | { type: 'followup-skipped'; mergeRequestNumber: number; reason: string }
+  | { type: 'ignored'; reason: string };
+
+export interface ProcessWebhookDependencies {
+  handleClose: HandleClose;
+  transitionState: Pick<TransitionStateUseCase, 'execute'>;
+  recordPush: Pick<RecordPushUseCase, 'execute'>;
+  checkFollowupNeeded: Pick<CheckFollowupNeededUseCase, 'execute'>;
+  removeWorktree: RemoveWorktreeAction;
+  logger: Logger;
+}
+
+export type ProcessWebhook = (event: WebhookEvent) => Promise<ProcessWebhookResult>;
+
+type CloseEvent = Extract<WebhookEvent, { type: 'close' }>;
+type MergeEvent = Extract<WebhookEvent, { type: 'merge' }>;
+type FollowupEvent = Extract<WebhookEvent, { type: 'followup-push' }>;
+
+function buildMergeRequestId(event: {
+  platform: string;
+  projectPath: string;
+  mergeRequestNumber: number;
+}): string {
+  return `${event.platform}-${event.projectPath}-${event.mergeRequestNumber}`;
+}
+
+async function routeClose(
+  event: CloseEvent,
+  deps: ProcessWebhookDependencies,
+): Promise<ProcessWebhookResult> {
+  const cleanup = await deps.handleClose({
+    platform: event.platform,
+    projectPath: event.projectPath,
+    localPath: event.localPath,
+    mergeRequestNumber: event.mergeRequestNumber,
+  });
+  return {
+    type: 'closed',
+    mergeRequestNumber: event.mergeRequestNumber,
+    jobCancelled: cleanup.jobCancelled,
+    trackingArchived: cleanup.trackingArchived,
+  };
+}
+
+async function removeWorktreeBestEffort(
+  event: MergeEvent,
+  deps: ProcessWebhookDependencies,
+): Promise<void> {
+  try {
+    const removal = await deps.removeWorktree({
+      identity: {
+        platform: event.platform,
+        projectPath: event.projectPath,
+        mrNumber: event.mergeRequestNumber,
+      },
+      sourceCheckoutPath: event.localPath,
+    });
+    if (removal.status === 'failed') {
+      deps.logger.warn(
+        { mergeRequestNumber: event.mergeRequestNumber, warning: removal.warning },
+        'removeWorktree failed on merge',
+      );
+    }
+  } catch (error) {
+    deps.logger.warn(
+      {
+        mergeRequestNumber: event.mergeRequestNumber,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      'removeWorktree threw on merge',
+    );
+  }
+}
+
+async function routeMerge(
+  event: MergeEvent,
+  deps: ProcessWebhookDependencies,
+): Promise<ProcessWebhookResult> {
+  deps.transitionState.execute({
+    projectPath: event.localPath,
+    mrId: buildMergeRequestId(event),
+    targetState: 'merged',
+  });
+  await removeWorktreeBestEffort(event, deps);
+  return { type: 'merged', mergeRequestNumber: event.mergeRequestNumber };
+}
+
+function decideFollowupSkipReason(
+  event: FollowupEvent,
+  deps: ProcessWebhookDependencies,
+): string | null {
+  const trackedMr = deps.recordPush.execute({
+    projectPath: event.localPath,
+    mrNumber: event.mergeRequestNumber,
+    platform: event.platform,
+  });
+  if (!trackedMr) return 'Merge request not tracked';
+
+  const needsFollowup = deps.checkFollowupNeeded.execute({
+    projectPath: event.localPath,
+    mrNumber: event.mergeRequestNumber,
+    platform: event.platform,
+  });
+  if (!needsFollowup) return 'No followup needed';
+
+  if (trackedMr.autoFollowup === false) return 'Auto-followup disabled';
+
+  return null;
+}
+
+function routeFollowup(
+  event: FollowupEvent,
+  deps: ProcessWebhookDependencies,
+): ProcessWebhookResult {
+  const skipReason = decideFollowupSkipReason(event, deps);
+  if (skipReason) {
+    return {
+      type: 'followup-skipped',
+      mergeRequestNumber: event.mergeRequestNumber,
+      reason: skipReason,
+    };
+  }
+
+  return { type: 'followup-eligible', mergeRequestNumber: event.mergeRequestNumber };
+}
+
+export async function processWebhook(
+  event: WebhookEvent,
+  deps: ProcessWebhookDependencies,
+): Promise<ProcessWebhookResult> {
+  switch (event.type) {
+    case 'close':
+      return routeClose(event, deps);
+    case 'merge':
+      return routeMerge(event, deps);
+    case 'followup-push':
+      return routeFollowup(event, deps);
+    case 'review-requested':
+      return { type: 'ignored', reason: 'review-requested-handled-by-controller' };
+    case 'approve':
+      return { type: 'ignored', reason: 'approve-handled-by-controller' };
+    case 'ignored':
+      return { type: 'ignored', reason: event.reason };
+  }
+}

--- a/src/tests/acceptance/197-trusted-actor-provenance-gate.acceptance.test.ts
+++ b/src/tests/acceptance/197-trusted-actor-provenance-gate.acceptance.test.ts
@@ -90,8 +90,13 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 import { enqueueReview } from '@/frameworks/queue/pQueueAdapter.js';
 import { MEMBER_ACCESS_LEVELS } from '@/modules/platform-integration/entities/memberAccess/memberAccess.js';
+import type { WebhookEvent } from '@/modules/platform-integration/entities/webhookEvent/webhookEvent.js';
 import { handleGitLabWebhook } from '@/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.js';
 import { IsTrustedActorUseCase } from '@/modules/platform-integration/usecases/isTrustedActor.usecase.js';
+import {
+  processWebhook,
+  type ProcessWebhookResult,
+} from '@/modules/platform-integration/usecases/processWebhook.usecase.js';
 import { GateClaudeInvocationUseCase } from '@/modules/review-execution/usecases/gateClaudeInvocation.usecase.js';
 import type { TrackedMr } from '@/modules/tracking/entities/tracking/trackedMr.js';
 import { CheckFollowupNeededUseCase } from '@/modules/tracking/usecases/tracking/checkFollowupNeeded.usecase.js';
@@ -165,6 +170,16 @@ function createAcceptAllEnforceBudget() {
 
 function buildBaseDeps(trackingGateway: ReturnType<typeof createMockTrackingGateway>) {
   const threadFetchGateway = { fetchThreads: vi.fn(() => []) };
+  const recordPush = new RecordPushUseCase(trackingGateway);
+  const transitionState = new TransitionStateUseCase(trackingGateway);
+  const checkFollowupNeeded = new CheckFollowupNeededUseCase(trackingGateway);
+  const removeWorktree = vi.fn(async () => ({ status: 'removed' as const }));
+  const handleClose = vi.fn(async () => ({
+    status: 'cleaned' as const,
+    jobCancelled: true,
+    trackingArchived: true,
+    contextDeleted: true,
+  }));
   return {
     reviewContextGateway: createStubContextGateway(),
     threadFetchGateway,
@@ -174,9 +189,9 @@ function buildBaseDeps(trackingGateway: ReturnType<typeof createMockTrackingGate
     diffStatsFetchGateway: { fetchDiffStats: vi.fn(() => null) },
     trackAssignment: new TrackAssignmentUseCase(trackingGateway),
     recordCompletion: new RecordReviewCompletionUseCase(trackingGateway),
-    recordPush: new RecordPushUseCase(trackingGateway),
-    transitionState: new TransitionStateUseCase(trackingGateway),
-    checkFollowupNeeded: new CheckFollowupNeededUseCase(trackingGateway),
+    recordPush,
+    transitionState,
+    checkFollowupNeeded,
     syncThreads: new SyncThreadsUseCase(trackingGateway, threadFetchGateway),
     executeReview: vi.fn(async () => ({
       status: 'completed' as const,
@@ -190,16 +205,20 @@ function buildBaseDeps(trackingGateway: ReturnType<typeof createMockTrackingGate
         durationMs: 1200,
       },
     })),
-    handleClose: vi.fn(async () => ({
-      status: 'cleaned' as const,
-      jobCancelled: true,
-      trackingArchived: true,
-      contextDeleted: true,
-    })),
+    handleClose,
+    processWebhook: (event: WebhookEvent): Promise<ProcessWebhookResult> =>
+      processWebhook(event, {
+        handleClose,
+        transitionState,
+        recordPush,
+        checkFollowupNeeded,
+        removeWorktree,
+        logger,
+      }),
     enforceBudget: createAcceptAllEnforceBudget(),
     broadcastBudgetExceeded: vi.fn(),
     getRepositories: vi.fn(() => []),
-    removeWorktree: vi.fn(async () => ({ status: 'removed' as const })),
+    removeWorktree,
     recordBypass: new RecordBypassUseCase(trackingGateway),
     noteCommentPostGateway: new StubNoteCommentPostGateway(),
     handlePlatformApproval: new HandlePlatformApprovalUseCase(trackingGateway),

--- a/src/tests/acceptance/200-webhook-event-idempotency.acceptance.test.ts
+++ b/src/tests/acceptance/200-webhook-event-idempotency.acceptance.test.ts
@@ -57,8 +57,13 @@ vi.mock('@/config/projectConfig.js', () => ({
 
 import { describe, it, expect, beforeEach } from 'vitest';
 
+import type { WebhookEvent } from '@/modules/platform-integration/entities/webhookEvent/webhookEvent.js';
 import { handleGitLabWebhook } from '@/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.js';
 import { InMemoryIdempotencyStore } from '@/modules/platform-integration/interface-adapters/gateways/inMemoryIdempotencyStore.gateway.js';
+import {
+  processWebhook,
+  type ProcessWebhookResult,
+} from '@/modules/platform-integration/usecases/processWebhook.usecase.js';
 import type {
   GateClaudeInvocationInput,
   GateClaudeInvocationResult,
@@ -157,6 +162,16 @@ function createDeps(
   overrides: Record<string, unknown> = {},
 ) {
   const threadFetchGateway = { fetchThreads: vi.fn(() => []) };
+  const recordPush = new RecordPushUseCase(trackingGateway);
+  const transitionState = new TransitionStateUseCase(trackingGateway);
+  const checkFollowupNeeded = new CheckFollowupNeededUseCase(trackingGateway);
+  const removeWorktree = vi.fn(async () => ({ status: 'removed' as const }));
+  const handleClose = vi.fn(async () => ({
+    status: 'cleaned' as const,
+    jobCancelled: true,
+    trackingArchived: true,
+    contextDeleted: true,
+  }));
   return {
     reviewContextGateway: createStubContextGateway(),
     threadFetchGateway,
@@ -166,9 +181,9 @@ function createDeps(
     diffStatsFetchGateway: { fetchDiffStats: vi.fn(() => null) },
     trackAssignment: new TrackAssignmentUseCase(trackingGateway),
     recordCompletion: new RecordReviewCompletionUseCase(trackingGateway),
-    recordPush: new RecordPushUseCase(trackingGateway),
-    transitionState: new TransitionStateUseCase(trackingGateway),
-    checkFollowupNeeded: new CheckFollowupNeededUseCase(trackingGateway),
+    recordPush,
+    transitionState,
+    checkFollowupNeeded,
     syncThreads: new SyncThreadsUseCase(trackingGateway, threadFetchGateway),
     executeReview: vi.fn(async () => ({
       status: 'completed' as const,
@@ -182,16 +197,20 @@ function createDeps(
         durationMs: 1200,
       },
     })),
-    handleClose: vi.fn(async () => ({
-      status: 'cleaned' as const,
-      jobCancelled: true,
-      trackingArchived: true,
-      contextDeleted: true,
-    })),
+    handleClose,
+    processWebhook: (event: WebhookEvent): Promise<ProcessWebhookResult> =>
+      processWebhook(event, {
+        handleClose,
+        transitionState,
+        recordPush,
+        checkFollowupNeeded,
+        removeWorktree,
+        logger: createStubLogger(),
+      }),
     enforceBudget: createAcceptAllEnforceBudget(),
     broadcastBudgetExceeded: vi.fn(),
     getRepositories: vi.fn(() => []),
-    removeWorktree: vi.fn(async () => ({ status: 'removed' as const })),
+    removeWorktree,
     recordBypass: new RecordBypassUseCase(trackingGateway),
     noteCommentPostGateway: new StubNoteCommentPostGateway(),
     handlePlatformApproval: new HandlePlatformApprovalUseCase(trackingGateway),

--- a/src/tests/acceptance/46-github-followup-review-on-push.acceptance.test.ts
+++ b/src/tests/acceptance/46-github-followup-review-on-push.acceptance.test.ts
@@ -63,9 +63,15 @@ vi.mock('@/config/projectConfig.js', () => ({
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 import { enqueueReview } from '@/frameworks/queue/pQueueAdapter.js';
+import type { WebhookEvent } from '@/modules/platform-integration/entities/webhookEvent/webhookEvent.js';
 import { handleGitHubWebhook } from '@/modules/platform-integration/interface-adapters/controllers/webhook/github.controller.js';
 import type { GitHubWebhookDependencies } from '@/modules/platform-integration/interface-adapters/controllers/webhook/github.controller.js';
+import {
+  processWebhook,
+  type ProcessWebhookResult,
+} from '@/modules/platform-integration/usecases/processWebhook.usecase.js';
 import type { TrackedMr } from '@/modules/tracking/entities/tracking/trackedMr.js';
+import type { TransitionStateResult } from '@/modules/tracking/usecases/tracking/transitionState.usecase.js';
 import { GitHubEventFactory } from '@/tests/factories/gitHubEvent.factory.js';
 import { TrackedMrFactory } from '@/tests/factories/trackedMr.factory.js';
 import { createStubLogger } from '@/tests/stubs/logger.stub.js';
@@ -158,6 +164,20 @@ function createDefaultDeps(
     transitionState: { execute: vi.fn() },
     checkFollowupNeeded: { execute: checkFollowupNeededExecute },
     syncThreads: { execute: vi.fn(() => null) },
+    processWebhook: (event: WebhookEvent): Promise<ProcessWebhookResult> =>
+      processWebhook(event, {
+        handleClose: async () => ({
+          status: 'cleaned',
+          jobCancelled: false,
+          trackingArchived: false,
+          contextDeleted: false,
+        }),
+        transitionState: { execute: vi.fn((): TransitionStateResult => ({ ok: true })) },
+        recordPush: { execute: recordPushExecute },
+        checkFollowupNeeded: { execute: checkFollowupNeededExecute },
+        removeWorktree: async () => ({ status: 'removed' }),
+        logger: createStubLogger(),
+      }),
     enforceBudget: { execute: enforceBudgetExecute },
     broadcastBudgetExceeded: vi.fn(),
     getRepositories: vi.fn(() => []),

--- a/src/tests/acceptance/73-process-webhook.acceptance.test.ts
+++ b/src/tests/acceptance/73-process-webhook.acceptance.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from 'vitest';
+
+import type { WebhookEvent } from '@/modules/platform-integration/entities/webhookEvent/webhookEvent.js';
+import {
+  processWebhook,
+  type ProcessWebhookDependencies,
+} from '@/modules/platform-integration/usecases/processWebhook.usecase.js';
+import type { TransitionStateResult } from '@/modules/tracking/usecases/tracking/transitionState.usecase.js';
+import { TrackedMrFactory } from '@/tests/factories/trackedMr.factory.js';
+import { createStubLogger } from '@/tests/stubs/logger.stub.js';
+
+interface Harness {
+  deps: ProcessWebhookDependencies;
+  handleCloseCalls: Array<{ platform: string; mergeRequestNumber: number }>;
+  transitionStateCalls: Array<{ mrId: string; targetState: string }>;
+  recordPushCalls: Array<{ projectPath: string; mrNumber: number }>;
+  checkFollowupNeededCalls: Array<{ mrNumber: number }>;
+  removeWorktreeCalls: Array<{ platform: string }>;
+}
+
+function buildHarness(overrides?: Partial<ProcessWebhookDependencies>): Harness {
+  const handleCloseCalls: Harness['handleCloseCalls'] = [];
+  const transitionStateCalls: Harness['transitionStateCalls'] = [];
+  const recordPushCalls: Harness['recordPushCalls'] = [];
+  const checkFollowupNeededCalls: Harness['checkFollowupNeededCalls'] = [];
+  const removeWorktreeCalls: Harness['removeWorktreeCalls'] = [];
+
+  const deps: ProcessWebhookDependencies = {
+    handleClose: async (input) => {
+      handleCloseCalls.push({
+        platform: input.platform,
+        mergeRequestNumber: input.mergeRequestNumber,
+      });
+      return {
+        status: 'cleaned',
+        jobCancelled: true,
+        trackingArchived: true,
+        contextDeleted: true,
+      };
+    },
+    transitionState: {
+      execute: (input): TransitionStateResult => {
+        transitionStateCalls.push({ mrId: input.mrId, targetState: input.targetState });
+        return { ok: true };
+      },
+    },
+    recordPush: {
+      execute: (input) => {
+        recordPushCalls.push({ projectPath: input.projectPath, mrNumber: input.mrNumber });
+        return TrackedMrFactory.create({ mrNumber: input.mrNumber, autoFollowup: true });
+      },
+    },
+    checkFollowupNeeded: {
+      execute: (input) => {
+        checkFollowupNeededCalls.push({ mrNumber: input.mrNumber });
+        return true;
+      },
+    },
+    removeWorktree: async ({ identity }) => {
+      removeWorktreeCalls.push({ platform: identity.platform });
+      return { status: 'removed' };
+    },
+    logger: createStubLogger(),
+    ...overrides,
+  };
+
+  return {
+    deps,
+    handleCloseCalls,
+    transitionStateCalls,
+    recordPushCalls,
+    checkFollowupNeededCalls,
+    removeWorktreeCalls,
+  };
+}
+
+const closeEvent: WebhookEvent = {
+  type: 'close',
+  platform: 'gitlab',
+  projectPath: 'group/project',
+  localPath: '/checkout/project',
+  mergeRequestNumber: 42,
+};
+
+const mergeEvent: WebhookEvent = {
+  type: 'merge',
+  platform: 'gitlab',
+  projectPath: 'group/project',
+  localPath: '/checkout/project',
+  mergeRequestNumber: 42,
+};
+
+const followupEvent: WebhookEvent = {
+  type: 'followup-push',
+  platform: 'gitlab',
+  projectPath: 'group/project',
+  localPath: '/checkout/project',
+  mergeRequestNumber: 42,
+  mergeRequestUrl: 'https://gitlab.com/group/project/-/merge_requests/42',
+  sourceBranch: 'fix-bug',
+  targetBranch: 'main',
+};
+
+describe('SPEC-073 Stage 3 — processWebhook (acceptance)', () => {
+  describe('the orchestrator routes synchronous webhook events without any platform-specific type', () => {
+    it('close: delegates to handleClose and returns a closed result', async () => {
+      const harness = buildHarness();
+
+      const result = await processWebhook(closeEvent, harness.deps);
+
+      expect(result.type).toBe('closed');
+      if (result.type !== 'closed') throw new Error('expected closed');
+      expect(result.mergeRequestNumber).toBe(42);
+      expect(result.jobCancelled).toBe(true);
+      expect(result.trackingArchived).toBe(true);
+      expect(harness.handleCloseCalls).toEqual([{ platform: 'gitlab', mergeRequestNumber: 42 }]);
+    });
+
+    it('merge: transitions state to merged and removes the worktree best-effort', async () => {
+      const harness = buildHarness();
+
+      const result = await processWebhook(mergeEvent, harness.deps);
+
+      expect(result.type).toBe('merged');
+      if (result.type !== 'merged') throw new Error('expected merged');
+      expect(result.mergeRequestNumber).toBe(42);
+      expect(harness.transitionStateCalls).toEqual([
+        { mrId: 'gitlab-group/project-42', targetState: 'merged' },
+      ]);
+      expect(harness.removeWorktreeCalls).toEqual([{ platform: 'gitlab' }]);
+    });
+
+    it('merge: stays merged even when worktree removal reports failure', async () => {
+      const harness = buildHarness({
+        removeWorktree: async () => ({ status: 'failed', warning: 'boom' }),
+      });
+
+      const result = await processWebhook(mergeEvent, harness.deps);
+
+      expect(result.type).toBe('merged');
+    });
+  });
+
+  describe('followup eligibility is decided from tracking state alone', () => {
+    it('eligible: records the push, confirms a followup is needed, returns followup-eligible', async () => {
+      const harness = buildHarness();
+
+      const result = await processWebhook(followupEvent, harness.deps);
+
+      expect(result.type).toBe('followup-eligible');
+      if (result.type !== 'followup-eligible') throw new Error('expected followup-eligible');
+      expect(result.mergeRequestNumber).toBe(42);
+      expect(harness.recordPushCalls).toEqual([{ projectPath: '/checkout/project', mrNumber: 42 }]);
+      expect(harness.checkFollowupNeededCalls).toEqual([{ mrNumber: 42 }]);
+    });
+
+    it('skipped: the merge request is not tracked, so no followup is eligible', async () => {
+      const harness = buildHarness({
+        recordPush: { execute: () => null },
+      });
+
+      const result = await processWebhook(followupEvent, harness.deps);
+
+      expect(result.type).toBe('followup-skipped');
+    });
+
+    it('skipped: there are no open threads, so checkFollowupNeeded returns false', async () => {
+      const harness = buildHarness({
+        checkFollowupNeeded: { execute: () => false },
+      });
+
+      const result = await processWebhook(followupEvent, harness.deps);
+
+      expect(result.type).toBe('followup-skipped');
+    });
+
+    it('skipped: auto-followup is disabled on the tracked merge request', async () => {
+      const harness = buildHarness({
+        recordPush: {
+          execute: () => TrackedMrFactory.create({ mrNumber: 42, autoFollowup: false }),
+        },
+      });
+
+      const result = await processWebhook(followupEvent, harness.deps);
+
+      expect(result.type).toBe('followup-skipped');
+      if (result.type !== 'followup-skipped') throw new Error('expected followup-skipped');
+      expect(result.reason).toBe('Auto-followup disabled');
+    });
+  });
+
+  describe('events the controller still owns are acknowledged as ignored', () => {
+    it('ignored: passes the reason straight through', async () => {
+      const harness = buildHarness();
+
+      const result = await processWebhook(
+        { type: 'ignored', reason: 'Not a MR event' },
+        harness.deps,
+      );
+
+      expect(result).toEqual({ type: 'ignored', reason: 'Not a MR event' });
+    });
+  });
+});

--- a/src/tests/units/interface-adapters/controllers/webhook/github.controller.test.ts
+++ b/src/tests/units/interface-adapters/controllers/webhook/github.controller.test.ts
@@ -82,7 +82,13 @@ vi.mock('../../../../../config/projectConfig.js', () => ({
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
+import type { WebhookEvent } from '@/modules/platform-integration/entities/webhookEvent/webhookEvent.js';
 import { handleGitHubWebhook } from '@/modules/platform-integration/interface-adapters/controllers/webhook/github.controller.js';
+import {
+  processWebhook,
+  type ProcessWebhookResult,
+} from '@/modules/platform-integration/usecases/processWebhook.usecase.js';
+import type { HandleCloseResult } from '@/modules/review-execution/usecases/handleClose.usecase.js';
 import type { TrackedMr } from '@/modules/tracking/entities/tracking/trackedMr.js';
 
 import { findRepositoryByRemoteUrl } from '../../../../../config/loader.js';
@@ -93,6 +99,18 @@ import { TrackedMrFactory } from '../../../../factories/trackedMr.factory.js';
 import { createStubLogger } from '../../../../stubs/logger.stub.js';
 
 function createMockDeps(): GitHubWebhookDependencies {
+  const recordPush = { execute: vi.fn(() => null) };
+  const transitionState = { execute: vi.fn() };
+  const checkFollowupNeeded = { execute: vi.fn(() => false) };
+  const removeWorktree = vi.fn(async () => ({ status: 'removed' as const }));
+  const handleClose = vi.fn(
+    async (): Promise<HandleCloseResult> => ({
+      status: 'cleaned',
+      jobCancelled: true,
+      trackingArchived: true,
+      contextDeleted: true,
+    }),
+  );
   return {
     reviewContextGateway: {
       create: vi.fn(),
@@ -116,9 +134,9 @@ function createMockDeps(): GitHubWebhookDependencies {
     },
     trackAssignment: { execute: vi.fn() },
     recordCompletion: { execute: vi.fn() },
-    recordPush: { execute: vi.fn(() => null) },
-    transitionState: { execute: vi.fn() },
-    checkFollowupNeeded: { execute: vi.fn(() => false) },
+    recordPush,
+    transitionState,
+    checkFollowupNeeded,
     syncThreads: { execute: vi.fn(() => null) },
     executeReview: vi.fn(async () => ({
       status: 'completed',
@@ -132,12 +150,16 @@ function createMockDeps(): GitHubWebhookDependencies {
         durationMs: 1200,
       },
     })),
-    handleClose: vi.fn(async () => ({
-      status: 'cleaned',
-      jobCancelled: true,
-      trackingArchived: true,
-      contextDeleted: true,
-    })),
+    handleClose,
+    processWebhook: (event: WebhookEvent): Promise<ProcessWebhookResult> =>
+      processWebhook(event, {
+        handleClose,
+        transitionState,
+        recordPush,
+        checkFollowupNeeded,
+        removeWorktree,
+        logger: createStubLogger(),
+      }),
     enforceBudget: {
       execute: vi.fn(async () => ({
         accepted: true,
@@ -153,7 +175,7 @@ function createMockDeps(): GitHubWebhookDependencies {
     },
     broadcastBudgetExceeded: vi.fn(),
     getRepositories: vi.fn(() => []),
-    removeWorktree: vi.fn(async () => ({ status: 'removed' as const })),
+    removeWorktree,
     recordBypass: { execute: vi.fn(() => ({ kind: 'no-marker' })) },
     noteCommentPostGateway: { postComment: vi.fn(async () => undefined) },
     handlePlatformApproval: { execute: vi.fn(() => ({ kind: 'allowed' })) },

--- a/src/tests/units/interface-adapters/controllers/webhook/gitlab.controller.test.ts
+++ b/src/tests/units/interface-adapters/controllers/webhook/gitlab.controller.test.ts
@@ -94,12 +94,17 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { findRepositoryByProjectPath } from '@/config/loader.js';
 import { enqueueReview } from '@/frameworks/queue/pQueueAdapter.js';
 import { MEMBER_ACCESS_LEVELS } from '@/modules/platform-integration/entities/memberAccess/memberAccess.js';
+import type { WebhookEvent } from '@/modules/platform-integration/entities/webhookEvent/webhookEvent.js';
 import {
   handleGitLabWebhook,
   extractBaseUrl,
   buildGitLabReviewProcessor,
 } from '@/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.js';
 import { IsTrustedActorUseCase } from '@/modules/platform-integration/usecases/isTrustedActor.usecase.js';
+import {
+  processWebhook,
+  type ProcessWebhookResult,
+} from '@/modules/platform-integration/usecases/processWebhook.usecase.js';
 import type { ExecuteReviewResult } from '@/modules/review-execution/usecases/executeReview.usecase.js';
 import { GateClaudeInvocationUseCase } from '@/modules/review-execution/usecases/gateClaudeInvocation.usecase.js';
 import type { HandleCloseResult } from '@/modules/review-execution/usecases/handleClose.usecase.js';
@@ -177,6 +182,18 @@ function createAcceptAllEnforceBudget() {
 
 function createDefaultDeps(trackingGateway: ReturnType<typeof createMockTrackingGateway>) {
   const threadFetchGateway = { fetchThreads: vi.fn(() => []) };
+  const recordPush = new RecordPushUseCase(trackingGateway);
+  const transitionState = new TransitionStateUseCase(trackingGateway);
+  const checkFollowupNeeded = new CheckFollowupNeededUseCase(trackingGateway);
+  const removeWorktree = vi.fn(async () => ({ status: 'removed' as const }));
+  const handleClose = vi.fn(
+    async (): Promise<HandleCloseResult> => ({
+      status: 'cleaned',
+      jobCancelled: true,
+      trackingArchived: true,
+      contextDeleted: true,
+    }),
+  );
   return {
     reviewContextGateway: createStubContextGateway(),
     threadFetchGateway,
@@ -186,9 +203,9 @@ function createDefaultDeps(trackingGateway: ReturnType<typeof createMockTracking
     diffStatsFetchGateway: { fetchDiffStats: vi.fn(() => null) },
     trackAssignment: new TrackAssignmentUseCase(trackingGateway),
     recordCompletion: new RecordReviewCompletionUseCase(trackingGateway),
-    recordPush: new RecordPushUseCase(trackingGateway),
-    transitionState: new TransitionStateUseCase(trackingGateway),
-    checkFollowupNeeded: new CheckFollowupNeededUseCase(trackingGateway),
+    recordPush,
+    transitionState,
+    checkFollowupNeeded,
     syncThreads: new SyncThreadsUseCase(trackingGateway, threadFetchGateway),
     executeReview: vi.fn(
       async (): Promise<ExecuteReviewResult> => ({
@@ -204,18 +221,20 @@ function createDefaultDeps(trackingGateway: ReturnType<typeof createMockTracking
         },
       }),
     ),
-    handleClose: vi.fn(
-      async (): Promise<HandleCloseResult> => ({
-        status: 'cleaned',
-        jobCancelled: true,
-        trackingArchived: true,
-        contextDeleted: true,
+    handleClose,
+    processWebhook: (event: WebhookEvent): Promise<ProcessWebhookResult> =>
+      processWebhook(event, {
+        handleClose,
+        transitionState,
+        recordPush,
+        checkFollowupNeeded,
+        removeWorktree,
+        logger: createStubLogger(),
       }),
-    ),
     enforceBudget: createAcceptAllEnforceBudget(),
     broadcastBudgetExceeded: vi.fn(),
     getRepositories: vi.fn(() => []),
-    removeWorktree: vi.fn(async () => ({ status: 'removed' as const })),
+    removeWorktree,
     recordBypass: new RecordBypassUseCase(trackingGateway),
     noteCommentPostGateway: new StubNoteCommentPostGateway(),
     handlePlatformApproval: new HandlePlatformApprovalUseCase(trackingGateway),
@@ -465,7 +484,19 @@ describe('handleGitLabWebhook', () => {
 
     it('calls removeWorktree on MR merge with platform/projectPath/mrNumber identity', async () => {
       const removeWorktree = vi.fn(async () => ({ status: 'removed' as const }));
-      const deps = { ...defaultDeps, removeWorktree };
+      const deps = {
+        ...defaultDeps,
+        removeWorktree,
+        processWebhook: (event: WebhookEvent): Promise<ProcessWebhookResult> =>
+          processWebhook(event, {
+            handleClose: defaultDeps.handleClose,
+            transitionState: defaultDeps.transitionState,
+            recordPush: defaultDeps.recordPush,
+            checkFollowupNeeded: defaultDeps.checkFollowupNeeded,
+            removeWorktree,
+            logger: createStubLogger(),
+          }),
+      };
       const event = GitLabEventFactory.createMergedMr();
       const request = { body: event, headers: {} } as unknown as FastifyRequest;
 

--- a/src/tests/units/modules/platform-integration/interface-adapters/controllers/webhook/gitlabIdempotency.controller.test.ts
+++ b/src/tests/units/modules/platform-integration/interface-adapters/controllers/webhook/gitlabIdempotency.controller.test.ts
@@ -57,8 +57,13 @@ vi.mock('@/config/projectConfig.js', () => ({
 
 import { describe, it, expect, beforeEach } from 'vitest';
 
+import type { WebhookEvent } from '@/modules/platform-integration/entities/webhookEvent/webhookEvent.js';
 import { handleGitLabWebhook } from '@/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.js';
 import { InMemoryIdempotencyStore } from '@/modules/platform-integration/interface-adapters/gateways/inMemoryIdempotencyStore.gateway.js';
+import {
+  processWebhook,
+  type ProcessWebhookResult,
+} from '@/modules/platform-integration/usecases/processWebhook.usecase.js';
 import type {
   GateClaudeInvocationInput,
   GateClaudeInvocationResult,
@@ -157,6 +162,16 @@ function createDeps(
   overrides: Record<string, unknown> = {},
 ) {
   const threadFetchGateway = { fetchThreads: vi.fn(() => []) };
+  const recordPush = new RecordPushUseCase(trackingGateway);
+  const transitionState = new TransitionStateUseCase(trackingGateway);
+  const checkFollowupNeeded = new CheckFollowupNeededUseCase(trackingGateway);
+  const removeWorktree = vi.fn(async () => ({ status: 'removed' as const }));
+  const handleClose = vi.fn(async () => ({
+    status: 'cleaned' as const,
+    jobCancelled: true,
+    trackingArchived: true,
+    contextDeleted: true,
+  }));
   return {
     reviewContextGateway: createStubContextGateway(),
     threadFetchGateway,
@@ -166,9 +181,9 @@ function createDeps(
     diffStatsFetchGateway: { fetchDiffStats: vi.fn(() => null) },
     trackAssignment: new TrackAssignmentUseCase(trackingGateway),
     recordCompletion: new RecordReviewCompletionUseCase(trackingGateway),
-    recordPush: new RecordPushUseCase(trackingGateway),
-    transitionState: new TransitionStateUseCase(trackingGateway),
-    checkFollowupNeeded: new CheckFollowupNeededUseCase(trackingGateway),
+    recordPush,
+    transitionState,
+    checkFollowupNeeded,
     syncThreads: new SyncThreadsUseCase(trackingGateway, threadFetchGateway),
     executeReview: vi.fn(async () => ({
       status: 'completed' as const,
@@ -182,16 +197,20 @@ function createDeps(
         durationMs: 1200,
       },
     })),
-    handleClose: vi.fn(async () => ({
-      status: 'cleaned' as const,
-      jobCancelled: true,
-      trackingArchived: true,
-      contextDeleted: true,
-    })),
+    handleClose,
+    processWebhook: (event: WebhookEvent): Promise<ProcessWebhookResult> =>
+      processWebhook(event, {
+        handleClose,
+        transitionState,
+        recordPush,
+        checkFollowupNeeded,
+        removeWorktree,
+        logger: createStubLogger(),
+      }),
     enforceBudget: createAcceptAllEnforceBudget(),
     broadcastBudgetExceeded: vi.fn(),
     getRepositories: vi.fn(() => []),
-    removeWorktree: vi.fn(async () => ({ status: 'removed' as const })),
+    removeWorktree,
     recordBypass: new RecordBypassUseCase(trackingGateway),
     noteCommentPostGateway: new StubNoteCommentPostGateway(),
     handlePlatformApproval: new HandlePlatformApprovalUseCase(trackingGateway),

--- a/src/tests/units/modules/platform-integration/usecases/processWebhook.usecase.test.ts
+++ b/src/tests/units/modules/platform-integration/usecases/processWebhook.usecase.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect } from 'vitest';
+
+import type { WebhookEvent } from '@/modules/platform-integration/entities/webhookEvent/webhookEvent.js';
+import {
+  processWebhook,
+  type ProcessWebhookDependencies,
+} from '@/modules/platform-integration/usecases/processWebhook.usecase.js';
+import type { TransitionStateResult } from '@/modules/tracking/usecases/tracking/transitionState.usecase.js';
+import { TrackedMrFactory } from '@/tests/factories/trackedMr.factory.js';
+import { createStubLogger } from '@/tests/stubs/logger.stub.js';
+
+interface Harness {
+  deps: ProcessWebhookDependencies;
+  handleCloseCalls: Array<{ platform: string; mergeRequestNumber: number; localPath: string }>;
+  transitionStateCalls: Array<{ projectPath: string; mrId: string; targetState: string }>;
+  recordPushCalls: Array<{ projectPath: string; mrNumber: number; platform: string }>;
+  checkFollowupNeededCalls: Array<{ projectPath: string; mrNumber: number; platform: string }>;
+  removeWorktreeCalls: Array<{ platform: string; sourceCheckoutPath: string }>;
+}
+
+function buildHarness(overrides?: Partial<ProcessWebhookDependencies>): Harness {
+  const handleCloseCalls: Harness['handleCloseCalls'] = [];
+  const transitionStateCalls: Harness['transitionStateCalls'] = [];
+  const recordPushCalls: Harness['recordPushCalls'] = [];
+  const checkFollowupNeededCalls: Harness['checkFollowupNeededCalls'] = [];
+  const removeWorktreeCalls: Harness['removeWorktreeCalls'] = [];
+
+  const deps: ProcessWebhookDependencies = {
+    handleClose: async (input) => {
+      handleCloseCalls.push({
+        platform: input.platform,
+        mergeRequestNumber: input.mergeRequestNumber,
+        localPath: input.localPath,
+      });
+      return {
+        status: 'cleaned',
+        jobCancelled: true,
+        trackingArchived: false,
+        contextDeleted: true,
+      };
+    },
+    transitionState: {
+      execute: (input): TransitionStateResult => {
+        transitionStateCalls.push({
+          projectPath: input.projectPath,
+          mrId: input.mrId,
+          targetState: input.targetState,
+        });
+        return { ok: true };
+      },
+    },
+    recordPush: {
+      execute: (input) => {
+        recordPushCalls.push({
+          projectPath: input.projectPath,
+          mrNumber: input.mrNumber,
+          platform: input.platform,
+        });
+        return TrackedMrFactory.create({ mrNumber: input.mrNumber, autoFollowup: true });
+      },
+    },
+    checkFollowupNeeded: {
+      execute: (input) => {
+        checkFollowupNeededCalls.push({
+          projectPath: input.projectPath,
+          mrNumber: input.mrNumber,
+          platform: input.platform,
+        });
+        return true;
+      },
+    },
+    removeWorktree: async ({ identity, sourceCheckoutPath }) => {
+      removeWorktreeCalls.push({ platform: identity.platform, sourceCheckoutPath });
+      return { status: 'removed' };
+    },
+    logger: createStubLogger(),
+    ...overrides,
+  };
+
+  return {
+    deps,
+    handleCloseCalls,
+    transitionStateCalls,
+    recordPushCalls,
+    checkFollowupNeededCalls,
+    removeWorktreeCalls,
+  };
+}
+
+const baseClose: WebhookEvent = {
+  type: 'close',
+  platform: 'github',
+  projectPath: 'org/repo',
+  localPath: '/checkout/repo',
+  mergeRequestNumber: 7,
+};
+
+const baseMerge: WebhookEvent = {
+  type: 'merge',
+  platform: 'gitlab',
+  projectPath: 'group/project',
+  localPath: '/checkout/project',
+  mergeRequestNumber: 42,
+};
+
+function followupFor(mrNumber: number): WebhookEvent {
+  return {
+    type: 'followup-push',
+    platform: 'gitlab',
+    projectPath: 'group/project',
+    localPath: '/checkout/project',
+    mergeRequestNumber: mrNumber,
+    mergeRequestUrl: `https://gitlab.com/group/project/-/merge_requests/${mrNumber}`,
+    sourceBranch: 'fix-bug',
+    targetBranch: 'main',
+  };
+}
+
+describe('processWebhook', () => {
+  describe('close', () => {
+    it('delegates to handleClose with the platform-neutral identity', async () => {
+      const harness = buildHarness();
+
+      const result = await processWebhook(baseClose, harness.deps);
+
+      expect(harness.handleCloseCalls).toEqual([
+        { platform: 'github', mergeRequestNumber: 7, localPath: '/checkout/repo' },
+      ]);
+      expect(result).toEqual({
+        type: 'closed',
+        mergeRequestNumber: 7,
+        jobCancelled: true,
+        trackingArchived: false,
+      });
+    });
+  });
+
+  describe('merge', () => {
+    it('transitions tracking state to merged using the platform-prefixed id', async () => {
+      const harness = buildHarness();
+
+      const result = await processWebhook(baseMerge, harness.deps);
+
+      expect(harness.transitionStateCalls).toEqual([
+        {
+          projectPath: '/checkout/project',
+          mrId: 'gitlab-group/project-42',
+          targetState: 'merged',
+        },
+      ]);
+      expect(result).toEqual({ type: 'merged', mergeRequestNumber: 42 });
+    });
+
+    it('removes the worktree best-effort with the source checkout path', async () => {
+      const harness = buildHarness();
+
+      await processWebhook(baseMerge, harness.deps);
+
+      expect(harness.removeWorktreeCalls).toEqual([
+        { platform: 'gitlab', sourceCheckoutPath: '/checkout/project' },
+      ]);
+    });
+
+    it('returns merged even when worktree removal throws', async () => {
+      const harness = buildHarness({
+        removeWorktree: async () => {
+          throw new Error('exploded');
+        },
+      });
+
+      const result = await processWebhook(baseMerge, harness.deps);
+
+      expect(result).toEqual({ type: 'merged', mergeRequestNumber: 42 });
+    });
+  });
+
+  describe('followup-push', () => {
+    it('records the push then checks followup eligibility', async () => {
+      const harness = buildHarness();
+
+      const result = await processWebhook(followupFor(42), harness.deps);
+
+      expect(harness.recordPushCalls).toEqual([
+        { projectPath: '/checkout/project', mrNumber: 42, platform: 'gitlab' },
+      ]);
+      expect(harness.checkFollowupNeededCalls).toEqual([
+        { projectPath: '/checkout/project', mrNumber: 42, platform: 'gitlab' },
+      ]);
+      expect(result).toEqual({ type: 'followup-eligible', mergeRequestNumber: 42 });
+    });
+
+    it('skips when the merge request is not tracked', async () => {
+      const harness = buildHarness({ recordPush: { execute: () => null } });
+
+      const result = await processWebhook(followupFor(42), harness.deps);
+
+      expect(harness.checkFollowupNeededCalls).toEqual([]);
+      expect(result).toEqual({
+        type: 'followup-skipped',
+        mergeRequestNumber: 42,
+        reason: 'Merge request not tracked',
+      });
+    });
+
+    it('skips when no followup is needed', async () => {
+      const harness = buildHarness({ checkFollowupNeeded: { execute: () => false } });
+
+      const result = await processWebhook(followupFor(42), harness.deps);
+
+      expect(result).toEqual({
+        type: 'followup-skipped',
+        mergeRequestNumber: 42,
+        reason: 'No followup needed',
+      });
+    });
+
+    it('skips when auto-followup is disabled on the tracked merge request', async () => {
+      const harness = buildHarness({
+        recordPush: {
+          execute: () => TrackedMrFactory.create({ mrNumber: 42, autoFollowup: false }),
+        },
+      });
+
+      const result = await processWebhook(followupFor(42), harness.deps);
+
+      expect(result).toEqual({
+        type: 'followup-skipped',
+        mergeRequestNumber: 42,
+        reason: 'Auto-followup disabled',
+      });
+    });
+  });
+
+  describe('events the controller still owns', () => {
+    it('treats review-requested as handled by the controller', async () => {
+      const harness = buildHarness();
+
+      const result = await processWebhook(
+        {
+          type: 'review-requested',
+          platform: 'gitlab',
+          projectPath: 'group/project',
+          localPath: '/checkout/project',
+          mergeRequestNumber: 42,
+          mergeRequestUrl: 'https://gitlab.com/group/project/-/merge_requests/42',
+          sourceBranch: 'fix-bug',
+          targetBranch: 'main',
+          title: 'Fix bug',
+          description: null,
+          assignedBy: { username: 'alice', displayName: null },
+          skill: 'review',
+          language: null,
+        },
+        harness.deps,
+      );
+
+      expect(result).toEqual({
+        type: 'ignored',
+        reason: 'review-requested-handled-by-controller',
+      });
+    });
+
+    it('treats approve as handled by the controller', async () => {
+      const harness = buildHarness();
+
+      const result = await processWebhook(
+        {
+          type: 'approve',
+          platform: 'gitlab',
+          projectPath: 'group/project',
+          localPath: '/checkout/project',
+          mergeRequestNumber: 42,
+        },
+        harness.deps,
+      );
+
+      expect(result).toEqual({ type: 'ignored', reason: 'approve-handled-by-controller' });
+    });
+  });
+
+  describe('ignored', () => {
+    it('passes the reason straight through', async () => {
+      const harness = buildHarness();
+
+      const result = await processWebhook(
+        { type: 'ignored', reason: 'Not a MR event' },
+        harness.deps,
+      );
+
+      expect(result).toEqual({ type: 'ignored', reason: 'Not a MR event' });
+    });
+  });
+});


### PR DESCRIPTION
## SPEC-073 Stage 3 — `ProcessWebhook` orchestrator + `WebhookEvent` union

Third of four staged increments extracting webhook business logic from the controllers (Stages 1-2 merged via #305). Spec: `docs/specs/73-extract-webhook-processing-usecase.md`.

### What this adds
- **`WebhookEvent`** — platform-neutral discriminated union (6 variants: `review-requested | followup-push | close | merge | approve | ignored`) in the entity layer.
- **`processWebhook(event, deps)`** — function-based orchestrator routing the **synchronous** outcomes (`close`, `merge`, `followup-push` eligibility, `ignored`) to the existing extracted use cases. Imports only `entities/` + sibling `usecases/` — **never** a platform-specific type or gateway (Dependency Rule).
- Both controllers map their parsed close/merge/followup events → `WebhookEvent` → `processWebhook` → **byte-for-byte identical** HTTP replies (incl. GitLab `mrNumber` vs GitHub `prNumber`).
- Wired in the composition root (`routes.ts`).

### Scope boundaries (deliberate — staged refactor)
- `approve` and `review-requested` stay **100% controller-side** (folded into Stage 4). The union carries both for completeness; the orchestrator returns `{ type:'ignored', reason:'<variant>-handled-by-controller' }` for them, keeping the switch total.
- Async enqueue tail (budget gate, processor closure capturing `executeReview`, `gateClaudeInvocation`, actor-trust, `enqueueReview`, 3-way reply shapes) **unchanged**.
- HTTP reply shapes preserved exactly (unification = Stage 4). `eventFilter.ts` untouched.

### Verification
- `yarn verify` green: **473 files / 3921 tests pass**, typecheck + lint + format clean.
- 13 unit + 8 acceptance Stage-3 tests; acceptance asserts platform-neutrality (imports no `GitLab*`/`GitHub*` type).
- 91 existing controller tests preserved (reply shapes intact).

Plan: `docs/plans/73-process-webhook.plan.md` · Report: `docs/reports/73-process-webhook.report.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)