### PR TITLE
fix(stats): MR detail diff stats + per-developer diff aggregation

### DIFF
--- a/src/main/routes.ts
+++ b/src/main/routes.ts
@@ -249,6 +249,7 @@ export async function registerRoutes(app: FastifyInstance, deps: Dependencies): 
     reviewRequestTrackingGateway: deps.reviewRequestTrackingGateway,
     getQualityThreshold: (projectPath: string) =>
       loadProjectConfig(projectPath)?.qualityThreshold ?? null,
+    statsGateway: deps.statsGateway,
   });
 
   const tokenUsageGateway = new FilesystemTokenUsageGateway();

--- a/src/modules/statistics-insights/usecases/insights/computeInsightsWithPersistence.usecase.ts
+++ b/src/modules/statistics-insights/usecases/insights/computeInsightsWithPersistence.usecase.ts
@@ -1,3 +1,4 @@
+import type { DiffStats } from '@/modules/shared-kernel/entities/diffStats/diffStats.js';
 import type {
   DeveloperInsight,
   CategoryLevels,
@@ -45,6 +46,7 @@ export function computeInsightsWithPersistence(
   const newReviews = reviews.filter((review) => !processedIds.has(review.id));
 
   const updatedDevelopers = updateDeveloperMetrics(currentPersistedData.developers, newReviews);
+  reconcileDiffStatsFromWindow(updatedDevelopers, reviews);
 
   const allProcessedIds = [
     ...currentPersistedData.processedReviewIds,
@@ -122,12 +124,6 @@ function updateExistingDeveloper(developer: PersistedDeveloperMetrics, review: R
     developer.scoredReviewCount += 1;
   }
 
-  if (review.diffStats !== null && review.diffStats !== undefined) {
-    developer.totalAdditions += review.diffStats.additions;
-    developer.totalDeletions += review.diffStats.deletions;
-    developer.diffStatsReviewCount += 1;
-  }
-
   developer.recentReviews.push(review);
   if (developer.recentReviews.length > RECENT_REVIEWS_WINDOW) {
     developer.recentReviews = developer.recentReviews.slice(-RECENT_REVIEWS_WINDOW);
@@ -144,11 +140,56 @@ function createDeveloperFromReview(review: ReviewStats): PersistedDeveloperMetri
     totalWarnings: review.warnings,
     totalSuggestions: review.suggestions ?? 0,
     totalDuration: review.duration,
-    totalAdditions: review.diffStats?.additions ?? 0,
-    totalDeletions: review.diffStats?.deletions ?? 0,
-    diffStatsReviewCount: review.diffStats !== null && review.diffStats !== undefined ? 1 : 0,
+    totalAdditions: 0,
+    totalDeletions: 0,
+    diffStatsReviewCount: 0,
     recentReviews: [review],
   };
+}
+
+/**
+ * Diff stats are only retained for the rolling window of recent reviews kept in
+ * project stats. Recompute each developer's diff-stat aggregates from that window
+ * so backfilled diff stats on already-processed reviews are picked up, and refresh
+ * the per-developer recentReviews so volume/score correlation can be computed.
+ * Developers with no review in the window keep their previously persisted values.
+ */
+function reconcileDiffStatsFromWindow(
+  developers: PersistedDeveloperMetrics[],
+  windowReviews: ReviewStats[],
+): void {
+  if (windowReviews.length === 0) return;
+
+  const windowReviewsByDeveloper = new Map<string, ReviewStats[]>();
+  const diffStatsByReviewId = new Map<string, DiffStats>();
+  for (const review of windowReviews) {
+    if (review.diffStats) {
+      diffStatsByReviewId.set(review.id, review.diffStats);
+    }
+    if (!review.assignedBy) continue;
+    const reviewsForDeveloper = windowReviewsByDeveloper.get(review.assignedBy) ?? [];
+    reviewsForDeveloper.push(review);
+    windowReviewsByDeveloper.set(review.assignedBy, reviewsForDeveloper);
+  }
+
+  for (const developer of developers) {
+    const reviewsForDeveloper = windowReviewsByDeveloper.get(developer.developerName);
+    if (reviewsForDeveloper) {
+      developer.totalAdditions = 0;
+      developer.totalDeletions = 0;
+      developer.diffStatsReviewCount = 0;
+      for (const review of reviewsForDeveloper) {
+        if (!review.diffStats) continue;
+        developer.totalAdditions += review.diffStats.additions;
+        developer.totalDeletions += review.diffStats.deletions;
+        developer.diffStatsReviewCount += 1;
+      }
+    }
+    developer.recentReviews = developer.recentReviews.map((review) => {
+      const diffStats = diffStatsByReviewId.get(review.id);
+      return diffStats ? { ...review, diffStats } : review;
+    });
+  }
 }
 
 function computeInsightsFromPersistedMetrics(

--- a/src/modules/tracking/interface-adapters/controllers/http/mrTracking.routes.ts
+++ b/src/modules/tracking/interface-adapters/controllers/http/mrTracking.routes.ts
@@ -1,13 +1,16 @@
 import type { FastifyPluginAsync } from 'fastify';
 
 import { logInfo, logError } from '@/frameworks/logging/logBuffer.js';
+import type { StatsGateway } from '@/modules/statistics-insights/entities/stats/stats.gateway.js';
 import { evaluateQualityGate } from '@/modules/tracking/entities/qualityGate/qualityGate.js';
 import type { ReviewRequestTrackingGateway } from '@/modules/tracking/entities/tracking/reviewRequestTracking.gateway.js';
+import { MrDiffStatsPresenter } from '@/modules/tracking/interface-adapters/presenters/mrDiffStats.presenter.js';
 import { TransitionStateUseCase } from '@/modules/tracking/usecases/tracking/transitionState.usecase.js';
 
 interface MrTrackingRoutesOptions {
   reviewRequestTrackingGateway: ReviewRequestTrackingGateway;
   getQualityThreshold?: (projectPath: string) => number | null;
+  statsGateway?: StatsGateway;
 }
 
 function validateProjectPath(
@@ -29,7 +32,8 @@ export const mrTrackingRoutes: FastifyPluginAsync<MrTrackingRoutesOptions> = asy
   fastify,
   opts,
 ) => {
-  const { reviewRequestTrackingGateway, getQualityThreshold } = opts;
+  const { reviewRequestTrackingGateway, getQualityThreshold, statsGateway } = opts;
+  const mrDiffStatsPresenter = new MrDiffStatsPresenter();
 
   fastify.get<{ Querystring: { path?: string } }>('/api/mr-tracking', async (request, reply) => {
     const validation = validateProjectPath(request.query.path);
@@ -45,10 +49,11 @@ export const mrTrackingRoutes: FastifyPluginAsync<MrTrackingRoutesOptions> = asy
         validation.path,
         'pending-approval',
       );
+      const stats = statsGateway?.loadProjectStats(validation.path) ?? null;
       return {
         success: true,
-        pendingFix,
-        pendingApproval,
+        pendingFix: mrDiffStatsPresenter.present(pendingFix, stats),
+        pendingApproval: mrDiffStatsPresenter.present(pendingApproval, stats),
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/src/modules/tracking/interface-adapters/presenters/mrDiffStats.presenter.ts
+++ b/src/modules/tracking/interface-adapters/presenters/mrDiffStats.presenter.ts
@@ -1,0 +1,35 @@
+import type { DiffStats } from '@/modules/shared-kernel/entities/diffStats/diffStats.js';
+import type { ProjectStats } from '@/modules/statistics-insights/entities/stats/projectStats.js';
+import type { TrackedMr } from '@/modules/tracking/entities/tracking/trackedMr.js';
+
+/**
+ * Diff stats live in project stats (keyed by MR number), not on tracking review
+ * events. Enrich each tracked MR's latest review event with the most recent diff
+ * stats recorded for that MR number so the dashboard MR detail can show
+ * commits/additions/deletions. MRs older than the retained stats window keep null.
+ */
+export class MrDiffStatsPresenter {
+  present(mrs: TrackedMr[], stats: ProjectStats | null): TrackedMr[] {
+    if (!stats) return mrs;
+
+    const latestDiffStatsByMrNumber = new Map<number, DiffStats>();
+    for (const review of stats.reviews) {
+      if (review.diffStats) {
+        latestDiffStatsByMrNumber.set(review.mrNumber, review.diffStats);
+      }
+    }
+
+    return mrs.map((mr) => this.enrichMr(mr, latestDiffStatsByMrNumber));
+  }
+
+  private enrichMr(mr: TrackedMr, diffStatsByMrNumber: Map<number, DiffStats>): TrackedMr {
+    const diffStats = diffStatsByMrNumber.get(mr.mrNumber);
+    if (!diffStats || mr.reviews.length === 0) return mr;
+
+    const lastIndex = mr.reviews.length - 1;
+    const reviews = mr.reviews.map((review, index) =>
+      index === lastIndex ? { ...review, diffStats } : review,
+    );
+    return { ...mr, reviews };
+  }
+}

--- a/src/tests/units/modules/tracking/interface-adapters/controllers/http/mrTracking.routes.test.ts
+++ b/src/tests/units/modules/tracking/interface-adapters/controllers/http/mrTracking.routes.test.ts
@@ -1,13 +1,17 @@
 import Fastify, { type FastifyInstance } from 'fastify';
 import { describe, it, expect, beforeEach } from 'vitest';
 
+import type { ReviewEvent } from '@/modules/tracking/entities/tracking/reviewEvent.js';
 import { mrTrackingRoutes } from '@/modules/tracking/interface-adapters/controllers/http/mrTracking.routes.js';
+import { ProjectStatsFactory, ReviewStatsFactory } from '@/tests/factories/projectStats.factory.js';
 import { TrackedMrFactory } from '@/tests/factories/trackedMr.factory.js';
 import { InMemoryReviewRequestTrackingGateway } from '@/tests/stubs/reviewRequestTracking.stub.js';
+import { InMemoryStatsGateway } from '@/tests/stubs/stats.stub.js';
 
 interface BuildAppOptions {
   gateway: InMemoryReviewRequestTrackingGateway;
   qualityThreshold: number | null;
+  statsGateway?: InMemoryStatsGateway;
 }
 
 async function buildApp(options: BuildAppOptions): Promise<FastifyInstance> {
@@ -15,8 +19,25 @@ async function buildApp(options: BuildAppOptions): Promise<FastifyInstance> {
   await app.register(mrTrackingRoutes, {
     reviewRequestTrackingGateway: options.gateway,
     getQualityThreshold: () => options.qualityThreshold,
+    statsGateway: options.statsGateway,
   });
   return app;
+}
+
+function reviewEvent(overrides: Partial<ReviewEvent> = {}): ReviewEvent {
+  return {
+    type: 'review',
+    timestamp: '2024-01-15T10:00:00Z',
+    durationMs: 60000,
+    score: 8,
+    blocking: 0,
+    warnings: 0,
+    suggestions: 0,
+    threadsClosed: 0,
+    threadsOpened: 0,
+    diffStats: null,
+    ...overrides,
+  };
 }
 
 describe('mrTrackingRoutes — POST /api/mr-tracking/approve quality gate', () => {
@@ -188,5 +209,73 @@ describe('mrTrackingRoutes — POST /api/mr-tracking/mark-as-merged', () => {
     expect(body.success).toBe(false);
     expect(body.error).toBe('Seules les MR en correction peuvent être marquées comme mergées');
     expect(gateway.getById(projectPath, 'mr-1')?.state).toBe('approved');
+  });
+});
+
+describe('mrTrackingRoutes — GET /api/mr-tracking diff stats enrichment', () => {
+  const projectPath = '/repo/project';
+
+  it('enriches pending MRs with diff stats from project stats by MR number', async () => {
+    const gateway = new InMemoryReviewRequestTrackingGateway();
+    gateway.create(
+      projectPath,
+      TrackedMrFactory.create({
+        id: 'mr-1',
+        mrNumber: 5438,
+        state: 'pending-fix',
+        reviews: [reviewEvent()],
+      }),
+    );
+    const statsGateway = new InMemoryStatsGateway();
+    statsGateway.saveProjectStats(
+      projectPath,
+      ProjectStatsFactory.withReviews([
+        ReviewStatsFactory.create({
+          mrNumber: 5438,
+          diffStats: { commitsCount: 3, additions: 120, deletions: 40 },
+        }),
+      ]),
+    );
+    const app = await buildApp({ gateway, qualityThreshold: null, statsGateway });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/mr-tracking?path=${encodeURIComponent(projectPath)}`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as {
+      pendingFix: Array<{ reviews: ReviewEvent[] }>;
+    };
+    expect(body.pendingFix[0].reviews.at(-1)?.diffStats).toEqual({
+      commitsCount: 3,
+      additions: 120,
+      deletions: 40,
+    });
+  });
+
+  it('returns MRs without diff stats when no stats gateway is wired', async () => {
+    const gateway = new InMemoryReviewRequestTrackingGateway();
+    gateway.create(
+      projectPath,
+      TrackedMrFactory.create({
+        id: 'mr-1',
+        mrNumber: 5438,
+        state: 'pending-fix',
+        reviews: [reviewEvent()],
+      }),
+    );
+    const app = await buildApp({ gateway, qualityThreshold: null });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/mr-tracking?path=${encodeURIComponent(projectPath)}`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as {
+      pendingFix: Array<{ reviews: ReviewEvent[] }>;
+    };
+    expect(body.pendingFix[0].reviews.at(-1)?.diffStats).toBeNull();
   });
 });

--- a/src/tests/units/modules/tracking/interface-adapters/presenters/mrDiffStats.presenter.test.ts
+++ b/src/tests/units/modules/tracking/interface-adapters/presenters/mrDiffStats.presenter.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+
+import type { ReviewEvent } from '@/modules/tracking/entities/tracking/reviewEvent.js';
+import { MrDiffStatsPresenter } from '@/modules/tracking/interface-adapters/presenters/mrDiffStats.presenter.js';
+import { ProjectStatsFactory, ReviewStatsFactory } from '@/tests/factories/projectStats.factory.js';
+import { TrackedMrFactory } from '@/tests/factories/trackedMr.factory.js';
+
+function reviewEvent(overrides: Partial<ReviewEvent> = {}): ReviewEvent {
+  return {
+    type: 'review',
+    timestamp: '2024-01-15T10:00:00Z',
+    durationMs: 60000,
+    score: 8,
+    blocking: 0,
+    warnings: 0,
+    suggestions: 0,
+    threadsClosed: 0,
+    threadsOpened: 0,
+    diffStats: null,
+    ...overrides,
+  };
+}
+
+describe('attachDiffStatsToMrs', () => {
+  it('attaches the matching MR diff stats from project stats onto the latest review event', () => {
+    const mrs = [TrackedMrFactory.create({ id: 'mr-1', mrNumber: 5438, reviews: [reviewEvent()] })];
+    const stats = ProjectStatsFactory.withReviews([
+      ReviewStatsFactory.create({
+        mrNumber: 5438,
+        diffStats: { commitsCount: 3, additions: 120, deletions: 40 },
+      }),
+    ]);
+
+    const [enriched] = new MrDiffStatsPresenter().present(mrs, stats);
+
+    expect(enriched.reviews.at(-1)?.diffStats).toEqual({
+      commitsCount: 3,
+      additions: 120,
+      deletions: 40,
+    });
+  });
+
+  it('uses the most recent diff stats when an MR has several review entries', () => {
+    const mrs = [TrackedMrFactory.create({ mrNumber: 7, reviews: [reviewEvent()] })];
+    const stats = ProjectStatsFactory.withReviews([
+      ReviewStatsFactory.create({
+        id: 'older',
+        mrNumber: 7,
+        diffStats: { commitsCount: 1, additions: 10, deletions: 5 },
+      }),
+      ReviewStatsFactory.create({
+        id: 'newer',
+        mrNumber: 7,
+        diffStats: { commitsCount: 2, additions: 99, deletions: 8 },
+      }),
+    ]);
+
+    const [enriched] = new MrDiffStatsPresenter().present(mrs, stats);
+
+    expect(enriched.reviews.at(-1)?.diffStats).toEqual({
+      commitsCount: 2,
+      additions: 99,
+      deletions: 8,
+    });
+  });
+
+  it('leaves an MR untouched when no matching diff stats exist (older than the retained window)', () => {
+    const mrs = [TrackedMrFactory.create({ mrNumber: 999, reviews: [reviewEvent()] })];
+    const stats = ProjectStatsFactory.withReviews([
+      ReviewStatsFactory.create({
+        mrNumber: 1,
+        diffStats: { commitsCount: 1, additions: 10, deletions: 5 },
+      }),
+    ]);
+
+    const [enriched] = new MrDiffStatsPresenter().present(mrs, stats);
+
+    expect(enriched.reviews.at(-1)?.diffStats).toBeNull();
+  });
+
+  it('returns the MRs unchanged when project stats are absent', () => {
+    const mrs = [TrackedMrFactory.create({ mrNumber: 5438, reviews: [reviewEvent()] })];
+
+    expect(new MrDiffStatsPresenter().present(mrs, null)).toBe(mrs);
+  });
+
+  it('does not crash on an MR with no review events', () => {
+    const mrs = [TrackedMrFactory.create({ mrNumber: 5438, reviews: [] })];
+    const stats = ProjectStatsFactory.withReviews([
+      ReviewStatsFactory.create({
+        mrNumber: 5438,
+        diffStats: { commitsCount: 3, additions: 120, deletions: 40 },
+      }),
+    ]);
+
+    const [enriched] = new MrDiffStatsPresenter().present(mrs, stats);
+
+    expect(enriched.reviews).toEqual([]);
+  });
+});

--- a/src/tests/units/usecases/insights/computeInsightsWithPersistence.usecase.test.ts
+++ b/src/tests/units/usecases/insights/computeInsightsWithPersistence.usecase.test.ts
@@ -443,6 +443,111 @@ describe('computeInsightsWithPersistence', () => {
     });
   });
 
+  describe('diffStats reconciliation from retained window (backfill recovery)', () => {
+    const windowReviews = [
+      ReviewStatsFactory.create({
+        id: 'alice-r1',
+        assignedBy: 'alice',
+        mrNumber: 1,
+        score: 8,
+        diffStats: { commitsCount: 2, additions: 100, deletions: 20 },
+      }),
+      ReviewStatsFactory.create({
+        id: 'alice-r2',
+        assignedBy: 'alice',
+        mrNumber: 2,
+        score: 8,
+        diffStats: { commitsCount: 1, additions: 50, deletions: 10 },
+      }),
+    ];
+
+    function persistedWithStaleDiffStats() {
+      const staleRecentReviews = windowReviews.map((review) => ({ ...review, diffStats: null }));
+      return PersistedInsightsDataFactory.withDevelopers(
+        [
+          PersistedDeveloperMetricsFactory.create({
+            developerName: 'alice',
+            totalReviews: 2,
+            totalAdditions: 0,
+            totalDeletions: 0,
+            diffStatsReviewCount: 0,
+            recentReviews: staleRecentReviews,
+          }),
+        ],
+        ['alice-r1', 'alice-r2'],
+      );
+    }
+
+    it('recomputes per-developer diffStats totals from the window even when reviews were already processed', () => {
+      const result = computeInsightsWithPersistence(windowReviews, persistedWithStaleDiffStats());
+
+      const alice = result.persistedData.developers.find(
+        (developer) => developer.developerName === 'alice',
+      );
+      expect(alice?.totalAdditions).toBe(150);
+      expect(alice?.totalDeletions).toBe(30);
+      expect(alice?.diffStatsReviewCount).toBe(2);
+    });
+
+    it('refreshes recentReviews diffStats from the window', () => {
+      const result = computeInsightsWithPersistence(windowReviews, persistedWithStaleDiffStats());
+
+      const alice = result.persistedData.developers.find(
+        (developer) => developer.developerName === 'alice',
+      );
+      expect(alice?.recentReviews.every((review) => review.diffStats !== null)).toBe(true);
+    });
+
+    it('does not wipe persisted diffStats when the window is empty', () => {
+      const persistedData = PersistedInsightsDataFactory.withDevelopers(
+        [
+          PersistedDeveloperMetricsFactory.create({
+            developerName: 'alice',
+            totalReviews: 20,
+            totalAdditions: 5000,
+            totalDeletions: 1000,
+            diffStatsReviewCount: 15,
+            recentReviews: createReviewsForDeveloper('alice', 15, { score: 8 }),
+          }),
+        ],
+        Array.from({ length: 20 }, (_, index) => `old-${index}`),
+      );
+
+      const result = computeInsightsWithPersistence([], persistedData);
+
+      const alice = result.persistedData.developers.find(
+        (developer) => developer.developerName === 'alice',
+      );
+      expect(alice?.totalAdditions).toBe(5000);
+      expect(alice?.totalDeletions).toBe(1000);
+      expect(alice?.diffStatsReviewCount).toBe(15);
+    });
+
+    it('leaves a developer untouched when none of their reviews are in the window', () => {
+      const persistedData = PersistedInsightsDataFactory.withDevelopers(
+        [
+          PersistedDeveloperMetricsFactory.create({
+            developerName: 'bob',
+            totalReviews: 5,
+            totalAdditions: 800,
+            totalDeletions: 200,
+            diffStatsReviewCount: 5,
+            recentReviews: createReviewsForDeveloper('bob', 5, { score: 7 }),
+          }),
+        ],
+        Array.from({ length: 5 }, (_, index) => `bob-old-${index}`),
+      );
+
+      const result = computeInsightsWithPersistence(windowReviews, persistedData);
+
+      const bob = result.persistedData.developers.find(
+        (developer) => developer.developerName === 'bob',
+      );
+      expect(bob?.totalAdditions).toBe(800);
+      expect(bob?.diffStatsReviewCount).toBe(5);
+    });
+  });
+
   describe('aiInsights preservation', () => {
     it('should default aiInsights to null and reviewCountAtAiGeneration to 0 on first run', () => {
       const reviews = createReviewsForDeveloper('alice', 6, { score: 8 });


### PR DESCRIPTION
## Problem

Two diff-stats gaps remained after the SPEC-206/207/208 backfill, which only repaired `stats.json`:

- **MR detail sheet** rendered `-` for Commits/Additions/Deletions — it reads diffStats from tracking review events, which are always null.
- **Per-developer insights** showed `diffStatsReviewCount=0` everywhere — `computeInsightsWithPersistence` is incremental (`processedReviewIds`), so backfilled diffStats on already-processed reviews were never re-aggregated, making quality-vs-size correlation impossible.

## Changes

**`fix(insights)`** — reconcile per-developer diff stats from the retained review window. Diff stats only exist for the rolling window kept in project stats, so recompute each developer's diff aggregates from that window and refresh their `recentReviews` diffStats. Self-healing on the next dashboard load. Developers absent from the window keep persisted values; an empty window is a no-op (history preserved).

**`fix(dashboard)`** — `MrDiffStatsPresenter` enriches each tracked MR's latest review event with the most recent diff stats for its MR number, wired into `GET /api/mr-tracking` via a `StatsGateway`. No frontend change (`mrSheet.js` already reads `mr.reviews[].diffStats`).

## Scope / limits

Per decision: local data only (last-100 retained window). MRs older than the window keep `-` (diff data unrecoverable without GitLab re-fetch). Cached AI-insight narrative stays stale until regenerated; numeric metrics are correct.

## Verification

`yarn verify` green — tsc clean, 3950 tests pass. TDD: presenter (5), route GET (2), insights reconciliation (4) tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)