### PR TITLE
fix(stats): self-service backfill via Recalculate button (spec-208)

### DIFF
--- a/docs/feature-tracker.md
+++ b/docs/feature-tracker.md
@@ -70,4 +70,4 @@
 | Show key insight cards on the analytics overview | [205-analytics-key-insight-cards](specs/205-analytics-key-insight-cards.md) — [plan](plans/205-analytics-key-insight-cards.plan.md) — [report](reports/205-analytics-key-insight-cards.report.md) | implemented | 2026-06-19 |
 | Fix the GitLab change-size source | [206-fix-gitlab-diff-stats-source](specs/206-fix-gitlab-diff-stats-source.md) — [plan](plans/206-fix-gitlab-diff-stats-source.plan.md) — [report](reports/206-fix-gitlab-diff-stats-source.report.md) | implemented | 2026-06-20 |
 | Backfill change-size data for past reviews | [207-backfill-historical-diff-stats](specs/207-backfill-historical-diff-stats.md) | implemented | 2026-06-20 |
-| Make the Recalculate button backfill change-size data | [208-self-service-backfill-button](specs/208-self-service-backfill-button.md) | drafted | 2026-06-20 |
+| Make the Recalculate button backfill change-size data | [208-self-service-backfill-button](specs/208-self-service-backfill-button.md) — [plan](plans/208-self-service-backfill-button.plan.md) — [report](reports/208-self-service-backfill-button.report.md) | implemented | 2026-06-20 |

--- a/docs/plans/208-self-service-backfill-button.plan.md
+++ b/docs/plans/208-self-service-backfill-button.plan.md
@@ -1,0 +1,176 @@
+# Plan — SPEC-208 Self-service backfill button
+
+> Spec: `docs/specs/208-self-service-backfill-button.md`
+> Architecture: modular monolith (`src/modules/<context>/...`), inside-out TDD (Detroit).
+> Goal: make the dashboard "Recalculate" button actually backfill change-size data by (1) resolving each project's platform + project identifier from its git remote, (2) feeding the identifier to the platform gateway instead of the local path, (3) recomputing `diffStatsReviewCount`, (4) rejecting unresolvable projects.
+
+```
+PLAN:
+  scope: self-service backfill button
+  is_new_module: false
+```
+
+## ANTI-OVERENGINEERING CHALLENGE
+
+The temptation is a new "ProjectIdentifierResolver" gateway/service hierarchy. Rejected.
+
+- The git side (run `git remote get-url`, sniff platform) **already exists** in `GitRemoteCliGateway` (setup-wizard). Reuse it, do not duplicate.
+- The only genuinely new logic is a **pure string parse**: git remote URL -> `group/proj`. That is one stateless function with branchy edge cases (SSH vs HTTPS, `.git` suffix, nested groups). It earns an entity file with a pure function + Zod-validated branded type at most — no class, no gateway, no use case wrapper.
+- No new platform abstraction: the existing `Platform` union (`'github' | 'gitlab' | 'unknown'`) is sufficient.
+- The resolver runs **once, in the route** (composition edge), producing `{ platform, projectIdentifier }` that flows inward as plain data. The inner use cases stay infrastructure-agnostic.
+
+Net new files: 1 entity (+test) + 1 cross-module reuse of an existing gateway. Everything else is modify-in-place. Within the <10-file budget.
+
+## ENTITIES
+
+- **ProjectIdentifier resolver (NEW)** — pure function, no class
+  - file: `src/modules/statistics-insights/entities/projectIdentifier/projectIdentifier.ts`
+  - export: `resolveProjectIdentifier(remoteUrl: string): string | null`
+  - returns `group/proj` (GitLab, may be nested e.g. `group/sub/proj`) or `owner/repo` (GitHub), or `null` if the URL cannot be parsed into an identifier
+  - test: `src/tests/units/modules/statistics-insights/entities/projectIdentifier/projectIdentifier.test.ts`
+  - NO schema/guard/gateway-contract files — the input is already a `string`, output is `string | null`; a Zod schema here would be boilerplate over a regex. (If branding `ProjectIdentifier` proves useful later, add it then — YAGNI now.)
+
+- **ReviewStats.diffStatsReviewCount** — field already exists optional in `entities/stats/projectStats.ts:41`. No entity change.
+
+## RESOLVER DESIGN
+
+**Where it lives**: pure function in `statistics-insights` entities (domain layer). It takes a remote URL string and returns the identifier. It does NOT touch the filesystem or run git — that is the gateway's job.
+
+**How the two halves compose (in the route, the dirty edge)**:
+
+```
+repository.localPath                      (from config)
+   │
+   ├─ gitRemoteGateway.getOriginRemote(localPath) ── string | null   (existing, setup-wizard)
+   │        │
+   │        ├─ null ──────────────────────────────► reject RULE 3
+   │        ▼
+   ├─ gitRemoteGateway.detectPlatform(remote) ──── 'github'|'gitlab'|'unknown'   (existing)
+   │        │
+   │        └─ 'unknown' ──────────────────────────► reject RULE 3
+   │
+   └─ resolveProjectIdentifier(remote) ──────────── string | null   (NEW pure fn)
+            │
+            └─ null ────────────────────────────────► reject RULE 3
+                                                        "Plateforme du projet introuvable"
+   ▼
+{ platform, projectIdentifier }  ──► recalculateWithBackfill (plain data, flows inward)
+```
+
+**Parsing rules** (drive the unit-test table):
+| input remote | output identifier |
+|---|---|
+| `git@gitlab.com:group/proj.git` | `group/proj` |
+| `https://gitlab.com/group/proj.git` | `group/proj` |
+| `git@gitlab.com:group/sub/proj.git` | `group/sub/proj` (nested groups preserved) |
+| `git@github.com:owner/repo.git` | `owner/repo` |
+| `https://github.com/owner/repo` | `owner/repo` |
+| `git@gitlab.example.com:org/proj.git` | `org/proj` (self-hosted host stripped) |
+| `not-a-url` / `""` | `null` |
+
+Strategy: strip protocol/host prefix (`scheme://host/` or `git@host:`), strip trailing `.git`, require at least `seg/seg`; otherwise `null`. Implementation detail left to the implementer; the table is the contract.
+
+## USECASES (all MODIFY — no new use case)
+
+- **`backfillDiffStats.usecase.ts`** (MODIFY)
+  - file: `src/modules/statistics-insights/usecases/stats/backfillDiffStats.usecase.ts`
+  - test: `src/tests/units/usecases/stats/backfillDiffStats.usecase.test.ts`
+  - **DEFECT 2 fix**: add `projectIdentifier: string` to `BackfillDiffStatsInput`. Keep `projectPath` for `statsGateway.loadProjectStats/saveProjectStats` (filesystem key). Change line 52 from `fetchDiffStats(projectPath, review.mrNumber)` to `fetchDiffStats(projectIdentifier, review.mrNumber)`.
+  - The gateway signature `fetchDiffStats(string, number)` is UNCHANGED — the first arg's *meaning* shifts from "local path" to "platform identifier". The `StubDiffStatsFetchGateway` already ignores arg 1 (`_projectPath`), so stub stays valid; add one assertion that the identifier (not the path) is forwarded.
+
+- **`recalculateWithBackfill.usecase.ts`** (MODIFY)
+  - file: `src/modules/statistics-insights/usecases/stats/recalculateWithBackfill.usecase.ts`
+  - test: `src/tests/units/usecases/stats/recalculateWithBackfill.usecase.test.ts`
+  - **DEFECT 1 + 3 fix**: add `projectIdentifier: string | null` to `RecalculateWithBackfillInput`. Guard becomes `shouldBackfill && diffStatsFetchGateways && platform && projectIdentifier`. Pass `projectIdentifier` through to `backfillDiffStats`. (Rejection itself — RULE 3 — is done upstream in the route so the user gets a 4xx + message; this use case stays fire-and-forget. If identifier is null here it simply skips, but the route should have rejected before calling.)
+
+- **`recalculateProjectStats.usecase.ts`** (MODIFY)
+  - file: `src/modules/statistics-insights/usecases/stats/recalculateProjectStats.usecase.ts`
+  - test: `src/tests/units/usecases/stats/recalculateProjectStats.usecase.test.ts`
+  - **DEFECT 4 fix (RULE 4)**: set `stats.diffStatsReviewCount = reviewsWithDiffStats.length` alongside the totals/averages block (currently computed at lines 49-69 but never stored). Set it in BOTH branches (the `> 0` branch and the `else` -> `0`). Also set it in the no-stats empty-stats object (`= 0`) for consistency.
+
+## GATEWAYS
+
+- **`DiffStatsFetchGateway`** contract — UNCHANGED.
+  - `src/modules/shared-kernel/entities/diffStats/diffStatsFetch.gateway.ts` keeps `fetchDiffStats(projectPath: string, mergeRequestNumber: number)`. Rename the param to `projectIdentifier` for clarity (optional, cosmetic; no behavior change). The GitLab/GitHub impls already interpolate arg 1 into `project(fullPath:"...")` / `repos/.../pulls` — they were always *expecting* the identifier; the bug was purely the caller passing the wrong value.
+  - GitLab impl: `diffStatsFetch.gitlab.gateway.ts` — UNCHANGED.
+  - GitHub impl: `diffStatsFetch.github.gateway.ts` — UNCHANGED.
+  - `StubDiffStatsFetchGateway` (`src/tests/stubs/diffStatsFetch.stub.ts`) — optionally record the received identifier to assert forwarding; otherwise UNCHANGED.
+
+- **`GitRemoteGateway`** (REUSE, cross-module) — `src/modules/setup-wizard/entities/gitRemote/gitRemote.gateway.ts` + impl `gitRemote.cli.gateway.ts`. Already exposes `getOriginRemote(path)` + `detectPlatform(url)`. Imported by the route. No change. (statistics-insights -> setup-wizard is an interface-adapter-to-interface-adapter dependency at the composition edge; the route imports the concrete gateway, the inner use cases stay clean.)
+
+## CONTROLLERS / ROUTES
+
+- **`stats.routes.ts`** (MODIFY) — `POST /api/stats/recalculate`
+  - file: `src/modules/statistics-insights/interface-adapters/controllers/http/stats.routes.ts`
+  - test: `src/tests/units/interface-adapters/controllers/http/statsRecalculate.routes.test.ts`
+  - Add `gitRemoteGateway: GitRemoteGateway` to `StatsRoutesOptions` (injected, so tests stub it).
+  - In the handler, AFTER the 404 repo check and BEFORE calling `recalculateWithBackfill`, resolve when `shouldBackfill` is true:
+    1. `remote = gitRemoteGateway.getOriginRemote(repository.localPath)`
+    2. `platform = remote ? gitRemoteGateway.detectPlatform(remote) : null`
+    3. `projectIdentifier = remote ? resolveProjectIdentifier(remote) : null`
+    4. If `shouldBackfill` AND (`remote === null` OR `platform === 'unknown'` OR `projectIdentifier === null`) -> `reply.status(422).send({ error: 'Plateforme du projet introuvable' })` and return. **(RULE 3)**
+  - Drop the stale `repository.platform ?? null` (DEFECT 1 source, line 106) in favour of the resolved `platform`. Pass `platform` and `projectIdentifier` into `recalculateWithBackfill`.
+  - When `shouldBackfill === false`: skip resolution entirely (recompute-only path stays working for projects without a remote).
+  - Status code for rejection: `422 Unprocessable Entity` (project exists in config but cannot be backfilled). Confirm with implementer if `400` is preferred; spec only mandates the message, not the code.
+
+## WIRING
+
+- file: `src/main/routes.ts` (MODIFY, the only composition-root change)
+  - Import `GitRemoteCliGateway` from `@/modules/setup-wizard/interface-adapters/gateways/gitRemote.cli.gateway.js`.
+  - In the existing `app.register(statsRoutes, { ... })` block (lines 193-202), add `gitRemoteGateway: new GitRemoteCliGateway()`.
+  - No new gateway instances for diff-stats (gitlab/github already wired lines 196-199). No route additions; `/api/stats/recalculate` already exists.
+
+## SPEC-RULE -> SCENARIO -> TEST MAPPING
+
+| Spec Rule | Scenario | Test (file :: case) |
+|---|---|---|
+| Resolve platform without manual config (RULE 1) | gitlab project / github project | `projectIdentifier.test.ts` (parse table) + `statsRecalculate.routes.test.ts` :: "resolves platform from git remote, not config" |
+| Fetch using platform identifier, not local path (RULE 2) | gitlab `group/proj`, github `owner/repo` | `backfillDiffStats.usecase.test.ts` :: "forwards projectIdentifier to gateway, not projectPath" + `projectIdentifier.test.ts` |
+| Reject unresolvable platform/identifier (RULE 3) | unresolvable platform: remote none -> reject | `statsRecalculate.routes.test.ts` :: "rejects with 'Plateforme du projet introuvable' when remote is missing / unknown / unparseable" |
+| Recompute diffStatsReviewCount with totals/averages (RULE 4) | count maintained: 40 reviews -> count 40 | `recalculateProjectStats.usecase.test.ts` :: "sets diffStatsReviewCount to the number of reviews with diffStats" |
+| Button populates reviews -> non-zero totals (RULE 5) | gitlab/github populated; nothing-missing unchanged | acceptance test (below) — full vertical slice |
+
+### Existing tests that MUST change
+- `statsRecalculate.routes.test.ts` — `createTestOptions` must add a stubbed `gitRemoteGateway` (e.g. `getOriginRemote -> 'git@gitlab.com:group/proj.git'`, `detectPlatform -> 'gitlab'`). Without it the backfill branch can't resolve. Add the rejection-path cases.
+- `recalculateWithBackfill.usecase.test.ts` — every `recalculateWithBackfill({ ... })` call gains `projectIdentifier`. The "github gateway" and "run backfill" cases assert the identifier is forwarded. The "skip when platform null" case keeps working (now also covered by null identifier).
+- `backfillDiffStats.usecase.test.ts` — every `backfillDiffStats({ projectPath, ... })` call gains `projectIdentifier`. Add the forwarding assertion.
+- `recalculateProjectStats.usecase.test.ts` — add the `diffStatsReviewCount` assertion; the empty-reviews case asserts `0`.
+
+## IMPLEMENTATION_ORDER
+
+1. `entities/projectIdentifier/projectIdentifier.ts` (+ test) — pure domain core, the only genuinely new logic; testable in isolation, no I/O. **Walking-skeleton seed.**
+2. `usecases/stats/recalculateProjectStats.usecase.ts` — RULE 4 one-liner (`diffStatsReviewCount`); smallest independent fix, unblocks the count scenario.
+3. `usecases/stats/backfillDiffStats.usecase.ts` — add `projectIdentifier` input, forward to gateway (RULE 2).
+4. `usecases/stats/recalculateWithBackfill.usecase.ts` — thread `projectIdentifier` through, tighten the guard (RULE 1 enablement).
+5. `interface-adapters/controllers/http/stats.routes.ts` — resolve via `gitRemoteGateway` + `resolveProjectIdentifier`, reject unresolvable (RULE 3), pass resolved data inward.
+6. `main/routes.ts` — wire `new GitRemoteCliGateway()` into `statsRoutes` (composition root, LAST).
+7. acceptance test green.
+
+## ACCEPTANCE_TEST
+
+```
+ACCEPTANCE_TEST:
+  file: src/tests/acceptance/208-self-service-backfill-button.acceptance.test.ts
+  note: "SDD outer loop — written first by implementer, RED during impl, GREEN at the end.
+         Drives stats.routes via fastify.inject POST /api/stats/recalculate with backfill:true,
+         a stubbed gitRemoteGateway (gitlab remote) and a StubDiffStatsFetchGateway returning
+         non-zero diffStats. Asserts: reviews populated, totals/averages non-zero,
+         diffStatsReviewCount == fetched count, and that the identifier (group/proj) — not the
+         local path — reached the gateway. Second case: remote=none -> 422 +
+         'Plateforme du projet introuvable'. Third: nothing-missing -> no fetch, totals unchanged."
+```
+
+## REFERENCE_FILES
+
+- `src/modules/setup-wizard/interface-adapters/gateways/gitRemote.cli.gateway.ts` — REUSE `getOriginRemote` + `detectPlatform`; the resolver is the missing third piece.
+- `src/modules/setup-wizard/entities/gitRemote/gitRemote.gateway.ts` — contract to inject into the route.
+- `src/modules/setup-wizard/entities/projectContext/projectContext.schema.ts` — the `Platform` union (`'github'|'gitlab'|'unknown'`) reused for rejection logic.
+- `src/modules/statistics-insights/usecases/stats/backfillDiffStats.usecase.ts:52` — DEFECT 2 (path passed where identifier expected).
+- `src/modules/statistics-insights/usecases/stats/recalculateWithBackfill.usecase.ts:31` — DEFECT 1 (skips when platform null).
+- `src/modules/statistics-insights/usecases/stats/recalculateProjectStats.usecase.ts:49-69` — DEFECT 4 (count never stored).
+- `src/modules/statistics-insights/interface-adapters/controllers/http/stats.routes.ts:106` — DEFECT 1 source (`repository.platform ?? null`).
+- `src/modules/statistics-insights/interface-adapters/gateways/diffStatsFetch.gitlab.gateway.ts:48` — confirms arg 1 must be `group/proj` (interpolated into `project(fullPath:)`).
+- `src/modules/statistics-insights/interface-adapters/gateways/diffStatsFetch.github.gateway.ts:18` — confirms arg 1 must be `owner/repo` (`repos/.../pulls`).
+- `src/modules/cli-configuration/usecases/cli/discoverRepositories.usecase.ts:43` — prior-art `detectPlatform`; do NOT reuse its loose `includes('gitlab')` for identifier parsing.
+- `src/main/routes.ts:193-202` — the `statsRoutes` registration to extend.
+- `src/tests/stubs/diffStatsFetch.stub.ts` — stub already ignores arg 1; add identifier capture if asserting forwarding.

--- a/docs/reports/208-self-service-backfill-button.report.md
+++ b/docs/reports/208-self-service-backfill-button.report.md
@@ -1,0 +1,70 @@
+# Implementation Report — SPEC-208 Self-service backfill button
+
+> Spec: `docs/specs/208-self-service-backfill-button.md` · Plan: `docs/plans/208-self-service-backfill-button.plan.md`
+> Status: **implemented** · Date: 2026-06-20
+
+## Summary
+
+The dashboard "Recalculate" button now actually backfills change-size data. Three wiring
+defects were fixed and one missing aggregate was added; only one genuinely new file (a pure
+git-remote parser) was created. The git side was reused from `setup-wizard`, not reinvented.
+
+## Files
+
+### Created
+
+| File | Purpose |
+|------|---------|
+| `src/modules/statistics-insights/entities/projectIdentifier/projectIdentifier.ts` | Pure `resolveProjectIdentifier(remoteUrl)` → `group/proj` \| `owner/repo` \| `null` |
+| `src/tests/units/modules/statistics-insights/entities/projectIdentifier/projectIdentifier.test.ts` | Parse-table unit tests |
+| `src/tests/acceptance/208-self-service-backfill-button.acceptance.test.ts` | SDD outer loop (4 cases) |
+
+### Modified
+
+| File | Change |
+|------|--------|
+| `src/modules/statistics-insights/usecases/stats/recalculateProjectStats.usecase.ts` | Store `diffStatsReviewCount` (RULE 4) |
+| `src/modules/statistics-insights/usecases/stats/backfillDiffStats.usecase.ts` | Accept + forward `projectIdentifier` to gateway instead of local path (RULE 2) |
+| `src/modules/statistics-insights/usecases/stats/recalculateWithBackfill.usecase.ts` | Thread `projectIdentifier`; guard requires platform + identifier (RULE 1) |
+| `src/modules/statistics-insights/interface-adapters/controllers/http/stats.routes.ts` | Resolve platform/identifier from git remote; reject unresolvable with 422 (RULE 3); drop stale `repository.platform ?? null` |
+| `src/modules/shared-kernel/entities/diffStats/diffStatsFetch.gateway.ts` | Param renamed to `projectIdentifier` (cosmetic; contract unchanged) |
+| `src/main/routes.ts` | Inject `new GitRemoteCliGateway()` into `statsRoutes` |
+| `src/tests/stubs/diffStatsFetch.stub.ts` | Capture `lastProjectIdentifier` / `fetchCallCount` for forwarding assertions |
+| `src/tests/units/.../statsRecalculate.routes.test.ts`, `backfillDiffStats.usecase.test.ts`, `recalculateWithBackfill.usecase.test.ts`, `recalculateProjectStats.usecase.test.ts` | Adapted to new inputs + rejection cases |
+
+## Tests
+
+- `yarn verify`: **PASS** — typecheck clean, lint warnings only (pre-existing debt), format clean.
+- **466 test files, 3878 tests passed**, 0 failed.
+
+## Acceptance — GREEN
+
+`src/tests/acceptance/208-self-service-backfill-button.acceptance.test.ts` — 4 cases:
+
+1. GitLab project: backfill fetches + populates reviews, totals + `diffStatsReviewCount` correct.
+2. Identifier (`group/proj`), not local path, reaches the gateway.
+3. Remote missing → `422` + `Plateforme du projet introuvable`.
+4. Nothing missing → no fetch, totals unchanged.
+
+## Spec coverage
+
+| Rule | Covered by |
+|------|-----------|
+| RULE 1 — resolve platform without manual config | `statsRecalculate.routes.test.ts` + acceptance case 1 |
+| RULE 2 — fetch using project identifier, not local path | `projectIdentifier.test.ts` + `backfillDiffStats.usecase.test.ts` + acceptance case 2 |
+| RULE 3 — reject unresolvable with clear message | `statsRecalculate.routes.test.ts` + acceptance case 3 |
+| RULE 4 — recompute `diffStatsReviewCount` | `recalculateProjectStats.usecase.test.ts` + acceptance case 1 |
+| RULE 5 — button populates → non-zero totals | acceptance case 1 |
+
+## Decisions / notes
+
+- Rejection status code **422** (validated by user).
+- Resolver kept as a pure function (no Zod, no class) — YAGNI.
+- `gitRemoteGateway` is an **optional** route option (backfill-only dep), consistent with the
+  existing optional `diffStatsFetchGateways`. Fixed during orchestrator review: the implementer
+  had made it required, which broke two unrelated GET-only stats-route test registrations.
+
+## Remaining issues
+
+None. Out-of-scope per spec: rendering additions/deletions in the dashboard, non-change-size
+fields, platform inference for projects without a git remote.

--- a/docs/specs/208-self-service-backfill-button.md
+++ b/docs/specs/208-self-service-backfill-button.md
@@ -1,5 +1,7 @@
 # Make the Recalculate button backfill change-size data
 
+## Status: implemented
+
 ## Context
 
 The dashboard `Recalculate` button is meant to backfill missing change-size data, but it
@@ -56,3 +58,25 @@ be repaired by an out-of-band script. This makes the button self-service.
 ## Definition of Done
 
 See `.claude/skills/product-manager/rules/dod.md`.
+
+## Implementation
+
+### Artefacts
+
+- **Entity (new)**: `src/modules/statistics-insights/entities/projectIdentifier/projectIdentifier.ts` — pure `resolveProjectIdentifier(remoteUrl)` parsing SSH/HTTPS git remotes into `group/proj` or `owner/repo` (nested GitLab groups preserved, `.git` stripped, self-hosted hosts dropped), `null` when unparseable.
+- **Use cases (modified)**:
+  - `recalculateProjectStats.usecase.ts` — now stores `diffStatsReviewCount` alongside totals/averages (RULE 4).
+  - `backfillDiffStats.usecase.ts` — takes a `projectIdentifier` and forwards it to the platform gateway instead of the local filesystem path (RULE 2). `projectPath` is retained only as the stats load/save key.
+  - `recalculateWithBackfill.usecase.ts` — threads `projectIdentifier` through; backfill guard tightened to require platform **and** identifier.
+- **Controller (modified)**: `stats.routes.ts` — resolves platform + project identifier from the project's git remote via the reused `GitRemoteCliGateway`; rejects unresolvable projects with `422 Plateforme du projet introuvable` (RULE 3). Stale `repository.platform ?? null` removed (RULE 1).
+- **Wiring**: `src/main/routes.ts` — injects `new GitRemoteCliGateway()` into the stats routes.
+
+### Reused (not reinvented)
+
+- `GitRemoteCliGateway` (`setup-wizard`) — `getOriginRemote()` + `detectPlatform()`. The `DiffStatsFetchGateway` contract was left unchanged: it always expected the platform identifier; the defect was the caller passing the local path.
+
+### Decisions
+
+- Rejection status code: **422 Unprocessable Entity** (project exists in config but cannot be backfilled).
+- The resolver is a pure function (no Zod schema, no class) — a regex parse does not warrant a branded type yet (YAGNI).
+- `gitRemoteGateway` is an optional route option (backfill-only dependency), consistent with `diffStatsFetchGateways`; recompute-only calls do not require it.

--- a/src/main/routes.ts
+++ b/src/main/routes.ts
@@ -114,6 +114,7 @@ import { DismissPendingReviewUseCase } from '@/modules/review-execution/usecases
 import { GateClaudeInvocationUseCase } from '@/modules/review-execution/usecases/gateClaudeInvocation.usecase.js';
 import { ListPendingReviewsUseCase } from '@/modules/review-execution/usecases/listPendingReviews.usecase.js';
 import { setupWizardRoutes } from '@/modules/setup-wizard/interface-adapters/controllers/http/setupWizard.routes.js';
+import { GitRemoteCliGateway } from '@/modules/setup-wizard/interface-adapters/gateways/gitRemote.cli.gateway.js';
 import { SetupProcessChildProcessGateway } from '@/modules/setup-wizard/interface-adapters/gateways/setupProcess.childProcess.gateway.js';
 import { SetupStateFileSystemGateway } from '@/modules/setup-wizard/interface-adapters/gateways/setupState.fileSystem.gateway.js';
 import { SetupRunRegistry } from '@/modules/setup-wizard/usecases/streamSetupRun.usecase.js';
@@ -193,6 +194,7 @@ export async function registerRoutes(app: FastifyInstance, deps: Dependencies): 
   await app.register(statsRoutes, {
     statsGateway: deps.statsGateway,
     getRepositories: () => deps.config.repositories,
+    gitRemoteGateway: new GitRemoteCliGateway(),
     diffStatsFetchGateways: {
       gitlab: new GitLabDiffStatsFetchGateway(defaultGitLabExecutor),
       github: new GitHubDiffStatsFetchGateway(defaultGitHubExecutor),

--- a/src/modules/shared-kernel/entities/diffStats/diffStatsFetch.gateway.ts
+++ b/src/modules/shared-kernel/entities/diffStats/diffStatsFetch.gateway.ts
@@ -1,5 +1,5 @@
 import type { DiffStats } from '@/modules/shared-kernel/entities/diffStats/diffStats.js';
 
 export interface DiffStatsFetchGateway {
-  fetchDiffStats(projectPath: string, mergeRequestNumber: number): DiffStats | null;
+  fetchDiffStats(projectIdentifier: string, mergeRequestNumber: number): DiffStats | null;
 }

--- a/src/modules/statistics-insights/entities/projectIdentifier/projectIdentifier.ts
+++ b/src/modules/statistics-insights/entities/projectIdentifier/projectIdentifier.ts
@@ -1,0 +1,14 @@
+const SSH_REMOTE = /^[^@]+@[^:]+:(.+)$/;
+const HTTP_REMOTE = /^https?:\/\/[^/]+\/(.+)$/;
+
+export function resolveProjectIdentifier(remoteUrl: string): string | null {
+  const match = SSH_REMOTE.exec(remoteUrl) ?? HTTP_REMOTE.exec(remoteUrl);
+  if (!match) {
+    return null;
+  }
+
+  const path = match[1].replace(/\.git$/, '');
+  const segments = path.split('/').filter((segment) => segment.length > 0);
+
+  return segments.length >= 2 ? segments.join('/') : null;
+}

--- a/src/modules/statistics-insights/interface-adapters/controllers/http/stats.routes.ts
+++ b/src/modules/statistics-insights/interface-adapters/controllers/http/stats.routes.ts
@@ -1,7 +1,9 @@
 import type { FastifyPluginAsync } from 'fastify';
 
+import type { GitRemoteGateway } from '@/modules/setup-wizard/entities/gitRemote/gitRemote.gateway.js';
 import type { DiffStatsFetchGateway } from '@/modules/shared-kernel/entities/diffStats/diffStatsFetch.gateway.js';
 import type { BackfillProgress } from '@/modules/statistics-insights/entities/backfill/backfillProgress.js';
+import { resolveProjectIdentifier } from '@/modules/statistics-insights/entities/projectIdentifier/projectIdentifier.js';
 import { safeParseRecalculateBody } from '@/modules/statistics-insights/entities/stats/recalculateBody.guard.js';
 import type { StatsGateway } from '@/modules/statistics-insights/entities/stats/stats.gateway.js';
 import { AnalyticsHeaderPresenter } from '@/modules/statistics-insights/interface-adapters/presenters/analyticsHeader.presenter.js';
@@ -14,12 +16,12 @@ interface RepositoryInfo {
   localPath: string;
   name: string;
   enabled: boolean;
-  platform?: string;
 }
 
 interface StatsRoutesOptions {
   statsGateway: StatsGateway;
   getRepositories: () => RepositoryInfo[];
+  gitRemoteGateway?: GitRemoteGateway;
   diffStatsFetchGateways?: { gitlab: DiffStatsFetchGateway; github: DiffStatsFetchGateway };
   broadcastBackfillProgress?: (progress: BackfillProgress) => void;
   logger?: {
@@ -27,6 +29,29 @@ interface StatsRoutesOptions {
     info: (message: string, data?: unknown) => void;
     error: (message: string, data?: unknown) => void;
   };
+}
+
+interface ResolvedProject {
+  platform: string;
+  projectIdentifier: string;
+}
+
+function resolveBackfillTarget(
+  localPath: string,
+  gitRemoteGateway: GitRemoteGateway,
+): ResolvedProject | null {
+  const remote = gitRemoteGateway.getOriginRemote(localPath);
+  if (!remote) {
+    return null;
+  }
+
+  const platform = gitRemoteGateway.detectPlatform(remote);
+  const projectIdentifier = resolveProjectIdentifier(remote);
+  if (platform === 'unknown' || projectIdentifier === null) {
+    return null;
+  }
+
+  return { platform, projectIdentifier };
 }
 
 export const statsRoutes: FastifyPluginAsync<StatsRoutesOptions> = async (fastify, options) => {
@@ -96,14 +121,25 @@ export const statsRoutes: FastifyPluginAsync<StatsRoutesOptions> = async (fastif
       return;
     }
 
-    const { diffStatsFetchGateways, broadcastBackfillProgress, logger } = options;
+    const { diffStatsFetchGateways, gitRemoteGateway, broadcastBackfillProgress, logger } = options;
     const noopLogger = { warn: () => {}, error: () => {} };
+
+    const resolved =
+      shouldBackfill && gitRemoteGateway
+        ? resolveBackfillTarget(repository.localPath, gitRemoteGateway)
+        : null;
+
+    if (shouldBackfill && resolved === null) {
+      reply.status(422).send({ error: 'Plateforme du projet introuvable' });
+      return;
+    }
 
     recalculateWithBackfill(
       {
         projectPath,
         shouldBackfill,
-        platform: repository.platform ?? null,
+        platform: resolved?.platform ?? null,
+        projectIdentifier: resolved?.projectIdentifier ?? null,
       },
       {
         statsGateway,

--- a/src/modules/statistics-insights/usecases/stats/backfillDiffStats.usecase.ts
+++ b/src/modules/statistics-insights/usecases/stats/backfillDiffStats.usecase.ts
@@ -10,6 +10,7 @@ export interface BackfillDiffStatsDependencies {
 
 export interface BackfillDiffStatsInput {
   projectPath: string;
+  projectIdentifier: string;
   batchSize?: number;
   batchDelayMs?: number;
   onProgress?: (progress: BackfillProgress) => void;
@@ -20,7 +21,7 @@ export async function backfillDiffStats(
   dependencies: BackfillDiffStatsDependencies,
 ): Promise<BackfillProgress> {
   const { statsGateway, diffStatsFetchGateway, logger } = dependencies;
-  const { projectPath, batchSize = 10, batchDelayMs = 2000, onProgress } = input;
+  const { projectPath, projectIdentifier, batchSize = 10, batchDelayMs = 2000, onProgress } = input;
 
   const stats = statsGateway.loadProjectStats(projectPath);
 
@@ -49,7 +50,10 @@ export async function backfillDiffStats(
 
     for (const review of batch) {
       try {
-        const diffStats = await diffStatsFetchGateway.fetchDiffStats(projectPath, review.mrNumber);
+        const diffStats = await diffStatsFetchGateway.fetchDiffStats(
+          projectIdentifier,
+          review.mrNumber,
+        );
         review.diffStats = diffStats;
       } catch (error) {
         logger.warn('Failed to fetch diff stats for review', { mrNumber: review.mrNumber, error });

--- a/src/modules/statistics-insights/usecases/stats/recalculateProjectStats.usecase.ts
+++ b/src/modules/statistics-insights/usecases/stats/recalculateProjectStats.usecase.ts
@@ -27,6 +27,7 @@ export function recalculateProjectStats(
       totalDeletions: 0,
       averageAdditions: 0,
       averageDeletions: 0,
+      diffStatsReviewCount: 0,
     };
     return emptyStats;
   }
@@ -49,6 +50,7 @@ export function recalculateProjectStats(
   const reviewsWithDiffStats = reviews.filter(
     (review) => review.diffStats !== null && review.diffStats !== undefined,
   );
+  stats.diffStatsReviewCount = reviewsWithDiffStats.length;
 
   if (reviewsWithDiffStats.length > 0) {
     stats.totalAdditions = reviewsWithDiffStats.reduce(

--- a/src/modules/statistics-insights/usecases/stats/recalculateWithBackfill.usecase.ts
+++ b/src/modules/statistics-insights/usecases/stats/recalculateWithBackfill.usecase.ts
@@ -8,6 +8,7 @@ export interface RecalculateWithBackfillInput {
   projectPath: string;
   shouldBackfill: boolean;
   platform: string | null;
+  projectIdentifier: string | null;
 }
 
 export interface RecalculateWithBackfillDependencies {
@@ -24,17 +25,18 @@ export async function recalculateWithBackfill(
   input: RecalculateWithBackfillInput,
   dependencies: RecalculateWithBackfillDependencies,
 ): Promise<void> {
-  const { projectPath, shouldBackfill, platform } = input;
+  const { projectPath, shouldBackfill, platform, projectIdentifier } = input;
   const { statsGateway, diffStatsFetchGateways, onProgress, logger } = dependencies;
 
   try {
-    if (shouldBackfill && diffStatsFetchGateways && platform) {
+    if (shouldBackfill && diffStatsFetchGateways && platform && projectIdentifier) {
       const resolvedPlatform = platform === 'github' ? 'github' : 'gitlab';
       const gateway = diffStatsFetchGateways[resolvedPlatform];
 
       await backfillDiffStats(
         {
           projectPath,
+          projectIdentifier,
           onProgress: (progress) => {
             onProgress(progress);
           },

--- a/src/tests/acceptance/208-self-service-backfill-button.acceptance.test.ts
+++ b/src/tests/acceptance/208-self-service-backfill-button.acceptance.test.ts
@@ -1,0 +1,190 @@
+import Fastify from 'fastify';
+import { describe, it, expect, vi } from 'vitest';
+
+import type { Platform } from '@/modules/setup-wizard/entities/projectContext/projectContext.schema.js';
+import { statsRoutes } from '@/modules/statistics-insights/interface-adapters/controllers/http/stats.routes.js';
+import { ProjectStatsFactory, ReviewStatsFactory } from '@/tests/factories/projectStats.factory.js';
+import { StubDiffStatsFetchGateway } from '@/tests/stubs/diffStatsFetch.stub.js';
+import { InMemoryStatsGateway } from '@/tests/stubs/stats.stub.js';
+
+class StubGitRemoteGateway {
+  constructor(
+    private readonly remote: string | null,
+    private readonly platform: Platform,
+  ) {}
+
+  isRepo(): boolean {
+    return this.remote !== null;
+  }
+
+  getOriginRemote(): string | null {
+    return this.remote;
+  }
+
+  detectPlatform(): Platform {
+    return this.platform;
+  }
+}
+
+async function waitForBackfill(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+describe('Self-service backfill button (acceptance)', () => {
+  describe('triggering the backfill from the dashboard populates missing reviews', () => {
+    it('gitlab project: fetches against the project identifier and populates reviews', async () => {
+      const statsGateway = new InMemoryStatsGateway();
+      const diffStatsFetchGateway = new StubDiffStatsFetchGateway();
+      diffStatsFetchGateway.setResponse(10, { commitsCount: 3, additions: 100, deletions: 20 });
+
+      const reviews = [ReviewStatsFactory.create({ id: 'r1', mrNumber: 10, diffStats: null })];
+      statsGateway.saveProjectStats(
+        '/repos/main-app-v3/frontend',
+        ProjectStatsFactory.create({ reviews }),
+      );
+
+      const fastify = Fastify();
+      await fastify.register(statsRoutes, {
+        statsGateway,
+        getRepositories: () => [
+          { localPath: '/repos/main-app-v3/frontend', name: 'frontend', enabled: true },
+        ],
+        diffStatsFetchGateways: { gitlab: diffStatsFetchGateway, github: diffStatsFetchGateway },
+        gitRemoteGateway: new StubGitRemoteGateway('git@gitlab.com:group/proj.git', 'gitlab'),
+        broadcastBackfillProgress: vi.fn(),
+        logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+      });
+
+      const response = await fastify.inject({
+        method: 'POST',
+        url: '/api/stats/recalculate',
+        payload: { path: '/repos/main-app-v3/frontend', backfill: true },
+      });
+
+      expect(response.statusCode).toBe(200);
+      await waitForBackfill();
+
+      const saved = statsGateway.loadProjectStats('/repos/main-app-v3/frontend');
+      expect(saved?.reviews[0].diffStats).toEqual({
+        commitsCount: 3,
+        additions: 100,
+        deletions: 20,
+      });
+      expect(saved?.totalAdditions).toBe(100);
+      expect(saved?.totalDeletions).toBe(20);
+      expect(saved?.diffStatsReviewCount).toBe(1);
+    });
+
+    it('forwards the platform project identifier to the gateway, not the local path', async () => {
+      const statsGateway = new InMemoryStatsGateway();
+      const diffStatsFetchGateway = new StubDiffStatsFetchGateway();
+      diffStatsFetchGateway.setResponse(10, { commitsCount: 1, additions: 5, deletions: 1 });
+
+      const reviews = [ReviewStatsFactory.create({ id: 'r1', mrNumber: 10, diffStats: null })];
+      statsGateway.saveProjectStats(
+        '/repos/main-app-v3/frontend',
+        ProjectStatsFactory.create({ reviews }),
+      );
+
+      const fastify = Fastify();
+      await fastify.register(statsRoutes, {
+        statsGateway,
+        getRepositories: () => [
+          { localPath: '/repos/main-app-v3/frontend', name: 'frontend', enabled: true },
+        ],
+        diffStatsFetchGateways: { gitlab: diffStatsFetchGateway, github: diffStatsFetchGateway },
+        gitRemoteGateway: new StubGitRemoteGateway('git@gitlab.com:group/proj.git', 'gitlab'),
+        broadcastBackfillProgress: vi.fn(),
+        logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+      });
+
+      await fastify.inject({
+        method: 'POST',
+        url: '/api/stats/recalculate',
+        payload: { path: '/repos/main-app-v3/frontend', backfill: true },
+      });
+
+      await waitForBackfill();
+
+      expect(diffStatsFetchGateway.lastProjectIdentifier).toBe('group/proj');
+    });
+  });
+
+  describe('a project whose platform cannot be resolved is rejected with a clear message', () => {
+    it('remote missing: rejects with 422 and "Plateforme du projet introuvable"', async () => {
+      const statsGateway = new InMemoryStatsGateway();
+      const diffStatsFetchGateway = new StubDiffStatsFetchGateway();
+
+      const reviews = [ReviewStatsFactory.create({ id: 'r1', mrNumber: 10, diffStats: null })];
+      statsGateway.saveProjectStats('/repos/local-only', ProjectStatsFactory.create({ reviews }));
+
+      const fastify = Fastify();
+      await fastify.register(statsRoutes, {
+        statsGateway,
+        getRepositories: () => [
+          { localPath: '/repos/local-only', name: 'local-only', enabled: true },
+        ],
+        diffStatsFetchGateways: { gitlab: diffStatsFetchGateway, github: diffStatsFetchGateway },
+        gitRemoteGateway: new StubGitRemoteGateway(null, 'unknown'),
+        broadcastBackfillProgress: vi.fn(),
+        logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+      });
+
+      const response = await fastify.inject({
+        method: 'POST',
+        url: '/api/stats/recalculate',
+        payload: { path: '/repos/local-only', backfill: true },
+      });
+
+      expect(response.statusCode).toBe(422);
+      const body = JSON.parse(response.body);
+      expect(body.error).toBe('Plateforme du projet introuvable');
+    });
+  });
+
+  describe('reviews already populated are left untouched', () => {
+    it('nothing missing: fetches nothing and leaves totals unchanged', async () => {
+      const statsGateway = new InMemoryStatsGateway();
+      const diffStatsFetchGateway = new StubDiffStatsFetchGateway();
+
+      const reviews = [
+        ReviewStatsFactory.withDiffStats(
+          { commitsCount: 2, additions: 50, deletions: 10 },
+          { id: 'r1', mrNumber: 10 },
+        ),
+      ];
+      statsGateway.saveProjectStats(
+        '/repos/main-app-v3/frontend',
+        ProjectStatsFactory.withReviews(reviews),
+      );
+      const before = statsGateway.loadProjectStats('/repos/main-app-v3/frontend');
+      const totalAdditionsBefore = before?.totalAdditions;
+      const totalDeletionsBefore = before?.totalDeletions;
+
+      const fastify = Fastify();
+      await fastify.register(statsRoutes, {
+        statsGateway,
+        getRepositories: () => [
+          { localPath: '/repos/main-app-v3/frontend', name: 'frontend', enabled: true },
+        ],
+        diffStatsFetchGateways: { gitlab: diffStatsFetchGateway, github: diffStatsFetchGateway },
+        gitRemoteGateway: new StubGitRemoteGateway('git@gitlab.com:group/proj.git', 'gitlab'),
+        broadcastBackfillProgress: vi.fn(),
+        logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+      });
+
+      await fastify.inject({
+        method: 'POST',
+        url: '/api/stats/recalculate',
+        payload: { path: '/repos/main-app-v3/frontend', backfill: true },
+      });
+
+      await waitForBackfill();
+
+      expect(diffStatsFetchGateway.fetchCallCount).toBe(0);
+      const after = statsGateway.loadProjectStats('/repos/main-app-v3/frontend');
+      expect(after?.totalAdditions).toBe(totalAdditionsBefore);
+      expect(after?.totalDeletions).toBe(totalDeletionsBefore);
+    });
+  });
+});

--- a/src/tests/stubs/diffStatsFetch.stub.ts
+++ b/src/tests/stubs/diffStatsFetch.stub.ts
@@ -5,9 +5,11 @@ export class StubDiffStatsFetchGateway implements DiffStatsFetchGateway {
   private responses = new Map<number, DiffStats | null>();
   private failingMergeRequests = new Set<number>();
   fetchCallCount = 0;
+  lastProjectIdentifier: string | null = null;
 
-  fetchDiffStats(_projectPath: string, mergeRequestNumber: number): DiffStats | null {
+  fetchDiffStats(projectIdentifier: string, mergeRequestNumber: number): DiffStats | null {
     this.fetchCallCount++;
+    this.lastProjectIdentifier = projectIdentifier;
 
     if (this.failingMergeRequests.has(mergeRequestNumber)) {
       throw new Error(`API error for MR ${mergeRequestNumber}`);

--- a/src/tests/units/interface-adapters/controllers/http/statsRecalculate.routes.test.ts
+++ b/src/tests/units/interface-adapters/controllers/http/statsRecalculate.routes.test.ts
@@ -1,10 +1,30 @@
 import Fastify from 'fastify';
 import { describe, it, expect, vi } from 'vitest';
 
+import type { Platform } from '@/modules/setup-wizard/entities/projectContext/projectContext.schema.js';
 import { statsRoutes } from '@/modules/statistics-insights/interface-adapters/controllers/http/stats.routes.js';
 import { ProjectStatsFactory, ReviewStatsFactory } from '@/tests/factories/projectStats.factory.js';
 import { StubDiffStatsFetchGateway } from '@/tests/stubs/diffStatsFetch.stub.js';
 import { InMemoryStatsGateway } from '@/tests/stubs/stats.stub.js';
+
+class StubGitRemoteGateway {
+  constructor(
+    private readonly remote: string | null,
+    private readonly platform: Platform,
+  ) {}
+
+  isRepo(): boolean {
+    return this.remote !== null;
+  }
+
+  getOriginRemote(): string | null {
+    return this.remote;
+  }
+
+  detectPlatform(): Platform {
+    return this.platform;
+  }
+}
 
 function createTestOptions(overrides: Record<string, unknown> = {}) {
   const statsGateway = new InMemoryStatsGateway();
@@ -12,10 +32,9 @@ function createTestOptions(overrides: Record<string, unknown> = {}) {
 
   return {
     statsGateway,
-    getRepositories: () => [
-      { localPath: '/test/project', name: 'test', enabled: true, platform: 'gitlab' },
-    ],
+    getRepositories: () => [{ localPath: '/test/project', name: 'test', enabled: true }],
     diffStatsFetchGateways: { gitlab: diffStatsFetchGateway, github: diffStatsFetchGateway },
+    gitRemoteGateway: new StubGitRemoteGateway('git@gitlab.com:group/proj.git', 'gitlab'),
     broadcastBackfillProgress: vi.fn(),
     logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
     ...overrides,
@@ -44,9 +63,7 @@ describe('POST /api/stats/recalculate', () => {
 
   it('should return 404 when path is not found in repositories', async () => {
     const options = createTestOptions({
-      getRepositories: () => [
-        { localPath: '/other/project', name: 'other', enabled: true, platform: 'gitlab' },
-      ],
+      getRepositories: () => [{ localPath: '/other/project', name: 'other', enabled: true }],
     });
 
     const fastify = Fastify();
@@ -105,5 +122,110 @@ describe('POST /api/stats/recalculate', () => {
 
     const saved = options.statsGateway.loadProjectStats('/test/project');
     expect(saved?.averageScore).toBe(7);
+  });
+
+  it('resolves the platform from the git remote, not from the config', async () => {
+    const diffStatsFetchGateway = new StubDiffStatsFetchGateway();
+    diffStatsFetchGateway.setResponse(10, { commitsCount: 3, additions: 100, deletions: 20 });
+    const options = createTestOptions({
+      diffStatsFetchGateways: { gitlab: diffStatsFetchGateway, github: diffStatsFetchGateway },
+      gitRemoteGateway: new StubGitRemoteGateway('git@gitlab.com:group/proj.git', 'gitlab'),
+    });
+    const reviews = [ReviewStatsFactory.create({ id: 'r1', mrNumber: 10, diffStats: null })];
+    options.statsGateway.saveProjectStats('/test/project', ProjectStatsFactory.create({ reviews }));
+
+    const fastify = Fastify();
+    await fastify.register(statsRoutes, options);
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/api/stats/recalculate',
+      payload: { path: '/test/project', backfill: true },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(diffStatsFetchGateway.lastProjectIdentifier).toBe('group/proj');
+  });
+
+  it('rejects with 422 when the git remote is missing', async () => {
+    const options = createTestOptions({
+      gitRemoteGateway: new StubGitRemoteGateway(null, 'unknown'),
+    });
+
+    const fastify = Fastify();
+    await fastify.register(statsRoutes, options);
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/api/stats/recalculate',
+      payload: { path: '/test/project', backfill: true },
+    });
+
+    expect(response.statusCode).toBe(422);
+    const body = JSON.parse(response.body);
+    expect(body.error).toBe('Plateforme du projet introuvable');
+  });
+
+  it('rejects with 422 when the platform is unknown', async () => {
+    const options = createTestOptions({
+      gitRemoteGateway: new StubGitRemoteGateway('git@example.com:group/proj.git', 'unknown'),
+    });
+
+    const fastify = Fastify();
+    await fastify.register(statsRoutes, options);
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/api/stats/recalculate',
+      payload: { path: '/test/project', backfill: true },
+    });
+
+    expect(response.statusCode).toBe(422);
+    const body = JSON.parse(response.body);
+    expect(body.error).toBe('Plateforme du projet introuvable');
+  });
+
+  it('rejects with 422 when the project identifier cannot be parsed', async () => {
+    const options = createTestOptions({
+      gitRemoteGateway: new StubGitRemoteGateway('not-a-url', 'gitlab'),
+    });
+
+    const fastify = Fastify();
+    await fastify.register(statsRoutes, options);
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/api/stats/recalculate',
+      payload: { path: '/test/project', backfill: true },
+    });
+
+    expect(response.statusCode).toBe(422);
+    const body = JSON.parse(response.body);
+    expect(body.error).toBe('Plateforme du projet introuvable');
+  });
+
+  it('does not resolve the remote on the recompute-only path', async () => {
+    const options = createTestOptions({
+      gitRemoteGateway: new StubGitRemoteGateway(null, 'unknown'),
+    });
+    const reviews = [ReviewStatsFactory.create({ id: 'r1', mrNumber: 1, score: 7 })];
+    options.statsGateway.saveProjectStats(
+      '/test/project',
+      ProjectStatsFactory.create({ reviews, averageScore: 0 }),
+    );
+
+    const fastify = Fastify();
+    await fastify.register(statsRoutes, options);
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/api/stats/recalculate',
+      payload: { path: '/test/project', backfill: false },
+    });
+
+    expect(response.statusCode).toBe(200);
   });
 });

--- a/src/tests/units/modules/statistics-insights/entities/projectIdentifier/projectIdentifier.test.ts
+++ b/src/tests/units/modules/statistics-insights/entities/projectIdentifier/projectIdentifier.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+
+import { resolveProjectIdentifier } from '@/modules/statistics-insights/entities/projectIdentifier/projectIdentifier.js';
+
+describe('resolveProjectIdentifier', () => {
+  it('resolves an SSH GitLab remote to its namespace', () => {
+    expect(resolveProjectIdentifier('git@gitlab.com:group/proj.git')).toBe('group/proj');
+  });
+
+  it('resolves an HTTPS GitLab remote to its namespace', () => {
+    expect(resolveProjectIdentifier('https://gitlab.com/group/proj.git')).toBe('group/proj');
+  });
+
+  it('preserves nested GitLab groups', () => {
+    expect(resolveProjectIdentifier('git@gitlab.com:group/sub/proj.git')).toBe('group/sub/proj');
+  });
+
+  it('resolves an SSH GitHub remote to owner/repo', () => {
+    expect(resolveProjectIdentifier('git@github.com:owner/repo.git')).toBe('owner/repo');
+  });
+
+  it('resolves an HTTPS GitHub remote without a .git suffix', () => {
+    expect(resolveProjectIdentifier('https://github.com/owner/repo')).toBe('owner/repo');
+  });
+
+  it('strips a self-hosted host', () => {
+    expect(resolveProjectIdentifier('git@gitlab.example.com:org/proj.git')).toBe('org/proj');
+  });
+
+  it('returns null for an unparseable string', () => {
+    expect(resolveProjectIdentifier('not-a-url')).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(resolveProjectIdentifier('')).toBeNull();
+  });
+});

--- a/src/tests/units/usecases/stats/backfillDiffStats.usecase.test.ts
+++ b/src/tests/units/usecases/stats/backfillDiffStats.usecase.test.ts
@@ -15,6 +15,32 @@ describe('backfillDiffStats', () => {
     vi.useRealTimers();
   });
 
+  it('should forward the projectIdentifier to the gateway, not the projectPath', async () => {
+    const statsGateway = new InMemoryStatsGateway();
+    const diffStatsFetchGateway = new StubDiffStatsFetchGateway();
+
+    const reviews = [ReviewStatsFactory.create({ id: 'r1', mrNumber: 10 })];
+    const projectStats = ProjectStatsFactory.create({ reviews });
+    statsGateway.saveProjectStats('/test/project', projectStats);
+
+    diffStatsFetchGateway.setResponse(10, { commitsCount: 3, additions: 100, deletions: 20 });
+
+    const promise = backfillDiffStats(
+      {
+        projectPath: '/test/project',
+        projectIdentifier: 'group/proj',
+        batchSize: 10,
+        batchDelayMs: 0,
+      },
+      { statsGateway, diffStatsFetchGateway, logger: { warn: vi.fn() } },
+    );
+
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(diffStatsFetchGateway.lastProjectIdentifier).toBe('group/proj');
+  });
+
   it('should fetch diff stats for reviews with undefined diffStats', async () => {
     const statsGateway = new InMemoryStatsGateway();
     const diffStatsFetchGateway = new StubDiffStatsFetchGateway();
@@ -26,7 +52,12 @@ describe('backfillDiffStats', () => {
     diffStatsFetchGateway.setResponse(10, { commitsCount: 3, additions: 100, deletions: 20 });
 
     const promise = backfillDiffStats(
-      { projectPath: '/test/project', batchSize: 10, batchDelayMs: 0 },
+      {
+        projectPath: '/test/project',
+        projectIdentifier: 'group/proj',
+        batchSize: 10,
+        batchDelayMs: 0,
+      },
       { statsGateway, diffStatsFetchGateway, logger: { warn: vi.fn() } },
     );
 
@@ -55,7 +86,12 @@ describe('backfillDiffStats', () => {
     statsGateway.saveProjectStats('/test/project', projectStats);
 
     const promise = backfillDiffStats(
-      { projectPath: '/test/project', batchSize: 10, batchDelayMs: 0 },
+      {
+        projectPath: '/test/project',
+        projectIdentifier: 'group/proj',
+        batchSize: 10,
+        batchDelayMs: 0,
+      },
       { statsGateway, diffStatsFetchGateway, logger: { warn: vi.fn() } },
     );
 
@@ -79,7 +115,12 @@ describe('backfillDiffStats', () => {
     diffStatsFetchGateway.setResponse(10, { commitsCount: 3, additions: 100, deletions: 20 });
 
     const promise = backfillDiffStats(
-      { projectPath: '/test/project', batchSize: 10, batchDelayMs: 0 },
+      {
+        projectPath: '/test/project',
+        projectIdentifier: 'group/proj',
+        batchSize: 10,
+        batchDelayMs: 0,
+      },
       { statsGateway, diffStatsFetchGateway, logger: { warn: vi.fn() } },
     );
 
@@ -114,6 +155,7 @@ describe('backfillDiffStats', () => {
     const promise = backfillDiffStats(
       {
         projectPath: '/test/project',
+        projectIdentifier: 'group/proj',
         batchSize: 10,
         batchDelayMs: 0,
         onProgress: (progress) => progressUpdates.push({ ...progress }),
@@ -141,7 +183,12 @@ describe('backfillDiffStats', () => {
     diffStatsFetchGateway.setFailure(10);
 
     const promise = backfillDiffStats(
-      { projectPath: '/test/project', batchSize: 10, batchDelayMs: 0 },
+      {
+        projectPath: '/test/project',
+        projectIdentifier: 'group/proj',
+        batchSize: 10,
+        batchDelayMs: 0,
+      },
       { statsGateway, diffStatsFetchGateway, logger },
     );
 
@@ -174,7 +221,12 @@ describe('backfillDiffStats', () => {
     diffStatsFetchGateway.setResponse(12, { commitsCount: 2, additions: 20, deletions: 10 });
 
     const promise = backfillDiffStats(
-      { projectPath: '/test/project', batchSize: 10, batchDelayMs: 0 },
+      {
+        projectPath: '/test/project',
+        projectIdentifier: 'group/proj',
+        batchSize: 10,
+        batchDelayMs: 0,
+      },
       { statsGateway, diffStatsFetchGateway, logger: { warn: vi.fn() } },
     );
 
@@ -198,7 +250,12 @@ describe('backfillDiffStats', () => {
     diffStatsFetchGateway.setResponse(10, { commitsCount: 3, additions: 100, deletions: 20 });
 
     const promise = backfillDiffStats(
-      { projectPath: '/test/project', batchSize: 10, batchDelayMs: 0 },
+      {
+        projectPath: '/test/project',
+        projectIdentifier: 'group/proj',
+        batchSize: 10,
+        batchDelayMs: 0,
+      },
       { statsGateway, diffStatsFetchGateway, logger: { warn: vi.fn() } },
     );
 
@@ -228,7 +285,12 @@ describe('backfillDiffStats', () => {
     statsGateway.saveProjectStats('/test/project', projectStats);
 
     const result = await backfillDiffStats(
-      { projectPath: '/test/project', batchSize: 10, batchDelayMs: 0 },
+      {
+        projectPath: '/test/project',
+        projectIdentifier: 'group/proj',
+        batchSize: 10,
+        batchDelayMs: 0,
+      },
       { statsGateway, diffStatsFetchGateway, logger: { warn: vi.fn() } },
     );
 
@@ -258,6 +320,7 @@ describe('backfillDiffStats', () => {
     const promise = backfillDiffStats(
       {
         projectPath: '/test/project',
+        projectIdentifier: 'group/proj',
         batchSize: 2,
         batchDelayMs: 1000,
         onProgress: (progress) => progressUpdates.push({ ...progress }),

--- a/src/tests/units/usecases/stats/recalculateProjectStats.usecase.test.ts
+++ b/src/tests/units/usecases/stats/recalculateProjectStats.usecase.test.ts
@@ -67,6 +67,7 @@ describe('recalculateProjectStats', () => {
     expect(result.totalDeletions).toBe(30);
     expect(result.averageAdditions).toBe(75);
     expect(result.averageDeletions).toBe(15);
+    expect(result.diffStatsReviewCount).toBe(2);
   });
 
   it('should exclude null diffStats from averages', () => {
@@ -93,6 +94,7 @@ describe('recalculateProjectStats', () => {
     expect(result.totalDeletions).toBe(30);
     expect(result.averageAdditions).toBe(75);
     expect(result.averageDeletions).toBe(15);
+    expect(result.diffStatsReviewCount).toBe(2);
   });
 
   it('should handle empty reviews array', () => {
@@ -114,6 +116,7 @@ describe('recalculateProjectStats', () => {
     expect(result.totalDeletions).toBe(0);
     expect(result.averageAdditions).toBe(0);
     expect(result.averageDeletions).toBe(0);
+    expect(result.diffStatsReviewCount).toBe(0);
   });
 
   it('should recalculate totalDuration and averageDuration', () => {

--- a/src/tests/units/usecases/stats/recalculateWithBackfill.usecase.test.ts
+++ b/src/tests/units/usecases/stats/recalculateWithBackfill.usecase.test.ts
@@ -32,7 +32,12 @@ describe('recalculateWithBackfill', () => {
     const progressUpdates: BackfillProgress[] = [];
 
     const promise = recalculateWithBackfill(
-      { projectPath: '/test/project', shouldBackfill: false, platform: 'gitlab' },
+      {
+        projectPath: '/test/project',
+        shouldBackfill: false,
+        platform: 'gitlab',
+        projectIdentifier: 'group/proj',
+      },
       {
         statsGateway,
         diffStatsFetchGateways: null,
@@ -59,7 +64,12 @@ describe('recalculateWithBackfill', () => {
     const progressUpdates: BackfillProgress[] = [];
 
     const promise = recalculateWithBackfill(
-      { projectPath: '/test/project', shouldBackfill: true, platform: 'gitlab' },
+      {
+        projectPath: '/test/project',
+        shouldBackfill: true,
+        platform: 'gitlab',
+        projectIdentifier: 'group/proj',
+      },
       {
         statsGateway,
         diffStatsFetchGateways: { gitlab: diffStatsFetchGateway, github: diffStatsFetchGateway },
@@ -73,6 +83,7 @@ describe('recalculateWithBackfill', () => {
 
     const saved = statsGateway.loadProjectStats('/test/project');
     expect(saved?.reviews[0].diffStats).toEqual({ commitsCount: 3, additions: 100, deletions: 20 });
+    expect(diffStatsFetchGateway.lastProjectIdentifier).toBe('group/proj');
     expect(progressUpdates.at(-1)?.status).toBe('completed');
   });
 
@@ -85,7 +96,12 @@ describe('recalculateWithBackfill', () => {
     const progressUpdates: BackfillProgress[] = [];
 
     const promise = recalculateWithBackfill(
-      { projectPath: '/test/project', shouldBackfill: true, platform: null },
+      {
+        projectPath: '/test/project',
+        shouldBackfill: true,
+        platform: null,
+        projectIdentifier: null,
+      },
       {
         statsGateway,
         diffStatsFetchGateways: { gitlab: diffStatsFetchGateway, github: diffStatsFetchGateway },
@@ -110,7 +126,12 @@ describe('recalculateWithBackfill', () => {
     githubGateway.setResponse(10, { commitsCount: 5, additions: 200, deletions: 50 });
 
     const promise = recalculateWithBackfill(
-      { projectPath: '/test/project', shouldBackfill: true, platform: 'github' },
+      {
+        projectPath: '/test/project',
+        shouldBackfill: true,
+        platform: 'github',
+        projectIdentifier: 'owner/repo',
+      },
       {
         statsGateway,
         diffStatsFetchGateways: { gitlab: gitlabGateway, github: githubGateway },
@@ -123,6 +144,7 @@ describe('recalculateWithBackfill', () => {
     await promise;
 
     expect(githubGateway.fetchCallCount).toBe(1);
+    expect(githubGateway.lastProjectIdentifier).toBe('owner/repo');
     expect(gitlabGateway.fetchCallCount).toBe(0);
   });
 
@@ -137,7 +159,12 @@ describe('recalculateWithBackfill', () => {
     statsGateway.saveProjectStats('/test/project', ProjectStatsFactory.create({ reviews }));
 
     const promise = recalculateWithBackfill(
-      { projectPath: '/test/project', shouldBackfill: true, platform: 'gitlab' },
+      {
+        projectPath: '/test/project',
+        shouldBackfill: true,
+        platform: 'gitlab',
+        projectIdentifier: 'group/proj',
+      },
       {
         statsGateway,
         diffStatsFetchGateways: { gitlab: diffStatsFetchGateway, github: diffStatsFetchGateway },
@@ -158,7 +185,12 @@ describe('recalculateWithBackfill', () => {
     const progressUpdates: BackfillProgress[] = [];
 
     const promise = recalculateWithBackfill(
-      { projectPath: '/test/project', shouldBackfill: false, platform: null },
+      {
+        projectPath: '/test/project',
+        shouldBackfill: false,
+        platform: null,
+        projectIdentifier: null,
+      },
       {
         statsGateway,
         diffStatsFetchGateways: null,


### PR DESCRIPTION
## Summary
- Resolve each project's platform + project identifier from its git remote (no manual config) — the `Recalculate` button is now self-service
- Feed the platform identifier (`group/proj` / `owner/repo`) to the diff-stats gateway instead of the local filesystem path
- Recompute `diffStatsReviewCount` alongside totals/averages
- Reject unresolvable projects with `422 Plateforme du projet introuvable`

Implements spec-208. Reuses `GitRemoteCliGateway` (setup-wizard); only new file is a pure `resolveProjectIdentifier` parser. `DiffStatsFetchGateway` contract unchanged.

## Test plan
- [x] yarn verify passes (466 files, 3878 tests)
- [x] Acceptance tests green (`208-self-service-backfill-button.acceptance.test.ts`, 4 cases → 5 Rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)