### PR TITLE
feat(webhook): guard oversized merge requests (spec-209)

### DIFF
--- a/docs/feature-tracker.md
+++ b/docs/feature-tracker.md
@@ -71,3 +71,4 @@
 | Fix the GitLab change-size source | [206-fix-gitlab-diff-stats-source](specs/206-fix-gitlab-diff-stats-source.md) — [plan](plans/206-fix-gitlab-diff-stats-source.plan.md) — [report](reports/206-fix-gitlab-diff-stats-source.report.md) | implemented | 2026-06-20 |
 | Backfill change-size data for past reviews | [207-backfill-historical-diff-stats](specs/207-backfill-historical-diff-stats.md) | implemented | 2026-06-20 |
 | Make the Recalculate button backfill change-size data | [208-self-service-backfill-button](specs/208-self-service-backfill-button.md) — [plan](plans/208-self-service-backfill-button.plan.md) — [report](reports/208-self-service-backfill-button.report.md) | implemented | 2026-06-20 |
+| Guard oversized merge requests | [209-mr-size-guard](specs/209-mr-size-guard.md) — [plan](plans/209-mr-size-guard.plan.md) — [report](reports/209-mr-size-guard.report.md) | implemented | 2026-06-22 |

--- a/docs/plans/209-mr-size-guard.plan.md
+++ b/docs/plans/209-mr-size-guard.plan.md
@@ -1,0 +1,240 @@
+# Plan — Guard oversized merge requests (SPEC-209)
+
+> Source spec: `docs/specs/209-mr-size-guard.md`
+> Status: planned
+
+PLAN:
+  scope: oversized merge request guard (diff-size gate, fail-open, FR split comment)
+  is_new_module: false (extends `shared-kernel`, `platform-integration`, `config`)
+
+## Architecture summary (inside-out)
+
+```
+config (maxDiffLines parse + resolver)
+        │
+entities/diffSizeGate  (pure gate)            entities/changedFilesFetch.gateway (port)
+        │                                               │
+        └──────────────► usecase guardDiffSize ◄────────┘ (+ FR comment builder)
+                                   │
+              gateways: changedFilesFetch.{gitlab,github}  (per-file impls)
+                                   │
+              controllers: gitlab + github  (one shared helper, 3 gated sites each)
+                                   │
+                              main/routes.ts  (DI wiring — LAST)
+```
+
+The guard is a single use case `guardDiffSize` that: resolves budget → fetches per-file changes (fail-open) → runs the pure gate → returns a verdict (`{ blocked, countedLines, budget, message }`). Controllers call it at each gated site and act on the verdict (skip enqueue / revoke + comment).
+
+## CONFIG CHANGES (modify, not create)
+
+### Per-project config — `src/config/projectConfig.ts`
+- ADD `maxDiffLines?: number` to `ProjectConfig` interface (after `qualityThreshold?`).
+- ADD `parseMaxDiffLines(value: unknown): number | undefined` — mirror `parseQualityThreshold`: positive integer (`Number.isInteger && value >= 1`), throw `'Invalid maxDiffLines: must be a positive integer'` on invalid, `undefined` on absent/null.
+- WIRE in `parseProjectConfig` (after the `qualityThreshold` block ~line 241): `const maxDiffLines = parseMaxDiffLines(parsed.maxDiffLines); if (maxDiffLines !== undefined) config.maxDiffLines = maxDiffLines;`
+- Test: extend `src/tests/units/config/projectConfig.test.ts` (verify file exists; if not, the new cases live wherever the existing projectConfig tests are — see REFERENCE_FILES).
+
+### Global config — `src/frameworks/config/configLoader.ts`
+- ADD optional `maxDiffLines?: number` to the `Config` interface (top-level, alongside `triggerMode`).
+- PARSE in `validateAndEnrichConfig`: read `config.maxDiffLines`, validate positive integer when present (throw FR message on invalid, mirror `triggerMode`/`jobHistoryRetentionDays` style), include in returned object only when defined.
+- Re-export already covered by `src/config/loader.ts` (`Config` type is re-exported).
+- Test: extend the configLoader test (see REFERENCE_FILES).
+
+DESIGN NOTE — keep budget resolution OUT of these files. Resolution (per-project → global → 2000) is a one-liner closure built in `routes.ts` (mirrors `getQualityThreshold`), injected as `getMaxDiffLines`.
+
+## ENTITIES
+
+### 1. Pure gate — `evaluateDiffSizeGate`
+  name: DiffSizeGate (pure function, NO class — mirrors `resolveProjectIdentifier`)
+  file: src/modules/shared-kernel/entities/diffSizeGate/diffSizeGate.ts
+  test: src/tests/units/modules/shared-kernel/entities/diffSizeGate/diffSizeGate.test.ts
+  signature: `evaluateDiffSizeGate(input: { files: ChangedFile[]; budget: number }) → { oversized: boolean; countedLines: number; budget: number }`
+  logic:
+    - EXCLUDED set (hardcoded basenames): `package.json`, `yarn.lock`, `package-lock.json`, `pnpm-lock.yaml`
+    - match by basename (`path.split('/').pop()`)
+    - countedLines = Σ (additions + deletions) over non-excluded files
+    - oversized = countedLines > budget (strictly greater)
+  type `ChangedFile = { path: string; additions: number; deletions: number }` — declare here (this is the canonical changed-file shape, also used by the gateway port).
+  NO schema/guard needed: input comes from our own gateways (typed), not from an external webhook boundary. (anti-overengineering: a Zod guard here would validate data we already typed — YAGNI. Boundary validation happens inside each gateway impl when parsing the API JSON.)
+
+## GATEWAYS
+
+### 2. Per-file changed-files port (NEW — existing diffStats is TOTALS only, insufficient)
+  name: ChangedFilesFetchGateway
+  contract: src/modules/shared-kernel/entities/diffSizeGate/changedFilesFetch.gateway.ts
+  method: `fetchChangedFiles(projectIdentifier: string, mergeRequestNumber: number): ChangedFile[] | null`
+  returns `null` on fetch failure (fail-open signal) — same contract style as `DiffStatsFetchGateway`.
+  stub: src/tests/stubs/changedFilesFetch.stub.ts  (mirror `diffStatsFetch.stub.ts`: `setResponse`, `setFailure`, `fetchCallCount`, `lastProjectIdentifier`)
+
+### 3a. GitLab impl
+  implementation: src/modules/platform-integration/interface-adapters/gateways/changedFilesFetch.gitlab.gateway.ts
+  transport: GraphQL via `glab api graphql -f query='…'` (SimpleCommandExecutor — same pattern as `diffStatsFetch.gitlab.gateway.ts`)
+  query: `query { project(fullPath:"<path>") { mergeRequest(iid:"<iid>") { diffStats { path additions deletions } } } }`
+  parse: read `data.project.mergeRequest.diffStats` (array). On any structural mismatch or executor throw → return `null` (fail-open at gateway level too; wrap in try/catch like the github diffStats impl).
+  test: src/tests/units/modules/platform-integration/interface-adapters/gateways/changedFilesFetch.gitlab.gateway.test.ts
+
+### 3b. GitHub impl
+  implementation: src/modules/platform-integration/interface-adapters/gateways/changedFilesFetch.github.gateway.ts
+  transport: `gh api repos/<owner>/<repo>/pulls/<n>/files` → array of `{ filename, additions, deletions }`
+  map: `filename → path`. NOTE: GitHub paginates `/files` at 30 per page; for the size gate the first page is acceptable for v1 (see RISKS). Use `--paginate` if the executor supports it — verify before relying on it.
+  parse: try/catch → return `null` on throw or non-array (fail-open).
+  test: src/tests/units/modules/platform-integration/interface-adapters/gateways/changedFilesFetch.github.gateway.test.ts
+
+## USECASES
+
+### 4. guardDiffSize
+  name: guardDiffSize
+  file: src/modules/platform-integration/usecases/guardDiffSize.usecase.ts
+  test: src/tests/units/modules/platform-integration/usecases/guardDiffSize.usecase.test.ts
+  type: query (no state mutation; pure orchestration + side-effect-free verdict)
+  shape (mirror `handlePlatformApproval` verdict + free `buildSplitMessage()`):
+    input: `{ projectIdentifier: string; mergeRequestNumber: number; budget: number }`
+    deps: `{ changedFilesFetchGateway: ChangedFilesFetchGateway }`
+    output:
+      | `{ kind: 'allowed' }`                         // not oversized OR fetch failed (fail-open)
+      | `{ kind: 'blocked'; countedLines; budget; message }`
+  logic:
+    1. `const files = gateway.fetchChangedFiles(...)` inside try/catch → on null/throw return `{ kind: 'allowed' }` (fail-open, scenario "fetch failure")
+    2. `const { oversized, countedLines } = evaluateDiffSizeGate({ files, budget })`
+    3. if not oversized → `{ kind: 'allowed' }`
+    4. if oversized → `{ kind: 'blocked', countedLines, budget, message: buildSplitMessage(countedLines, budget) }`
+  `buildSplitMessage(countedLines, budget)` — free function in the usecase file (mirrors `buildRevertMessage`):
+    concise FR comment stating `countedLines` vs `budget` + 2-3 split tips. NOT verbose. Draft:
+    > « Revue refusée : cette MR fait <countedLines> lignes comptées (budget <budget>). Pour faciliter la revue, découpez-la : 1) séparez refactorings et nouvelles fonctionnalités, 2) extrayez les changements indépendants dans des MR dédiées, 3) limitez chaque MR à une seule intention. »
+    (tips wording left negotiable per spec.)
+
+## SHARED HELPER (controller-level, DRY across 6 sites)
+
+A single async helper applied at every gated site, kept in a controller-adjacent file (NOT a usecase — it does I/O orchestration of comment/revoke which are interface-adapter concerns):
+  name: applyDiffSizeGuard
+  file: src/modules/platform-integration/interface-adapters/controllers/webhook/diffSizeGuard.helper.ts
+  test: src/tests/units/modules/platform-integration/interface-adapters/controllers/webhook/diffSizeGuard.helper.test.ts
+  signature:
+    ```
+    applyDiffSizeGuard(input: {
+      projectIdentifier; localPath; mergeRequestNumber;
+      mode: 'review' | 'followup' | 'approve';
+      deps: { guardDiffSize; getMaxDiffLines; noteCommentPostGateway; approvalRevocationGateway };
+      revokeArgs?: { reviewId?; dismissalMessage? };   // github approve passes reviewId
+      logger;
+    }) → Promise<{ blocked: boolean }>
+    ```
+  behavior:
+    - budget = `deps.getMaxDiffLines(localPath)`
+    - verdict = `await deps.guardDiffSize.execute({ projectIdentifier, mergeRequestNumber, budget })` (usecase is sync over a sync gateway today — confirm; if sync, no await needed)
+    - if `kind === 'allowed'` → `{ blocked: false }`
+    - if `kind === 'blocked'`:
+        - mode `approve`: best-effort `revoke(...)` (try/catch warn) THEN best-effort `postComment(message)` (try/catch warn)
+        - mode `review`: best-effort `postComment(message)` (try/catch warn)
+        - mode `followup`: NO comment (anti-spam, spec rule) — block silently
+        - return `{ blocked: true }`
+  RATIONALE for a helper vs use case: revoke + comment are interface-adapter side effects (ACL), and the per-mode comment/anti-spam policy is presentation/UX policy, not a domain rule. Keeping it in interface-adapters respects the Dependency Rule and avoids leaking gateways into the usecase layer beyond the one fetch gateway.
+
+## CONTROLLERS (modify — 3 gated sites each)
+
+Add to BOTH `GitLabWebhookDependencies` and `GitHubWebhookDependencies`:
+  - `guardDiffSize: GuardDiffSizeUseCase`
+  - `getMaxDiffLines: (localPath: string) => number`
+(`noteCommentPostGateway` and `approvalRevocationGateway` already present in both.)
+
+### `gitlab.controller.ts`
+  - APPROVE site (~line 344-438, `filterGitLabMrApprove` block): BEFORE the existing quality-gate transition, call `applyDiffSizeGuard({ mode: 'approve', ... })`. If `blocked` → reply `{ status: 'unapproved', reason: 'oversized' }` and return (skip quality-gate path).
+  - REVIEW enqueue site (~line 644-741): AFTER budget check (~665-686), BEFORE `gateClaudeInvocation`/`enqueueReview` (~688). If `blocked` → reply `{ status: 'rejected', reason: 'oversized' }` and return.
+  - FOLLOWUP site (~line 488-592): AFTER followup budget check (~515-536), BEFORE followup gate/enqueue (~556). mode `followup` → if `blocked` → reply `{ status: 'rejected', reason: 'oversized' }` and return (no comment).
+
+### `github.controller.ts`
+  - APPROVE site (`handleGitHubPullRequestReviewHook` ~line 122-227): BEFORE quality-gate transition (~158). mode `approve`, pass `revokeArgs: { reviewId: filterResult.reviewId, dismissalMessage: 'oversized' }`. If `blocked` → reply `{ status: 'unapproved', reason: 'oversized' }`.
+  - REVIEW enqueue site (~line 582-659): AFTER budget check (~604-625), BEFORE `gateClaudeInvocation`/`enqueueReview`.
+  - FOLLOWUP site (~line 435-512): AFTER followup budget check, BEFORE gate/enqueue. mode `followup`, no comment.
+
+Both controllers resolve `projectIdentifier` from the existing `filterResult.projectPath` / `approveResult.projectPath` (the `group/project` or `owner/repo` form already used for revoke + comment gateways at these sites — verified identical to what `approvalRevocationGateway.revoke` receives).
+
+## WIRING — `src/main/routes.ts` (LAST step)
+
+For EACH of the GitLab and GitHub `handle*Webhook` deps objects (~lines 578-619 and ~652-691):
+  - `guardDiffSize: new GuardDiffSizeUseCase({ changedFilesFetchGateway: new GitLab|GitHubChangedFilesFetchGateway(defaultGitLab|GitHubExecutor) })`
+  - `getMaxDiffLines: (localPath) => loadProjectConfig(localPath)?.maxDiffLines ?? globalConfig.maxDiffLines ?? 2000`
+    - `globalConfig` = the already-loaded `deps.config` / `loadConfig()` result available in routes (verify the in-scope variable name; `deps.config` is used at line 602/676 `getRepositories: () => deps.config.repositories`).
+  - import the two new gateways + the use case at top of routes.ts (mirror existing `GitLabDiffStatsFetchGateway` import lines 133-134).
+
+## TEST MAPPING (spec rule/scenario → test)
+
+| Spec rule / scenario | Test file | Test |
+|---|---|---|
+| counted size excludes package.json + lockfiles | diffSizeGate.test.ts | "lockfiles excluded" → counted 30; "package.json excluded" → counted 10 |
+| oversized = counted strictly > budget | diffSizeGate.test.ts | counted == budget → not oversized; counted == budget+1 → oversized |
+| under budget gitlab | guardDiffSize.usecase.test.ts | files counted 60, budget 2000 → `{ kind: 'allowed' }` |
+| over budget review | guardDiffSize.usecase.test.ts | counted 2500, budget 2000 → `{ kind: 'blocked', countedLines:2500, message contains 2500/2000 }` |
+| FR split comment content | guardDiffSize.usecase.test.ts | message is FR, mentions counted + budget, has split tips |
+| fail-open: fetch throws | guardDiffSize.usecase.test.ts | stub `setFailure` → `{ kind: 'allowed' }`, no message |
+| fail-open: fetch returns null | guardDiffSize.usecase.test.ts | stub null → `{ kind: 'allowed' }` |
+| per-repo override 500 → counted 800 oversized | projectConfig.test.ts (parse) + guardDiffSize (budget 500, counted 800 → blocked) | |
+| global fallback 1000 → counted 1200 oversized | configLoader.test.ts (parse) + routes resolver (covered by acceptance) | |
+| default budget 2000 → counted 2100 oversized | guardDiffSize (budget 2000, counted 2100 → blocked) | |
+| GitLab per-file fetch parses diffStats | changedFilesFetch.gitlab.gateway.test.ts | parses array; null on throw/malformed |
+| GitHub per-file fetch parses /files | changedFilesFetch.github.gateway.test.ts | maps filename→path; null on throw/non-array |
+| approve oversized → revoke + comment | diffSizeGuard.helper.test.ts | mode approve blocked → revoke called + comment called |
+| review oversized → comment, no revoke | diffSizeGuard.helper.test.ts | mode review blocked → comment called, revoke NOT called |
+| followup oversized → no comment (anti-spam) | diffSizeGuard.helper.test.ts | mode followup blocked → revoke NOT called, comment NOT called |
+| revoke/comment failure is best-effort | diffSizeGuard.helper.test.ts | gateway throws → still returns `{ blocked: true }`, warn logged |
+| end-to-end both platforms | 209-mr-size-guard.acceptance.test.ts | over-budget review blocked + comment; under-budget enqueued; approve revoked |
+
+## REUSE — NOT REINVENT
+
+| Need | Reuse | Do NOT create |
+|---|---|---|
+| Approval revocation | `ApprovalRevocationGateway` (`deps.approvalRevocationGateway`, both impls wired) | new revoke gateway |
+| FR comment posting | `NoteCommentPostGateway` (`deps.noteCommentPostGateway`, egress-scanned in routes) | new comment gateway |
+| Verdict + FR message pattern | `handlePlatformApproval.usecase.ts` (`buildRevertMessage` free fn) | new pattern |
+| Pure-function entity | `resolveProjectIdentifier` (no class) | a class for the gate |
+| Per-project resolver closure | `getQualityThreshold` precedent in routes (3 sites) | resolver inside config files |
+| Stub shape | `diffStatsFetch.stub.ts` | bespoke stub style |
+| Factory style | `diffStats.factory.ts` | hardcoded test data |
+| Command executor | `SimpleCommandExecutor` + `defaultGitLab/GitHubExecutor` | new executor |
+| Config parse style | `parseQualityThreshold` | new validation lib |
+
+EXPLICITLY NOT reused: `DiffStatsFetchGateway` — it returns TOTALS (`additions/deletions/commitsCount`) with no per-file paths, so it cannot exclude lockfiles/package.json. A new per-file gateway is mandatory. (verified: `diffStats.ts` shape + both impls.)
+
+## IMPLEMENTATION_ORDER (inside-out; step 1 = walking skeleton)
+
+1. `diffSizeGate.ts` + test — pure gate, the heart of the feature. Walking-skeleton domain core; everything else depends on its `ChangedFile` type. No external deps → fastest RED→GREEN.
+2. `changedFilesFetch.gateway.ts` (port) + `changedFilesFetch.stub.ts` — contract the usecase will depend on.
+3. `guardDiffSize.usecase.ts` + test (uses stub) — orchestration + FR message; covers fail-open + budget scenarios.
+4. `projectConfig.ts` `maxDiffLines` parse + test — per-project budget.
+5. `configLoader.ts` global `maxDiffLines` + test — global fallback.
+6. `changedFilesFetch.gitlab.gateway.ts` + test — real GraphQL parse.
+7. `changedFilesFetch.github.gateway.ts` + test — real `/files` parse.
+8. `diffSizeGuard.helper.ts` + test — DRY controller helper, per-mode comment/revoke/anti-spam policy.
+9. `gitlab.controller.ts` — wire deps interface + 3 gated sites.
+10. `github.controller.ts` — wire deps interface + 3 gated sites.
+11. `main/routes.ts` — DI wiring for both webhooks (composition root, LAST).
+12. `209-mr-size-guard.acceptance.test.ts` — written FIRST by implementer (RED), GREEN here.
+
+## REFERENCE_FILES
+
+- `docs/specs/209-mr-size-guard.md` — the spec (rules + scenarios)
+- `src/modules/statistics-insights/entities/projectIdentifier/projectIdentifier.ts` — pure-function entity precedent (no class)
+- `src/modules/tracking/usecases/tracking/handlePlatformApproval.usecase.ts` — verdict + `buildRevertMessage` free-fn pattern to mirror
+- `src/modules/statistics-insights/interface-adapters/gateways/diffStatsFetch.gitlab.gateway.ts` — GraphQL executor pattern
+- `src/modules/statistics-insights/interface-adapters/gateways/diffStatsFetch.github.gateway.ts` — `gh api` executor + try/catch null pattern
+- `src/tests/stubs/diffStatsFetch.stub.ts` — stub shape to mirror
+- `src/tests/factories/diffStats.factory.ts` — factory style
+- `src/config/projectConfig.ts` — `parseQualityThreshold` to mirror for `maxDiffLines`
+- `src/frameworks/config/configLoader.ts` — global `Config` interface + validation style
+- `src/main/routes.ts` (lines 133-134, 250-251, 578-619, 652-691) — DI wiring + `getQualityThreshold` resolver precedent
+- `gitlab.controller.ts` / `github.controller.ts` — gated sites + existing revoke/comment usage to mirror
+- Locate config tests: `src/tests/units/config/projectConfig.test.ts` and the configLoader test (run `Glob src/tests/**/*config*`) before editing — verify exact paths.
+
+## RISKS / CONCERNS
+
+- FILE COUNT: ~10 new files + ~5 modified = ~15 touched. Spec claims "<16 files" — within budget but at the edge. No room for scope creep.
+- GitHub `/files` PAGINATION: `gh api repos/.../pulls/{n}/files` returns 30 files/page by default. A large MR with >30 changed files would undercount unless `--paginate` is used. For v1, fail-open semantics make undercounting "safe" (never a false block) but could let a genuinely-huge MR slip through. RECOMMENDATION: use `gh api --paginate` if the executor passes it through; otherwise accept the v1 limitation and note it. FLAG to user — confirm acceptable.
+- GitLab GraphQL `diffStats` field: VERIFIED the existing gitlab diffStats gateway already calls `diffStatsSummary` successfully via `glab api graphql`; the per-file `diffStats { path additions deletions }` field is the documented sibling. Implementer must validate the exact GraphQL field name against a real MR before trusting it (anti-hallucination) — do a manual `glab api graphql` probe.
+- `projectIdentifier` vs `projectPath`: at the gated sites controllers already pass `*.projectPath` to `revoke`/`postComment`. The new per-file gateways must accept the SAME identifier form (`group/project` for GitLab, `owner/repo` for GitHub). VERIFIED both revoke and comment use `projectPath` at these sites → reuse it directly, do not re-resolve.
+- usecase sync vs async: existing fetch gateways are SYNCHRONOUS (`fetchDiffStats` returns, not Promise). `guardDiffSize` can therefore be sync; the helper stays async only for the revoke/comment awaits. Keep the usecase sync to match the gateway contract (do not gratuitously make it async).
+- ANTI-OVERENGINEERING VERDICT: scope is justified. One new pure entity, one new gateway (2 impls), one usecase, one controller helper. NO Zod schema/guard for `ChangedFile` (typed internal data, not a webhook boundary), NO new module, NO value object, NO presenter/view (dashboard surfacing is explicitly out of scope). Helper is a plain function, not a strategy hierarchy despite 3 modes.
+
+## ACCEPTANCE_TEST
+
+  file: src/tests/acceptance/209-mr-size-guard.acceptance.test.ts
+  note: "SDD outer loop — written first by implementer, RED during impl, GREEN at the end"
+  covers: over-budget review (no enqueue + FR comment), over-budget approve (revoke + FR comment), under-budget (normal enqueue, no comment), fail-open (fetch failure → normal), both GitLab and GitHub.

--- a/docs/reports/209-mr-size-guard.report.md
+++ b/docs/reports/209-mr-size-guard.report.md
@@ -1,0 +1,58 @@
+# Implementation Report — SPEC-209 Guard oversized merge requests
+
+> Spec: `docs/specs/209-mr-size-guard.md` · Plan: `docs/plans/209-mr-size-guard.plan.md`
+> Status: implemented · Date: 2026-06-22
+
+## Status: Complete
+
+## Files created
+
+| File | Description |
+|------|-------------|
+| `src/modules/shared-kernel/entities/diffSizeGate/diffSizeGate.ts` | Pure `evaluateDiffSizeGate` + `ChangedFile` type + excluded-basename set |
+| `src/modules/shared-kernel/entities/diffSizeGate/changedFilesFetch.gateway.ts` | Per-file changed-files port (`ChangedFile[] | null`) |
+| `src/modules/platform-integration/interface-adapters/gateways/changedFilesFetch.gitlab.gateway.ts` | GitLab GraphQL `diffStats` impl |
+| `src/modules/platform-integration/interface-adapters/gateways/changedFilesFetch.github.gateway.ts` | GitHub `pulls/{n}/files --paginate` impl |
+| `src/modules/platform-integration/usecases/guardDiffSize.usecase.ts` | Fetch → gate → verdict + FR `buildSplitMessage` |
+| `src/modules/platform-integration/interface-adapters/controllers/webhook/diffSizeGuard.helper.ts` | `applyDiffSizeGuard` — per-mode revoke/comment/anti-spam |
+| `src/tests/factories/changedFiles.factory.ts` | `ChangedFile` test factory |
+| `src/tests/stubs/changedFilesFetch.stub.ts` | Stub gateway (`setResponse`/`setFailure`) |
+| `src/tests/units/.../diffSizeGate.test.ts` | Gate unit tests |
+| `src/tests/units/.../guardDiffSize.usecase.test.ts` | Use case unit tests |
+| `src/tests/units/.../changedFilesFetch.gitlab.gateway.test.ts` | GitLab gateway tests |
+| `src/tests/units/.../changedFilesFetch.github.gateway.test.ts` | GitHub gateway tests |
+| `src/tests/units/.../diffSizeGuard.helper.test.ts` | Helper tests (3 modes + best-effort failures) |
+| `src/tests/acceptance/209-mr-size-guard.acceptance.test.ts` | Outer-loop acceptance test |
+
+## Files modified
+
+- `src/config/projectConfig.ts` — `maxDiffLines?` per-repo + `parseMaxDiffLines`
+- `src/frameworks/config/configLoader.ts` — global `maxDiffLines?`
+- `src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts` — deps + 3 gated sites
+- `src/modules/platform-integration/interface-adapters/controllers/webhook/github.controller.ts` — deps + 3 gated sites
+- `src/main/routes.ts` — DI wiring + `getMaxDiffLines` resolver (both webhooks)
+- Test-wiring (new required deps added to deps builders): `46`, `180`, `197` acceptance tests; `github.controller.test.ts`, `gitlab.controller.test.ts`, `gitlabIdempotency.controller.test.ts`, config tests
+
+## Tests
+
+- `yarn verify` GREEN: typecheck + lint + format + **3988 tests passed** (481 files), 0 failures.
+- Lint: only pre-existing size/depth warnings (tracked debt); no errors.
+
+## Spec coverage
+
+| Rule / scenario | Covered by |
+|---|---|
+| counted size excludes package.json + lockfiles | `diffSizeGate.test.ts`, acceptance "lockfiles/package.json excluded" |
+| oversized = counted strictly > budget | `diffSizeGate.test.ts` |
+| budget per-repo → global → 2000 | `projectConfig.test.ts`, `configLoader.test.ts`, `routes` resolver |
+| oversized review → no enqueue + FR comment | `guardDiffSize.usecase.test.ts`, `diffSizeGuard.helper.test.ts`, acceptance, controller tests |
+| oversized followup → no enqueue, silent | `diffSizeGuard.helper.test.ts`, acceptance |
+| oversized approve → approval revoked + comment | `diffSizeGuard.helper.test.ts`, acceptance |
+| fail-open on fetch failure | `guardDiffSize.usecase.test.ts`, acceptance |
+| both GitLab and GitHub | controller tests + gateway tests both platforms |
+
+## Notes / follow-ups
+
+- The controller blocked-branch (`if (blocked) { reply rejected; return }`) is a trivial reply+return; the decision logic it guards is fully tested at the helper seam.
+- GitHub `/files` pagination handled via `--paginate`.
+- Dashboard surfacing of the blocked-for-size state remains out of scope (potential follow-up).

--- a/docs/specs/209-mr-size-guard.md
+++ b/docs/specs/209-mr-size-guard.md
@@ -1,0 +1,95 @@
+# Guard oversized merge requests
+
+## Status: implemented
+
+## Context
+
+A merge request that changes too many lines is hard to review well and risks rubber-stamp
+approvals. ReviewFlow should refuse to spend a review (or follow-up) on an MR that exceeds a
+configurable line budget, revoke any approval already granted, and tell the author how to
+split the work into smaller MRs. Lock files and `package.json` churn must not count toward the
+budget — they inflate the size without adding review burden.
+
+## Rules
+
+- the counted size of an MR is `additions + deletions` summed over its changed files, excluding `package.json` and lock files (`yarn.lock`, `package-lock.json`, `pnpm-lock.yaml`)
+- an MR is oversized when its counted size is strictly greater than the configured line budget
+- the line budget is resolved per project: `.claude/reviews/config.json` `maxDiffLines`, falling back to the global `config.json` `maxDiffLines`, falling back to `2000`
+- when an oversized MR requests a review, no review job is enqueued
+- when an oversized MR is pushed to (follow-up), no follow-up job is enqueued
+- when an oversized MR is approved on the platform, the approval is revoked
+- whenever a review or approval is blocked for size, a concise French comment is posted explaining the counted size vs the budget and giving 2-3 actionable tips to split the MR
+- a non-oversized MR is processed exactly as before (no comment, no revocation, normal enqueue)
+- the guard is fail-open: if the changed-files size cannot be fetched, the MR is processed normally (no false block)
+- the guard applies to both GitLab and GitHub
+
+## Scenarios
+
+- under budget gitlab: {files: [{path:"src/a.ts", additions:50, deletions:10}], budget:2000} → not oversized, review enqueued, no comment
+- over budget gitlab review: {files totaling 2500 counted lines, budget:2000} → no review enqueued + FR split comment posted
+- over budget gitlab approve: {counted 2500, budget:2000, MR approved} → approval revoked + FR split comment posted
+- over budget followup: {counted 2500, budget:2000, push event} → no follow-up enqueued
+- lockfiles excluded: {files: [{path:"yarn.lock", additions:5000, deletions:0}, {path:"src/a.ts", additions:30, deletions:0}], budget:2000} → counted 30, not oversized
+- package.json excluded: {files: [{path:"package.json", additions:3000, deletions:0}, {path:"src/a.ts", additions:10, deletions:0}], budget:2000} → counted 10, not oversized
+- per-repo override: {project config maxDiffLines:500, counted 800} → oversized
+- global fallback: {no per-repo maxDiffLines, global config maxDiffLines:1000, counted 1200} → oversized
+- default budget: {no maxDiffLines anywhere, counted 2100} → oversized (default 2000)
+- fetch failure: {changed-files fetch throws, counted unknown} → processed normally (fail-open), no comment
+
+## Out of Scope
+
+- Dashboard surfacing of "blocked for size" state (separate UI follow-up)
+- Auto-splitting the MR for the author
+- Per-file or per-language budgets (single global counted-line budget only)
+- Making the excluded-file list itself configurable (hardcoded list for now)
+- Re-posting / deduplicating the comment across repeated follow-up pushes beyond the rules above
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| counted size | `additions + deletions` over changed files excluding `package.json` and lock files |
+| line budget | The `maxDiffLines` threshold above which an MR is oversized |
+| changed files | The per-file additions/deletions of an MR (GitLab GraphQL `diffStats`, GitHub `pulls/{n}/files`) |
+
+## INVEST Evaluation
+
+| Criterion | Status | Note |
+|-----------|--------|------|
+| Independent | OK | Reuses existing approval-revocation + comment gateways; adds one fetch + one gate |
+| Negotiable | OK | Excluded-file set and tips wording left open |
+| Valuable | OK | Prevents low-quality reviews of giant MRs, nudges good MR hygiene |
+| Estimable | OK | One gateway (2 impls), one pure gate, one use case, controller wiring |
+| Small | OK | <16 files |
+| Testable | OK | Each rule maps to a scenario |
+
+## Definition of Done
+
+See `.claude/skills/product-manager/rules/dod.md`.
+
+## Implementation
+
+### Artefacts
+
+- **Entity (new)**: `src/modules/shared-kernel/entities/diffSizeGate/diffSizeGate.ts` — pure `evaluateDiffSizeGate({ files, budget })` summing `additions + deletions` over files whose basename is not in `{package.json, yarn.lock, package-lock.json, pnpm-lock.yaml}`; `oversized = countedLines > budget`. Declares the canonical `ChangedFile` type. No class, no Zod (internal typed data).
+- **Gateway contract (new)**: `src/modules/shared-kernel/entities/diffSizeGate/changedFilesFetch.gateway.ts` — `fetchChangedFiles(projectIdentifier, mrNumber): ChangedFile[] | null` (`null` = fetch failure → fail-open). The existing `DiffStatsFetchGateway` returns totals only and cannot exclude per file, so a new per-file port was required.
+- **Gateway impls (new)**: `changedFilesFetch.gitlab.gateway.ts` (GraphQL `diffStats { path additions deletions }` via `glab api graphql`) and `changedFilesFetch.github.gateway.ts` (`gh api --paginate repos/<owner>/<repo>/pulls/<n>/files`). Both try/catch → `null` on any failure or structural mismatch.
+- **Use case (new)**: `src/modules/platform-integration/usecases/guardDiffSize.usecase.ts` — fetch → gate → verdict `{ kind: 'allowed' } | { kind: 'blocked', countedLines, budget, message }`. Fail-open on `null`/throw. FR split comment built by the free `buildSplitMessage()` (mirrors `handlePlatformApproval`'s `buildRevertMessage`).
+- **Controller helper (new)**: `src/modules/platform-integration/interface-adapters/controllers/webhook/diffSizeGuard.helper.ts` — `applyDiffSizeGuard({ mode, ... })`. `approve` → revoke then comment (both best-effort); `review` → comment only; `followup` → block silently (anti-spam). Always returns `{ blocked }`.
+- **Config (modified)**: `src/config/projectConfig.ts` (`maxDiffLines?` per-repo, `parseMaxDiffLines`) and `src/frameworks/config/configLoader.ts` (global `maxDiffLines?`).
+- **Controllers (modified)**: `gitlab.controller.ts` + `github.controller.ts` — `guardDiffSize` + `getMaxDiffLines` added to the deps interfaces; the guard runs at 3 sites each (approve, review-requested enqueue, followup), after the budget check and before enqueue. Blocked → `unapproved`/`rejected` reply with reason `oversized`, no enqueue.
+- **Wiring**: `src/main/routes.ts` — both webhook deps wired with the platform `Changed*FilesFetchGateway` and `getMaxDiffLines: (localPath) => loadProjectConfig(localPath)?.maxDiffLines ?? globalConfig.maxDiffLines ?? 2000`.
+
+### Reused (not reinvented)
+
+- `ApprovalRevocationGateway` and `NoteCommentPostGateway` (already injected in both controllers) — no new revoke/comment gateways.
+- Verdict + free-function FR message pattern from `handlePlatformApproval.usecase.ts`.
+- Per-project resolver closure pattern from `getQualityThreshold` in `routes.ts`.
+
+### Decisions
+
+- Budget resolution: per-repo `.claude/reviews/config.json` → global `config.json` → default `2000`. Lives as a one-line closure in `routes.ts`, not in the config files.
+- Excluded-file list is hardcoded (basename match) — making it configurable is out of scope.
+- Fail-open everywhere: a fetch failure never blocks an MR (no false positives).
+- Anti-spam: the FR comment is posted on review-requested and approve, but follow-up pushes block silently — no new persistent state.
+- GitHub `/files` uses `--paginate` to avoid the 30-file/page undercount.

--- a/src/config/projectConfig.ts
+++ b/src/config/projectConfig.ts
@@ -34,6 +34,7 @@ export interface ProjectConfig {
   externalLink?: string;
   qualityThreshold?: number;
   maxConcurrentReviews?: number;
+  maxDiffLines?: number;
 }
 
 const projectConfigFileSchema = z.record(z.string(), z.unknown());
@@ -63,6 +64,16 @@ function parseQualityThreshold(value: unknown): number | undefined {
   }
   if (typeof value !== 'number' || !Number.isInteger(value) || value < 0 || value > 10) {
     throw new Error('Invalid qualityThreshold: must be an integer between 0 and 10');
+  }
+  return value;
+}
+
+function parseMaxDiffLines(value: unknown): number | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 1) {
+    throw new Error('Invalid maxDiffLines: must be a positive integer');
   }
   return value;
 }
@@ -246,6 +257,11 @@ export function parseProjectConfig(parsed: Record<string, unknown>): ProjectConf
   const maxConcurrentReviews = parseMaxConcurrentReviews(parsed.maxConcurrentReviews);
   if (maxConcurrentReviews !== undefined) {
     config.maxConcurrentReviews = maxConcurrentReviews;
+  }
+
+  const maxDiffLines = parseMaxDiffLines(parsed.maxDiffLines);
+  if (maxDiffLines !== undefined) {
+    config.maxDiffLines = maxDiffLines;
   }
 
   return config;

--- a/src/frameworks/config/configLoader.ts
+++ b/src/frameworks/config/configLoader.ts
@@ -52,6 +52,7 @@ export interface Config {
   queue: QueueConfig;
   repositories: RepositoryConfig[];
   triggerMode: TriggerMode;
+  maxDiffLines?: number;
 }
 
 export interface EnvSecrets {
@@ -242,6 +243,19 @@ export function validateAndEnrichConfig(data: unknown): Config {
     triggerMode = config.triggerMode;
   }
 
+  // Validate maxDiffLines (optional, falls back to the per-call default when absent)
+  let maxDiffLines: number | undefined;
+  if (config.maxDiffLines !== undefined && config.maxDiffLines !== null) {
+    if (
+      typeof config.maxDiffLines !== 'number' ||
+      !Number.isInteger(config.maxDiffLines) ||
+      config.maxDiffLines < 1
+    ) {
+      throw new Error('Configuration invalide : maxDiffLines invalide');
+    }
+    maxDiffLines = config.maxDiffLines;
+  }
+
   // Validate and enrich repositories
   if (!Array.isArray(config.repositories)) {
     throw new Error('Configuration invalide : repositories doit être un tableau');
@@ -276,7 +290,7 @@ export function validateAndEnrichConfig(data: unknown): Config {
     }
   }
 
-  return {
+  const result: Config = {
     server: { port },
     user: { gitlabUsername, githubUsername },
     queue: {
@@ -287,6 +301,12 @@ export function validateAndEnrichConfig(data: unknown): Config {
     repositories: enrichedRepositories,
     triggerMode,
   };
+
+  if (maxDiffLines !== undefined) {
+    result.maxDiffLines = maxDiffLines;
+  }
+
+  return result;
 }
 
 function loadSecrets(): EnvSecrets {

--- a/src/main/routes.ts
+++ b/src/main/routes.ts
@@ -85,6 +85,8 @@ import {
   buildGitLabReviewProcessor,
 } from '@/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.js';
 import { transportGuardMiddleware } from '@/modules/platform-integration/interface-adapters/controllers/webhook/transportGuard.middleware.js';
+import { GitHubChangedFilesFetchGateway } from '@/modules/platform-integration/interface-adapters/gateways/changedFilesFetch.github.gateway.js';
+import { GitLabChangedFilesFetchGateway } from '@/modules/platform-integration/interface-adapters/gateways/changedFilesFetch.gitlab.gateway.js';
 import { GitHubApprovalRevocationCliGateway } from '@/modules/platform-integration/interface-adapters/gateways/cli/approvalRevocation.github.cli.gateway.js';
 import { GitLabApprovalRevocationCliGateway } from '@/modules/platform-integration/interface-adapters/gateways/cli/approvalRevocation.gitlab.cli.gateway.js';
 import { GitHubNoteCommentPostCliGateway } from '@/modules/platform-integration/interface-adapters/gateways/cli/noteCommentPost.github.cli.gateway.js';
@@ -104,6 +106,7 @@ import {
   defaultGitLabExecutor,
 } from '@/modules/platform-integration/interface-adapters/gateways/threadFetch.gitlab.gateway.js';
 import { ForwardedForClientIpResolver } from '@/modules/platform-integration/interface-adapters/gateways/transport/clientIpResolver.forwardedFor.gateway.js';
+import { GuardDiffSizeUseCase } from '@/modules/platform-integration/usecases/guardDiffSize.usecase.js';
 import { IsTrustedActorUseCase } from '@/modules/platform-integration/usecases/isTrustedActor.usecase.js';
 import { processWebhook } from '@/modules/platform-integration/usecases/processWebhook.usecase.js';
 import { pendingReviewsRoutes } from '@/modules/review-execution/interface-adapters/controllers/http/pendingReviews.routes.js';
@@ -615,6 +618,11 @@ export async function registerRoutes(app: FastifyInstance, deps: Dependencies): 
       idempotencyStore,
       getQualityThreshold: (projectPath: string) =>
         loadProjectConfig(projectPath)?.qualityThreshold ?? null,
+      guardDiffSize: new GuardDiffSizeUseCase({
+        changedFilesFetchGateway: new GitLabChangedFilesFetchGateway(defaultGitLabExecutor),
+      }),
+      getMaxDiffLines: (localPath: string) =>
+        loadProjectConfig(localPath)?.maxDiffLines ?? deps.config.maxDiffLines ?? 2000,
       now: () => new Date().toISOString(),
     });
   });
@@ -687,6 +695,11 @@ export async function registerRoutes(app: FastifyInstance, deps: Dependencies): 
       approvalRevocationGateway: new GitHubApprovalRevocationCliGateway(defaultGitHubExecutor),
       getQualityThreshold: (projectPath: string) =>
         loadProjectConfig(projectPath)?.qualityThreshold ?? null,
+      guardDiffSize: new GuardDiffSizeUseCase({
+        changedFilesFetchGateway: new GitHubChangedFilesFetchGateway(defaultGitHubExecutor),
+      }),
+      getMaxDiffLines: (localPath: string) =>
+        loadProjectConfig(localPath)?.maxDiffLines ?? deps.config.maxDiffLines ?? 2000,
       now: () => new Date().toISOString(),
     });
   });

--- a/src/modules/platform-integration/interface-adapters/controllers/webhook/diffSizeGuard.helper.ts
+++ b/src/modules/platform-integration/interface-adapters/controllers/webhook/diffSizeGuard.helper.ts
@@ -1,0 +1,98 @@
+import type { ApprovalRevocationGateway } from '@/modules/platform-integration/entities/approvalRevocation/approvalRevocation.gateway.js';
+import type { NoteCommentPostGateway } from '@/modules/platform-integration/entities/noteComment/noteCommentPost.gateway.js';
+import type { GuardDiffSizeUseCase } from '@/modules/platform-integration/usecases/guardDiffSize.usecase.js';
+
+type DiffSizeGuardMode = 'review' | 'followup' | 'approve';
+
+interface DiffSizeGuardLogger {
+  warn(payload: object, message: string): void;
+  info(payload: object, message: string): void;
+}
+
+interface DiffSizeGuardDependencies {
+  guardDiffSize: Pick<GuardDiffSizeUseCase, 'execute'>;
+  getMaxDiffLines: (localPath: string) => number;
+  noteCommentPostGateway: NoteCommentPostGateway;
+  approvalRevocationGateway: ApprovalRevocationGateway;
+}
+
+interface ApplyDiffSizeGuardInput {
+  projectIdentifier: string;
+  localPath: string;
+  mergeRequestNumber: number;
+  mode: DiffSizeGuardMode;
+  deps: DiffSizeGuardDependencies;
+  revokeArgs?: { reviewId?: number; dismissalMessage?: string };
+  logger: DiffSizeGuardLogger;
+}
+
+async function revokeApproval(input: ApplyDiffSizeGuardInput): Promise<void> {
+  try {
+    await input.deps.approvalRevocationGateway.revoke({
+      projectPath: input.projectIdentifier,
+      mrNumber: input.mergeRequestNumber,
+      reviewId: input.revokeArgs?.reviewId,
+      dismissalMessage: input.revokeArgs?.dismissalMessage,
+    });
+  } catch (error) {
+    input.logger.warn(
+      {
+        mrNumber: input.mergeRequestNumber,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      'Failed to revoke approval on oversized MR; continuing with FR comment',
+    );
+  }
+}
+
+async function postSplitComment(input: ApplyDiffSizeGuardInput, message: string): Promise<void> {
+  try {
+    await input.deps.noteCommentPostGateway.postComment({
+      projectPath: input.projectIdentifier,
+      mrNumber: input.mergeRequestNumber,
+      body: message,
+    });
+  } catch (error) {
+    input.logger.warn(
+      {
+        mrNumber: input.mergeRequestNumber,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      'Failed to post FR split comment on oversized MR',
+    );
+  }
+}
+
+export async function applyDiffSizeGuard(
+  input: ApplyDiffSizeGuardInput,
+): Promise<{ blocked: boolean }> {
+  const budget = input.deps.getMaxDiffLines(input.localPath);
+  const verdict = input.deps.guardDiffSize.execute({
+    projectIdentifier: input.projectIdentifier,
+    mergeRequestNumber: input.mergeRequestNumber,
+    budget,
+  });
+
+  if (verdict.kind === 'allowed') {
+    return { blocked: false };
+  }
+
+  if (input.mode === 'approve') {
+    await revokeApproval(input);
+    await postSplitComment(input, verdict.message);
+  } else if (input.mode === 'review') {
+    await postSplitComment(input, verdict.message);
+  }
+
+  input.logger.info(
+    {
+      mrNumber: input.mergeRequestNumber,
+      mode: input.mode,
+      countedLines: verdict.countedLines,
+      budget: verdict.budget,
+    },
+    'Merge request blocked for oversized diff',
+  );
+
+  return { blocked: true };
+}

--- a/src/modules/platform-integration/interface-adapters/controllers/webhook/github.controller.ts
+++ b/src/modules/platform-integration/interface-adapters/controllers/webhook/github.controller.ts
@@ -18,6 +18,7 @@ import { gitHubPullRequestEventGuard } from '@/modules/platform-integration/enti
 import { gitHubPullRequestReviewEventGuard } from '@/modules/platform-integration/entities/github/githubPullRequestReviewEvent.guard.js';
 import type { NoteCommentPostGateway } from '@/modules/platform-integration/entities/noteComment/noteCommentPost.gateway.js';
 import type { ThreadFetchGateway } from '@/modules/platform-integration/entities/threadFetch/threadFetch.gateway.js';
+import { applyDiffSizeGuard } from '@/modules/platform-integration/interface-adapters/controllers/webhook/diffSizeGuard.helper.js';
 import {
   filterGitHubEvent,
   filterGitHubLabelEvent,
@@ -26,6 +27,7 @@ import {
   filterGitHubIssueCommentEvent,
   filterGitHubPullRequestReviewEvent,
 } from '@/modules/platform-integration/interface-adapters/controllers/webhook/eventFilter.js';
+import type { GuardDiffSizeUseCase } from '@/modules/platform-integration/usecases/guardDiffSize.usecase.js';
 import type { ProcessWebhook } from '@/modules/platform-integration/usecases/processWebhook.usecase.js';
 import type { ReviewJob } from '@/modules/review-execution/entities/job/reviewJob.js';
 import {
@@ -80,6 +82,8 @@ export interface GitHubWebhookDependencies {
   handlePlatformApproval: HandlePlatformApprovalUseCase;
   approvalRevocationGateway: ApprovalRevocationGateway;
   getQualityThreshold: (projectPath: string) => number | null;
+  guardDiffSize: GuardDiffSizeUseCase;
+  getMaxDiffLines: (localPath: string) => number;
   now: () => string;
 }
 
@@ -150,6 +154,29 @@ async function handleGitHubPullRequestReviewHook(
       'Pull request review for unconfigured repository (ignored)',
     );
     reply.status(200).send({ status: 'ignored', reason: 'Repository not configured' });
+    return;
+  }
+
+  const sizeGuard = await applyDiffSizeGuard({
+    projectIdentifier: filterResult.projectPath,
+    localPath: repoConfig.localPath,
+    mergeRequestNumber: filterResult.mergeRequestNumber,
+    mode: 'approve',
+    revokeArgs: { reviewId: filterResult.reviewId, dismissalMessage: 'oversized' },
+    deps: {
+      guardDiffSize: deps.guardDiffSize,
+      getMaxDiffLines: deps.getMaxDiffLines,
+      noteCommentPostGateway: deps.noteCommentPostGateway,
+      approvalRevocationGateway: deps.approvalRevocationGateway,
+    },
+    logger,
+  });
+  if (sizeGuard.blocked) {
+    reply.status(200).send({
+      status: 'unapproved',
+      prNumber: filterResult.mergeRequestNumber,
+      reason: 'oversized',
+    });
     return;
   }
 
@@ -483,6 +510,24 @@ export async function handleGitHubWebhook(
             return;
           }
 
+          const followupSizeGuard = await applyDiffSizeGuard({
+            projectIdentifier: updateResult.projectPath,
+            localPath: updateRepoConfig.localPath,
+            mergeRequestNumber: updateResult.mergeRequestNumber,
+            mode: 'followup',
+            deps: {
+              guardDiffSize: deps.guardDiffSize,
+              getMaxDiffLines: deps.getMaxDiffLines,
+              noteCommentPostGateway: deps.noteCommentPostGateway,
+              approvalRevocationGateway: deps.approvalRevocationGateway,
+            },
+            logger,
+          });
+          if (followupSizeGuard.blocked) {
+            reply.status(200).send({ status: 'rejected', reason: 'oversized' });
+            return;
+          }
+
           const followupProcessor = async (j: ReviewJob, signal: AbortSignal): Promise<void> => {
             await runGitHubReview(deps.executeReview, {
               job: j,
@@ -621,6 +666,24 @@ export async function handleGitHubWebhook(
       consumedUsd: budgetDecision.status.consumedUsd,
     });
     reply.status(200).send({ status: 'rejected', reason: 'budget-exceeded' });
+    return;
+  }
+
+  const reviewSizeGuard = await applyDiffSizeGuard({
+    projectIdentifier: filterResult.projectPath,
+    localPath: repoConfig.localPath,
+    mergeRequestNumber: filterResult.mergeRequestNumber,
+    mode: 'review',
+    deps: {
+      guardDiffSize: deps.guardDiffSize,
+      getMaxDiffLines: deps.getMaxDiffLines,
+      noteCommentPostGateway: deps.noteCommentPostGateway,
+      approvalRevocationGateway: deps.approvalRevocationGateway,
+    },
+    logger,
+  });
+  if (reviewSizeGuard.blocked) {
+    reply.status(200).send({ status: 'rejected', reason: 'oversized' });
     return;
   }
 

--- a/src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts
+++ b/src/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.ts
@@ -18,6 +18,7 @@ import { gitLabNoteEventGuard } from '@/modules/platform-integration/entities/gi
 import type { IdempotencyStore } from '@/modules/platform-integration/entities/idempotency/idempotencyStore.gateway.js';
 import type { NoteCommentPostGateway } from '@/modules/platform-integration/entities/noteComment/noteCommentPost.gateway.js';
 import type { ThreadFetchGateway } from '@/modules/platform-integration/entities/threadFetch/threadFetch.gateway.js';
+import { applyDiffSizeGuard } from '@/modules/platform-integration/interface-adapters/controllers/webhook/diffSizeGuard.helper.js';
 import {
   filterGitLabEvent,
   filterGitLabMrUpdate,
@@ -26,6 +27,7 @@ import {
   filterGitLabMrApprove,
   filterGitLabNoteEvent,
 } from '@/modules/platform-integration/interface-adapters/controllers/webhook/eventFilter.js';
+import type { GuardDiffSizeUseCase } from '@/modules/platform-integration/usecases/guardDiffSize.usecase.js';
 import type { IsTrustedActorUseCase } from '@/modules/platform-integration/usecases/isTrustedActor.usecase.js';
 import type { ProcessWebhook } from '@/modules/platform-integration/usecases/processWebhook.usecase.js';
 import type { ReviewJob } from '@/modules/review-execution/entities/job/reviewJob.js';
@@ -119,6 +121,8 @@ export interface GitLabWebhookDependencies {
   approvalRevocationGateway: ApprovalRevocationGateway;
   idempotencyStore?: IdempotencyStore;
   getQualityThreshold: (projectPath: string) => number | null;
+  guardDiffSize: GuardDiffSizeUseCase;
+  getMaxDiffLines: (localPath: string) => number;
   now: () => string;
 }
 
@@ -345,6 +349,28 @@ export async function handleGitLabWebhook(
   if (approveResult.shouldProcess) {
     const repoConfig = findRepositoryByProjectPath(approveResult.projectPath);
     if (repoConfig) {
+      const sizeGuard = await applyDiffSizeGuard({
+        projectIdentifier: approveResult.projectPath,
+        localPath: repoConfig.localPath,
+        mergeRequestNumber: approveResult.mergeRequestNumber,
+        mode: 'approve',
+        deps: {
+          guardDiffSize: deps.guardDiffSize,
+          getMaxDiffLines: deps.getMaxDiffLines,
+          noteCommentPostGateway: deps.noteCommentPostGateway,
+          approvalRevocationGateway: deps.approvalRevocationGateway,
+        },
+        logger,
+      });
+      if (sizeGuard.blocked) {
+        reply.status(200).send({
+          status: 'unapproved',
+          mrNumber: approveResult.mergeRequestNumber,
+          reason: 'oversized',
+        });
+        return;
+      }
+
       const mrId = `gitlab-${approveResult.projectPath}-${approveResult.mergeRequestNumber}`;
       const threshold = deps.getQualityThreshold(repoConfig.localPath);
       const transitionResult = deps.transitionState.execute({
@@ -535,6 +561,24 @@ export async function handleGitLabWebhook(
             return;
           }
 
+          const followupSizeGuard = await applyDiffSizeGuard({
+            projectIdentifier: updateResult.projectPath,
+            localPath: updateRepoConfig.localPath,
+            mergeRequestNumber: updateResult.mergeRequestNumber,
+            mode: 'followup',
+            deps: {
+              guardDiffSize: deps.guardDiffSize,
+              getMaxDiffLines: deps.getMaxDiffLines,
+              noteCommentPostGateway: deps.noteCommentPostGateway,
+              approvalRevocationGateway: deps.approvalRevocationGateway,
+            },
+            logger,
+          });
+          if (followupSizeGuard.blocked) {
+            reply.status(200).send({ status: 'rejected', reason: 'oversized' });
+            return;
+          }
+
           const followupProcessor = async (j: ReviewJob, signal: AbortSignal): Promise<void> => {
             await runGitLabReview(deps.executeReview, {
               job: j,
@@ -682,6 +726,24 @@ export async function handleGitLabWebhook(
       consumedUsd: budgetDecision.status.consumedUsd,
     });
     reply.status(200).send({ status: 'rejected', reason: 'budget-exceeded' });
+    return;
+  }
+
+  const reviewSizeGuard = await applyDiffSizeGuard({
+    projectIdentifier: filterResult.projectPath,
+    localPath: repoConfig.localPath,
+    mergeRequestNumber: filterResult.mergeRequestNumber,
+    mode: 'review',
+    deps: {
+      guardDiffSize: deps.guardDiffSize,
+      getMaxDiffLines: deps.getMaxDiffLines,
+      noteCommentPostGateway: deps.noteCommentPostGateway,
+      approvalRevocationGateway: deps.approvalRevocationGateway,
+    },
+    logger,
+  });
+  if (reviewSizeGuard.blocked) {
+    reply.status(200).send({ status: 'rejected', reason: 'oversized' });
     return;
   }
 

--- a/src/modules/platform-integration/interface-adapters/gateways/changedFilesFetch.github.gateway.ts
+++ b/src/modules/platform-integration/interface-adapters/gateways/changedFilesFetch.github.gateway.ts
@@ -1,0 +1,47 @@
+import type { ChangedFilesFetchGateway } from '@/modules/shared-kernel/entities/diffSizeGate/changedFilesFetch.gateway.js';
+import type { ChangedFile } from '@/modules/shared-kernel/entities/diffSizeGate/diffSizeGate.js';
+import type { SimpleCommandExecutor } from '@/shared/foundation/commandExecutor.js';
+
+export type CommandExecutor = SimpleCommandExecutor;
+
+function readField(value: unknown, field: string): unknown {
+  if (typeof value !== 'object' || value === null || !(field in value)) {
+    throw new Error(`GitHub pulls/files entry is missing "${field}"`);
+  }
+  return Reflect.get(value, field);
+}
+
+function toChangedFile(entry: unknown): ChangedFile {
+  const filename = readField(entry, 'filename');
+  const additions = readField(entry, 'additions');
+  const deletions = readField(entry, 'deletions');
+
+  if (
+    typeof filename !== 'string' ||
+    typeof additions !== 'number' ||
+    typeof deletions !== 'number'
+  ) {
+    throw new Error('GitHub pulls/files entry has invalid fields');
+  }
+
+  return { path: filename, additions, deletions };
+}
+
+export class GitHubChangedFilesFetchGateway implements ChangedFilesFetchGateway {
+  constructor(private readonly executor: CommandExecutor) {}
+
+  fetchChangedFiles(projectPath: string, mergeRequestNumber: number): ChangedFile[] | null {
+    try {
+      const response = this.executor(
+        `gh api --paginate repos/${projectPath}/pulls/${mergeRequestNumber}/files`,
+      );
+      const parsed: unknown = JSON.parse(response);
+      if (!Array.isArray(parsed)) {
+        return null;
+      }
+      return parsed.map(toChangedFile);
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/modules/platform-integration/interface-adapters/gateways/changedFilesFetch.gitlab.gateway.ts
+++ b/src/modules/platform-integration/interface-adapters/gateways/changedFilesFetch.gitlab.gateway.ts
@@ -1,0 +1,50 @@
+import type { ChangedFilesFetchGateway } from '@/modules/shared-kernel/entities/diffSizeGate/changedFilesFetch.gateway.js';
+import type { ChangedFile } from '@/modules/shared-kernel/entities/diffSizeGate/diffSizeGate.js';
+import type { SimpleCommandExecutor } from '@/shared/foundation/commandExecutor.js';
+
+export type CommandExecutor = SimpleCommandExecutor;
+
+function readField(value: unknown, field: string): unknown {
+  if (typeof value !== 'object' || value === null || !(field in value)) {
+    throw new Error(`GitLab GraphQL response is missing "${field}"`);
+  }
+  return Reflect.get(value, field);
+}
+
+function toChangedFile(entry: unknown): ChangedFile {
+  const path = readField(entry, 'path');
+  const additions = readField(entry, 'additions');
+  const deletions = readField(entry, 'deletions');
+
+  if (typeof path !== 'string' || typeof additions !== 'number' || typeof deletions !== 'number') {
+    throw new Error('GitLab GraphQL diffStats entry has invalid fields');
+  }
+
+  return { path, additions, deletions };
+}
+
+function extractChangedFiles(response: unknown): ChangedFile[] {
+  const project = readField(readField(response, 'data'), 'project');
+  const mergeRequest = readField(project, 'mergeRequest');
+  const diffStats = readField(mergeRequest, 'diffStats');
+
+  if (!Array.isArray(diffStats)) {
+    throw new Error('GitLab GraphQL diffStats is not an array');
+  }
+
+  return diffStats.map(toChangedFile);
+}
+
+export class GitLabChangedFilesFetchGateway implements ChangedFilesFetchGateway {
+  constructor(private readonly executor: CommandExecutor) {}
+
+  fetchChangedFiles(projectPath: string, mergeRequestNumber: number): ChangedFile[] | null {
+    try {
+      const query = `query { project(fullPath:"${projectPath}") { mergeRequest(iid:"${mergeRequestNumber}") { diffStats { path additions deletions } } } }`;
+      const response = this.executor(`glab api graphql -f query='${query}'`);
+      return extractChangedFiles(JSON.parse(response));
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/modules/platform-integration/usecases/guardDiffSize.usecase.ts
+++ b/src/modules/platform-integration/usecases/guardDiffSize.usecase.ts
@@ -1,0 +1,65 @@
+import type { ChangedFilesFetchGateway } from '@/modules/shared-kernel/entities/diffSizeGate/changedFilesFetch.gateway.js';
+import { evaluateDiffSizeGate } from '@/modules/shared-kernel/entities/diffSizeGate/diffSizeGate.js';
+import type { UseCase } from '@/shared/foundation/usecase.base.js';
+
+interface GuardDiffSizeInput {
+  projectIdentifier: string;
+  mergeRequestNumber: number;
+  budget: number;
+}
+
+export type GuardDiffSizeVerdict =
+  | { kind: 'allowed' }
+  | { kind: 'blocked'; countedLines: number; budget: number; message: string };
+
+interface GuardDiffSizeDependencies {
+  changedFilesFetchGateway: ChangedFilesFetchGateway;
+}
+
+function buildSplitMessage(countedLines: number, budget: number): string {
+  return (
+    `Revue refusée : cette merge request fait ${countedLines} lignes comptées ` +
+    `(budget ${budget}). Pour faciliter la revue, découpez-la : ` +
+    '1) séparez les refactorings des nouvelles fonctionnalités, ' +
+    '2) extrayez les changements indépendants dans des MR dédiées, ' +
+    '3) limitez chaque MR à une seule intention.'
+  );
+}
+
+export class GuardDiffSizeUseCase implements UseCase<GuardDiffSizeInput, GuardDiffSizeVerdict> {
+  constructor(private readonly dependencies: GuardDiffSizeDependencies) {}
+
+  execute(input: GuardDiffSizeInput): GuardDiffSizeVerdict {
+    const files = this.fetchChangedFiles(input);
+    if (files === null) {
+      return { kind: 'allowed' };
+    }
+
+    const { oversized, countedLines, budget } = evaluateDiffSizeGate({
+      files,
+      budget: input.budget,
+    });
+
+    if (!oversized) {
+      return { kind: 'allowed' };
+    }
+
+    return {
+      kind: 'blocked',
+      countedLines,
+      budget,
+      message: buildSplitMessage(countedLines, budget),
+    };
+  }
+
+  private fetchChangedFiles(input: GuardDiffSizeInput) {
+    try {
+      return this.dependencies.changedFilesFetchGateway.fetchChangedFiles(
+        input.projectIdentifier,
+        input.mergeRequestNumber,
+      );
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/modules/shared-kernel/entities/diffSizeGate/changedFilesFetch.gateway.ts
+++ b/src/modules/shared-kernel/entities/diffSizeGate/changedFilesFetch.gateway.ts
@@ -1,0 +1,5 @@
+import type { ChangedFile } from '@/modules/shared-kernel/entities/diffSizeGate/diffSizeGate.js';
+
+export interface ChangedFilesFetchGateway {
+  fetchChangedFiles(projectIdentifier: string, mergeRequestNumber: number): ChangedFile[] | null;
+}

--- a/src/modules/shared-kernel/entities/diffSizeGate/diffSizeGate.ts
+++ b/src/modules/shared-kernel/entities/diffSizeGate/diffSizeGate.ts
@@ -1,0 +1,39 @@
+export type ChangedFile = {
+  path: string;
+  additions: number;
+  deletions: number;
+};
+
+interface DiffSizeGateInput {
+  files: ChangedFile[];
+  budget: number;
+}
+
+interface DiffSizeGateResult {
+  oversized: boolean;
+  countedLines: number;
+  budget: number;
+}
+
+const EXCLUDED_BASENAMES = new Set([
+  'package.json',
+  'yarn.lock',
+  'package-lock.json',
+  'pnpm-lock.yaml',
+]);
+
+function basename(path: string): string {
+  return path.split('/').pop() ?? path;
+}
+
+export function evaluateDiffSizeGate(input: DiffSizeGateInput): DiffSizeGateResult {
+  const countedLines = input.files
+    .filter((file) => !EXCLUDED_BASENAMES.has(basename(file.path)))
+    .reduce((total, file) => total + file.additions + file.deletions, 0);
+
+  return {
+    oversized: countedLines > input.budget,
+    countedLines,
+    budget: input.budget,
+  };
+}

--- a/src/tests/acceptance/180-quality-threshold-block-approval-iter-C.acceptance.test.ts
+++ b/src/tests/acceptance/180-quality-threshold-block-approval-iter-C.acceptance.test.ts
@@ -190,6 +190,8 @@ function buildGitLabDeps(
     handlePlatformApproval: new HandlePlatformApprovalUseCase(tracking),
     approvalRevocationGateway: approvalRevocation,
     getQualityThreshold: () => 7,
+    guardDiffSize: { execute: () => ({ kind: 'allowed' }) },
+    getMaxDiffLines: () => 2000,
     now: () => '2026-05-26T12:00:00.000Z',
     enforceBudget: {
       execute: vi.fn(async () => ({
@@ -241,6 +243,8 @@ function buildGitHubDeps(
     handlePlatformApproval: new HandlePlatformApprovalUseCase(tracking),
     approvalRevocationGateway: approvalRevocation,
     getQualityThreshold: () => 7,
+    guardDiffSize: { execute: () => ({ kind: 'allowed' }) },
+    getMaxDiffLines: () => 2000,
     now: () => '2026-05-26T12:00:00.000Z',
     enforceBudget: {
       execute: vi.fn(async () => ({

--- a/src/tests/acceptance/197-trusted-actor-provenance-gate.acceptance.test.ts
+++ b/src/tests/acceptance/197-trusted-actor-provenance-gate.acceptance.test.ts
@@ -92,6 +92,7 @@ import { enqueueReview } from '@/frameworks/queue/pQueueAdapter.js';
 import { MEMBER_ACCESS_LEVELS } from '@/modules/platform-integration/entities/memberAccess/memberAccess.js';
 import type { WebhookEvent } from '@/modules/platform-integration/entities/webhookEvent/webhookEvent.js';
 import { handleGitLabWebhook } from '@/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.js';
+import { GuardDiffSizeUseCase } from '@/modules/platform-integration/usecases/guardDiffSize.usecase.js';
 import { IsTrustedActorUseCase } from '@/modules/platform-integration/usecases/isTrustedActor.usecase.js';
 import {
   processWebhook,
@@ -111,6 +112,7 @@ import { verifyGitLabSignature, getGitLabEventType } from '@/security/verifier.j
 import { GitLabEventFactory } from '@/tests/factories/gitLabEvent.factory.js';
 import { TrackedMrFactory } from '@/tests/factories/trackedMr.factory.js';
 import { StubApprovalRevocationGateway } from '@/tests/stubs/approvalRevocation.stub.js';
+import { StubChangedFilesFetchGateway } from '@/tests/stubs/changedFilesFetch.stub.js';
 import { createStubLogger } from '@/tests/stubs/logger.stub.js';
 import { StubMemberAccessGateway } from '@/tests/stubs/memberAccess.stub.js';
 import { StubNoteCommentPostGateway } from '@/tests/stubs/noteCommentPost.stub.js';
@@ -224,6 +226,10 @@ function buildBaseDeps(trackingGateway: ReturnType<typeof createMockTrackingGate
     handlePlatformApproval: new HandlePlatformApprovalUseCase(trackingGateway),
     approvalRevocationGateway: new StubApprovalRevocationGateway(),
     getQualityThreshold: (): number | null => null,
+    guardDiffSize: new GuardDiffSizeUseCase({
+      changedFilesFetchGateway: new StubChangedFilesFetchGateway(),
+    }),
+    getMaxDiffLines: (): number => 2000,
     now: (): string => '2026-05-26T12:00:00.000Z',
   };
 }

--- a/src/tests/acceptance/200-webhook-event-idempotency.acceptance.test.ts
+++ b/src/tests/acceptance/200-webhook-event-idempotency.acceptance.test.ts
@@ -60,6 +60,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import type { WebhookEvent } from '@/modules/platform-integration/entities/webhookEvent/webhookEvent.js';
 import { handleGitLabWebhook } from '@/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.js';
 import { InMemoryIdempotencyStore } from '@/modules/platform-integration/interface-adapters/gateways/inMemoryIdempotencyStore.gateway.js';
+import { GuardDiffSizeUseCase } from '@/modules/platform-integration/usecases/guardDiffSize.usecase.js';
 import {
   processWebhook,
   type ProcessWebhookResult,
@@ -80,6 +81,7 @@ import { TransitionStateUseCase } from '@/modules/tracking/usecases/tracking/tra
 import { GitLabEventFactory } from '@/tests/factories/gitLabEvent.factory.js';
 import { TrackedMrFactory } from '@/tests/factories/trackedMr.factory.js';
 import { StubApprovalRevocationGateway } from '@/tests/stubs/approvalRevocation.stub.js';
+import { StubChangedFilesFetchGateway } from '@/tests/stubs/changedFilesFetch.stub.js';
 import { StubIdempotencyStore } from '@/tests/stubs/idempotencyStore.stub.js';
 import { createStubLogger } from '@/tests/stubs/logger.stub.js';
 import { StubNoteCommentPostGateway } from '@/tests/stubs/noteCommentPost.stub.js';
@@ -216,6 +218,10 @@ function createDeps(
     handlePlatformApproval: new HandlePlatformApprovalUseCase(trackingGateway),
     approvalRevocationGateway: new StubApprovalRevocationGateway(),
     getQualityThreshold: (): number | null => null,
+    guardDiffSize: new GuardDiffSizeUseCase({
+      changedFilesFetchGateway: new StubChangedFilesFetchGateway(),
+    }),
+    getMaxDiffLines: (): number => 2000,
     now: (): string => '2026-05-26T12:00:00.000Z',
     ...overrides,
   };

--- a/src/tests/acceptance/209-mr-size-guard.acceptance.test.ts
+++ b/src/tests/acceptance/209-mr-size-guard.acceptance.test.ts
@@ -1,0 +1,227 @@
+/**
+ * SPEC-209 — Guard oversized merge requests (outer-loop acceptance test, SDD)
+ *
+ * Exercises the size guard end-to-end at the controller-helper seam: the real
+ * GuardDiffSizeUseCase resolving a per-project budget, fetching per-file changes
+ * through a stub gateway, running the pure gate, and the applyDiffSizeGuard
+ * helper acting on the verdict (skip enqueue / revoke + FR comment). Covers both
+ * GitLab and GitHub.
+ *
+ * Scenarios from docs/specs/209-mr-size-guard.md:
+ *   - under budget gitlab: not oversized → allowed, no comment
+ *   - over budget gitlab review: oversized → blocked + FR split comment, no revoke
+ *   - over budget gitlab approve: oversized → blocked + revoke + FR split comment
+ *   - over budget followup: oversized → blocked, no comment (anti-spam)
+ *   - lockfiles/package.json excluded: not oversized
+ *   - fetch failure: fail-open → allowed, no comment
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { applyDiffSizeGuard } from '@/modules/platform-integration/interface-adapters/controllers/webhook/diffSizeGuard.helper.js';
+import { GuardDiffSizeUseCase } from '@/modules/platform-integration/usecases/guardDiffSize.usecase.js';
+import { ChangedFilesFactory } from '@/tests/factories/changedFiles.factory.js';
+import { StubApprovalRevocationGateway } from '@/tests/stubs/approvalRevocation.stub.js';
+import { StubChangedFilesFetchGateway } from '@/tests/stubs/changedFilesFetch.stub.js';
+import { StubNoteCommentPostGateway } from '@/tests/stubs/noteCommentPost.stub.js';
+
+const silentLogger = {
+  warn: () => undefined,
+  info: () => undefined,
+  debug: () => undefined,
+};
+
+interface Harness {
+  changedFilesGateway: StubChangedFilesFetchGateway;
+  guardDiffSize: GuardDiffSizeUseCase;
+  noteCommentPostGateway: StubNoteCommentPostGateway;
+  approvalRevocationGateway: StubApprovalRevocationGateway;
+}
+
+function buildHarness(): Harness {
+  const changedFilesGateway = new StubChangedFilesFetchGateway();
+  return {
+    changedFilesGateway,
+    guardDiffSize: new GuardDiffSizeUseCase({ changedFilesFetchGateway: changedFilesGateway }),
+    noteCommentPostGateway: new StubNoteCommentPostGateway(),
+    approvalRevocationGateway: new StubApprovalRevocationGateway(),
+  };
+}
+
+const BUDGET = 2000;
+
+describe('Acceptance — SPEC-209: Guard oversized merge requests', () => {
+  let harness: Harness;
+
+  beforeEach(() => {
+    harness = buildHarness();
+  });
+
+  describe('Rule: a non-oversized MR is processed exactly as before', () => {
+    it('under budget gitlab review → not blocked, no comment, no revocation', async () => {
+      harness.changedFilesGateway.setResponse(
+        42,
+        ChangedFilesFactory.list([{ path: 'src/a.ts', additions: 50, deletions: 10 }]),
+      );
+
+      const result = await applyDiffSizeGuard({
+        projectIdentifier: 'group/project',
+        localPath: '/repo/project',
+        mergeRequestNumber: 42,
+        mode: 'review',
+        deps: {
+          guardDiffSize: harness.guardDiffSize,
+          getMaxDiffLines: () => BUDGET,
+          noteCommentPostGateway: harness.noteCommentPostGateway,
+          approvalRevocationGateway: harness.approvalRevocationGateway,
+        },
+        logger: silentLogger,
+      });
+
+      expect(result.blocked).toBe(false);
+      expect(harness.noteCommentPostGateway.calls).toHaveLength(0);
+      expect(harness.approvalRevocationGateway.calls).toHaveLength(0);
+    });
+
+    it('lockfiles and package.json are excluded from the counted size', async () => {
+      harness.changedFilesGateway.setResponse(
+        7,
+        ChangedFilesFactory.list([
+          { path: 'yarn.lock', additions: 5000, deletions: 0 },
+          { path: 'package.json', additions: 3000, deletions: 0 },
+          { path: 'src/a.ts', additions: 30, deletions: 0 },
+        ]),
+      );
+
+      const result = await applyDiffSizeGuard({
+        projectIdentifier: 'group/project',
+        localPath: '/repo/project',
+        mergeRequestNumber: 7,
+        mode: 'review',
+        deps: {
+          guardDiffSize: harness.guardDiffSize,
+          getMaxDiffLines: () => BUDGET,
+          noteCommentPostGateway: harness.noteCommentPostGateway,
+          approvalRevocationGateway: harness.approvalRevocationGateway,
+        },
+        logger: silentLogger,
+      });
+
+      expect(result.blocked).toBe(false);
+      expect(harness.noteCommentPostGateway.calls).toHaveLength(0);
+    });
+  });
+
+  describe('Rule: an oversized MR requesting a review is blocked with a FR split comment', () => {
+    it('over budget gitlab review → blocked, FR comment posted, no revocation', async () => {
+      harness.changedFilesGateway.setResponse(
+        42,
+        ChangedFilesFactory.list([{ path: 'src/big.ts', additions: 2000, deletions: 500 }]),
+      );
+
+      const result = await applyDiffSizeGuard({
+        projectIdentifier: 'group/project',
+        localPath: '/repo/project',
+        mergeRequestNumber: 42,
+        mode: 'review',
+        deps: {
+          guardDiffSize: harness.guardDiffSize,
+          getMaxDiffLines: () => BUDGET,
+          noteCommentPostGateway: harness.noteCommentPostGateway,
+          approvalRevocationGateway: harness.approvalRevocationGateway,
+        },
+        logger: silentLogger,
+      });
+
+      expect(result.blocked).toBe(true);
+      expect(harness.approvalRevocationGateway.calls).toHaveLength(0);
+      expect(harness.noteCommentPostGateway.calls).toHaveLength(1);
+      const comment = harness.noteCommentPostGateway.calls[0];
+      expect(comment?.projectPath).toBe('group/project');
+      expect(comment?.mrNumber).toBe(42);
+      expect(comment?.body).toContain('2500');
+      expect(comment?.body).toContain('2000');
+    });
+  });
+
+  describe('Rule: an oversized MR approval is revoked with a FR split comment', () => {
+    it('over budget github approve → blocked, revocation + FR comment', async () => {
+      harness.changedFilesGateway.setResponse(
+        99,
+        ChangedFilesFactory.list([{ path: 'src/huge.ts', additions: 2400, deletions: 100 }]),
+      );
+
+      const result = await applyDiffSizeGuard({
+        projectIdentifier: 'owner/repo',
+        localPath: '/repo/project',
+        mergeRequestNumber: 99,
+        mode: 'approve',
+        revokeArgs: { reviewId: 555, dismissalMessage: 'oversized' },
+        deps: {
+          guardDiffSize: harness.guardDiffSize,
+          getMaxDiffLines: () => BUDGET,
+          noteCommentPostGateway: harness.noteCommentPostGateway,
+          approvalRevocationGateway: harness.approvalRevocationGateway,
+        },
+        logger: silentLogger,
+      });
+
+      expect(result.blocked).toBe(true);
+      expect(harness.approvalRevocationGateway.calls).toHaveLength(1);
+      expect(harness.approvalRevocationGateway.calls[0]?.projectPath).toBe('owner/repo');
+      expect(harness.approvalRevocationGateway.calls[0]?.reviewId).toBe(555);
+      expect(harness.noteCommentPostGateway.calls).toHaveLength(1);
+      expect(harness.noteCommentPostGateway.calls[0]?.body).toContain('2500');
+    });
+  });
+
+  describe('Rule: an oversized follow-up push is blocked silently (anti-spam)', () => {
+    it('over budget followup → blocked, no comment, no revocation', async () => {
+      harness.changedFilesGateway.setResponse(
+        42,
+        ChangedFilesFactory.list([{ path: 'src/big.ts', additions: 2400, deletions: 200 }]),
+      );
+
+      const result = await applyDiffSizeGuard({
+        projectIdentifier: 'group/project',
+        localPath: '/repo/project',
+        mergeRequestNumber: 42,
+        mode: 'followup',
+        deps: {
+          guardDiffSize: harness.guardDiffSize,
+          getMaxDiffLines: () => BUDGET,
+          noteCommentPostGateway: harness.noteCommentPostGateway,
+          approvalRevocationGateway: harness.approvalRevocationGateway,
+        },
+        logger: silentLogger,
+      });
+
+      expect(result.blocked).toBe(true);
+      expect(harness.noteCommentPostGateway.calls).toHaveLength(0);
+      expect(harness.approvalRevocationGateway.calls).toHaveLength(0);
+    });
+  });
+
+  describe('Rule: the guard is fail-open when changed files cannot be fetched', () => {
+    it('fetch failure → not blocked, no comment (processed normally)', async () => {
+      harness.changedFilesGateway.setFailure(42);
+
+      const result = await applyDiffSizeGuard({
+        projectIdentifier: 'group/project',
+        localPath: '/repo/project',
+        mergeRequestNumber: 42,
+        mode: 'review',
+        deps: {
+          guardDiffSize: harness.guardDiffSize,
+          getMaxDiffLines: () => BUDGET,
+          noteCommentPostGateway: harness.noteCommentPostGateway,
+          approvalRevocationGateway: harness.approvalRevocationGateway,
+        },
+        logger: silentLogger,
+      });
+
+      expect(result.blocked).toBe(false);
+      expect(harness.noteCommentPostGateway.calls).toHaveLength(0);
+    });
+  });
+});

--- a/src/tests/acceptance/46-github-followup-review-on-push.acceptance.test.ts
+++ b/src/tests/acceptance/46-github-followup-review-on-push.acceptance.test.ts
@@ -181,6 +181,8 @@ function createDefaultDeps(
     enforceBudget: { execute: enforceBudgetExecute },
     broadcastBudgetExceeded: vi.fn(),
     getRepositories: vi.fn(() => []),
+    guardDiffSize: { execute: vi.fn(() => ({ kind: 'allowed' })) },
+    getMaxDiffLines: vi.fn(() => 2000),
   } as unknown as GitHubWebhookDependencies;
 }
 

--- a/src/tests/factories/changedFiles.factory.ts
+++ b/src/tests/factories/changedFiles.factory.ts
@@ -1,0 +1,16 @@
+import type { ChangedFile } from '@/modules/shared-kernel/entities/diffSizeGate/diffSizeGate.js';
+
+export class ChangedFilesFactory {
+  static create(overrides: Partial<ChangedFile> = {}): ChangedFile {
+    return {
+      path: 'src/example.ts',
+      additions: 50,
+      deletions: 10,
+      ...overrides,
+    };
+  }
+
+  static list(files: Array<Partial<ChangedFile>>): ChangedFile[] {
+    return files.map((file) => ChangedFilesFactory.create(file));
+  }
+}

--- a/src/tests/stubs/changedFilesFetch.stub.ts
+++ b/src/tests/stubs/changedFilesFetch.stub.ts
@@ -1,0 +1,28 @@
+import type { ChangedFilesFetchGateway } from '@/modules/shared-kernel/entities/diffSizeGate/changedFilesFetch.gateway.js';
+import type { ChangedFile } from '@/modules/shared-kernel/entities/diffSizeGate/diffSizeGate.js';
+
+export class StubChangedFilesFetchGateway implements ChangedFilesFetchGateway {
+  private responses = new Map<number, ChangedFile[] | null>();
+  private failingMergeRequests = new Set<number>();
+  fetchCallCount = 0;
+  lastProjectIdentifier: string | null = null;
+
+  fetchChangedFiles(projectIdentifier: string, mergeRequestNumber: number): ChangedFile[] | null {
+    this.fetchCallCount++;
+    this.lastProjectIdentifier = projectIdentifier;
+
+    if (this.failingMergeRequests.has(mergeRequestNumber)) {
+      throw new Error(`API error for MR ${mergeRequestNumber}`);
+    }
+
+    return this.responses.get(mergeRequestNumber) ?? null;
+  }
+
+  setResponse(mergeRequestNumber: number, files: ChangedFile[] | null): void {
+    this.responses.set(mergeRequestNumber, files);
+  }
+
+  setFailure(mergeRequestNumber: number): void {
+    this.failingMergeRequests.add(mergeRequestNumber);
+  }
+}

--- a/src/tests/units/config/projectConfig.test.ts
+++ b/src/tests/units/config/projectConfig.test.ts
@@ -161,6 +161,73 @@ describe('loadProjectConfig', () => {
     expect(config?.qualityThreshold).toBe(0);
   });
 
+  it('should leave maxDiffLines undefined when not specified', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({
+        github: true,
+        gitlab: false,
+        defaultModel: 'sonnet',
+        reviewSkill: 'review-front',
+        reviewFollowupSkill: 'review-followup',
+      }),
+    );
+
+    const config = loadProjectConfig('/fake/path');
+
+    expect(config?.maxDiffLines).toBeUndefined();
+  });
+
+  it('should accept a positive integer maxDiffLines', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({
+        github: true,
+        gitlab: false,
+        defaultModel: 'sonnet',
+        reviewSkill: 'review-front',
+        reviewFollowupSkill: 'review-followup',
+        maxDiffLines: 500,
+      }),
+    );
+
+    const config = loadProjectConfig('/fake/path');
+
+    expect(config?.maxDiffLines).toBe(500);
+  });
+
+  it('should reject a non-integer maxDiffLines', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({
+        github: true,
+        gitlab: false,
+        defaultModel: 'sonnet',
+        reviewSkill: 'review-front',
+        reviewFollowupSkill: 'review-followup',
+        maxDiffLines: 500.5,
+      }),
+    );
+
+    expect(() => loadProjectConfig('/fake/path')).toThrow(/maxDiffLines/);
+  });
+
+  it('should reject a maxDiffLines below 1', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({
+        github: true,
+        gitlab: false,
+        defaultModel: 'sonnet',
+        reviewSkill: 'review-front',
+        reviewFollowupSkill: 'review-followup',
+        maxDiffLines: 0,
+      }),
+    );
+
+    expect(() => loadProjectConfig('/fake/path')).toThrow(/maxDiffLines/);
+  });
+
   it('should use custom retentionDays when specified', () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(

--- a/src/tests/units/frameworks/config/configLoader.test.ts
+++ b/src/tests/units/frameworks/config/configLoader.test.ts
@@ -158,6 +158,40 @@ describe('validateAndEnrichConfig', () => {
     });
   });
 
+  describe('maxDiffLines validation (SPEC-209)', () => {
+    it('leaves maxDiffLines undefined when the field is missing', () => {
+      const config = createValidConfig();
+
+      const result = validateAndEnrichConfig(config);
+
+      expect(result.maxDiffLines).toBeUndefined();
+    });
+
+    it('accepts a positive integer maxDiffLines', () => {
+      const config = { ...createValidConfig(), maxDiffLines: 1000 };
+
+      const result = validateAndEnrichConfig(config);
+
+      expect(result.maxDiffLines).toBe(1000);
+    });
+
+    it('rejects a non-integer maxDiffLines with the French message', () => {
+      const config = { ...createValidConfig(), maxDiffLines: 1000.5 };
+
+      expect(() => validateAndEnrichConfig(config)).toThrow(
+        'Configuration invalide : maxDiffLines invalide',
+      );
+    });
+
+    it('rejects a maxDiffLines below 1 with the French message', () => {
+      const config = { ...createValidConfig(), maxDiffLines: 0 };
+
+      expect(() => validateAndEnrichConfig(config)).toThrow(
+        'Configuration invalide : maxDiffLines invalide',
+      );
+    });
+  });
+
   describe('triggerMode validation (SPEC-174)', () => {
     it('default mode when missing: falls back to full-auto', () => {
       const config = createValidConfig();

--- a/src/tests/units/interface-adapters/controllers/webhook/github.controller.test.ts
+++ b/src/tests/units/interface-adapters/controllers/webhook/github.controller.test.ts
@@ -181,6 +181,8 @@ function createMockDeps(): GitHubWebhookDependencies {
     handlePlatformApproval: { execute: vi.fn(() => ({ kind: 'allowed' })) },
     approvalRevocationGateway: { revoke: vi.fn(async () => undefined) },
     getQualityThreshold: vi.fn(() => null),
+    guardDiffSize: { execute: vi.fn(() => ({ kind: 'allowed' })) },
+    getMaxDiffLines: vi.fn(() => 2000),
     now: (): string => '2026-05-26T12:00:00.000Z',
   } as unknown as GitHubWebhookDependencies;
 }

--- a/src/tests/units/interface-adapters/controllers/webhook/gitlab.controller.test.ts
+++ b/src/tests/units/interface-adapters/controllers/webhook/gitlab.controller.test.ts
@@ -100,6 +100,7 @@ import {
   extractBaseUrl,
   buildGitLabReviewProcessor,
 } from '@/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.js';
+import { GuardDiffSizeUseCase } from '@/modules/platform-integration/usecases/guardDiffSize.usecase.js';
 import { IsTrustedActorUseCase } from '@/modules/platform-integration/usecases/isTrustedActor.usecase.js';
 import {
   processWebhook,
@@ -121,6 +122,7 @@ import { verifyGitLabSignature, getGitLabEventType } from '@/security/verifier.j
 import { GitLabEventFactory } from '@/tests/factories/gitLabEvent.factory.js';
 import { TrackedMrFactory } from '@/tests/factories/trackedMr.factory.js';
 import { StubApprovalRevocationGateway } from '@/tests/stubs/approvalRevocation.stub.js';
+import { StubChangedFilesFetchGateway } from '@/tests/stubs/changedFilesFetch.stub.js';
 import { createStubLogger } from '@/tests/stubs/logger.stub.js';
 import { StubMemberAccessGateway } from '@/tests/stubs/memberAccess.stub.js';
 import { StubNoteCommentPostGateway } from '@/tests/stubs/noteCommentPost.stub.js';
@@ -240,6 +242,10 @@ function createDefaultDeps(trackingGateway: ReturnType<typeof createMockTracking
     handlePlatformApproval: new HandlePlatformApprovalUseCase(trackingGateway),
     approvalRevocationGateway: new StubApprovalRevocationGateway(),
     getQualityThreshold: (): number | null => null,
+    guardDiffSize: new GuardDiffSizeUseCase({
+      changedFilesFetchGateway: new StubChangedFilesFetchGateway(),
+    }),
+    getMaxDiffLines: (): number => 2000,
     now: (): string => '2026-05-26T12:00:00.000Z',
   };
 }

--- a/src/tests/units/modules/platform-integration/interface-adapters/controllers/webhook/diffSizeGuard.helper.test.ts
+++ b/src/tests/units/modules/platform-integration/interface-adapters/controllers/webhook/diffSizeGuard.helper.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { applyDiffSizeGuard } from '@/modules/platform-integration/interface-adapters/controllers/webhook/diffSizeGuard.helper.js';
+import { GuardDiffSizeUseCase } from '@/modules/platform-integration/usecases/guardDiffSize.usecase.js';
+import { ChangedFilesFactory } from '@/tests/factories/changedFiles.factory.js';
+import { StubApprovalRevocationGateway } from '@/tests/stubs/approvalRevocation.stub.js';
+import { StubChangedFilesFetchGateway } from '@/tests/stubs/changedFilesFetch.stub.js';
+import { StubNoteCommentPostGateway } from '@/tests/stubs/noteCommentPost.stub.js';
+
+const silentLogger = {
+  warn: () => undefined,
+  info: () => undefined,
+  debug: () => undefined,
+};
+
+interface Harness {
+  changedFilesGateway: StubChangedFilesFetchGateway;
+  guardDiffSize: GuardDiffSizeUseCase;
+  noteCommentPostGateway: StubNoteCommentPostGateway;
+  approvalRevocationGateway: StubApprovalRevocationGateway;
+}
+
+function buildHarness(): Harness {
+  const changedFilesGateway = new StubChangedFilesFetchGateway();
+  return {
+    changedFilesGateway,
+    guardDiffSize: new GuardDiffSizeUseCase({ changedFilesFetchGateway: changedFilesGateway }),
+    noteCommentPostGateway: new StubNoteCommentPostGateway(),
+    approvalRevocationGateway: new StubApprovalRevocationGateway(),
+  };
+}
+
+const OVERSIZED = ChangedFilesFactory.list([
+  { path: 'src/big.ts', additions: 2400, deletions: 200 },
+]);
+const UNDER_BUDGET = ChangedFilesFactory.list([{ path: 'src/a.ts', additions: 50, deletions: 10 }]);
+
+function depsOf(harness: Harness) {
+  return {
+    guardDiffSize: harness.guardDiffSize,
+    getMaxDiffLines: () => 2000,
+    noteCommentPostGateway: harness.noteCommentPostGateway,
+    approvalRevocationGateway: harness.approvalRevocationGateway,
+  };
+}
+
+describe('applyDiffSizeGuard', () => {
+  let harness: Harness;
+
+  beforeEach(() => {
+    harness = buildHarness();
+  });
+
+  it('review mode: blocked posts a comment and does not revoke', async () => {
+    harness.changedFilesGateway.setResponse(42, OVERSIZED);
+
+    const result = await applyDiffSizeGuard({
+      projectIdentifier: 'group/project',
+      localPath: '/repo',
+      mergeRequestNumber: 42,
+      mode: 'review',
+      deps: depsOf(harness),
+      logger: silentLogger,
+    });
+
+    expect(result.blocked).toBe(true);
+    expect(harness.noteCommentPostGateway.calls).toHaveLength(1);
+    expect(harness.noteCommentPostGateway.calls[0]?.projectPath).toBe('group/project');
+    expect(harness.noteCommentPostGateway.calls[0]?.mrNumber).toBe(42);
+    expect(harness.approvalRevocationGateway.calls).toHaveLength(0);
+  });
+
+  it('approve mode: blocked revokes and then posts a comment', async () => {
+    harness.changedFilesGateway.setResponse(99, OVERSIZED);
+
+    const result = await applyDiffSizeGuard({
+      projectIdentifier: 'owner/repo',
+      localPath: '/repo',
+      mergeRequestNumber: 99,
+      mode: 'approve',
+      revokeArgs: { reviewId: 555, dismissalMessage: 'oversized' },
+      deps: depsOf(harness),
+      logger: silentLogger,
+    });
+
+    expect(result.blocked).toBe(true);
+    expect(harness.approvalRevocationGateway.calls).toHaveLength(1);
+    expect(harness.approvalRevocationGateway.calls[0]?.projectPath).toBe('owner/repo');
+    expect(harness.approvalRevocationGateway.calls[0]?.mrNumber).toBe(99);
+    expect(harness.approvalRevocationGateway.calls[0]?.reviewId).toBe(555);
+    expect(harness.noteCommentPostGateway.calls).toHaveLength(1);
+  });
+
+  it('followup mode: blocked stays silent (no comment, no revoke)', async () => {
+    harness.changedFilesGateway.setResponse(42, OVERSIZED);
+
+    const result = await applyDiffSizeGuard({
+      projectIdentifier: 'group/project',
+      localPath: '/repo',
+      mergeRequestNumber: 42,
+      mode: 'followup',
+      deps: depsOf(harness),
+      logger: silentLogger,
+    });
+
+    expect(result.blocked).toBe(true);
+    expect(harness.noteCommentPostGateway.calls).toHaveLength(0);
+    expect(harness.approvalRevocationGateway.calls).toHaveLength(0);
+  });
+
+  it('not blocked when under budget (no comment, no revoke)', async () => {
+    harness.changedFilesGateway.setResponse(42, UNDER_BUDGET);
+
+    const result = await applyDiffSizeGuard({
+      projectIdentifier: 'group/project',
+      localPath: '/repo',
+      mergeRequestNumber: 42,
+      mode: 'review',
+      deps: depsOf(harness),
+      logger: silentLogger,
+    });
+
+    expect(result.blocked).toBe(false);
+    expect(harness.noteCommentPostGateway.calls).toHaveLength(0);
+    expect(harness.approvalRevocationGateway.calls).toHaveLength(0);
+  });
+
+  it('still reports blocked when the revocation gateway throws (best-effort)', async () => {
+    harness.changedFilesGateway.setResponse(99, OVERSIZED);
+    harness.approvalRevocationGateway.shouldThrow = true;
+
+    const result = await applyDiffSizeGuard({
+      projectIdentifier: 'owner/repo',
+      localPath: '/repo',
+      mergeRequestNumber: 99,
+      mode: 'approve',
+      revokeArgs: { reviewId: 555 },
+      deps: depsOf(harness),
+      logger: silentLogger,
+    });
+
+    expect(result.blocked).toBe(true);
+    expect(harness.noteCommentPostGateway.calls).toHaveLength(1);
+  });
+
+  it('still reports blocked when the comment gateway throws (best-effort)', async () => {
+    harness.changedFilesGateway.setResponse(42, OVERSIZED);
+    const throwingComment = {
+      calls: harness.noteCommentPostGateway.calls,
+      postComment: async () => {
+        throw new Error('comment failed');
+      },
+    };
+
+    const result = await applyDiffSizeGuard({
+      projectIdentifier: 'group/project',
+      localPath: '/repo',
+      mergeRequestNumber: 42,
+      mode: 'review',
+      deps: { ...depsOf(harness), noteCommentPostGateway: throwingComment },
+      logger: silentLogger,
+    });
+
+    expect(result.blocked).toBe(true);
+  });
+
+  it('fail-open: not blocked when the changed files fetch fails', async () => {
+    harness.changedFilesGateway.setFailure(42);
+
+    const result = await applyDiffSizeGuard({
+      projectIdentifier: 'group/project',
+      localPath: '/repo',
+      mergeRequestNumber: 42,
+      mode: 'review',
+      deps: depsOf(harness),
+      logger: silentLogger,
+    });
+
+    expect(result.blocked).toBe(false);
+    expect(harness.noteCommentPostGateway.calls).toHaveLength(0);
+  });
+});

--- a/src/tests/units/modules/platform-integration/interface-adapters/controllers/webhook/gitlabIdempotency.controller.test.ts
+++ b/src/tests/units/modules/platform-integration/interface-adapters/controllers/webhook/gitlabIdempotency.controller.test.ts
@@ -60,6 +60,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import type { WebhookEvent } from '@/modules/platform-integration/entities/webhookEvent/webhookEvent.js';
 import { handleGitLabWebhook } from '@/modules/platform-integration/interface-adapters/controllers/webhook/gitlab.controller.js';
 import { InMemoryIdempotencyStore } from '@/modules/platform-integration/interface-adapters/gateways/inMemoryIdempotencyStore.gateway.js';
+import { GuardDiffSizeUseCase } from '@/modules/platform-integration/usecases/guardDiffSize.usecase.js';
 import {
   processWebhook,
   type ProcessWebhookResult,
@@ -80,6 +81,7 @@ import { TransitionStateUseCase } from '@/modules/tracking/usecases/tracking/tra
 import { GitLabEventFactory } from '@/tests/factories/gitLabEvent.factory.js';
 import { TrackedMrFactory } from '@/tests/factories/trackedMr.factory.js';
 import { StubApprovalRevocationGateway } from '@/tests/stubs/approvalRevocation.stub.js';
+import { StubChangedFilesFetchGateway } from '@/tests/stubs/changedFilesFetch.stub.js';
 import { StubIdempotencyStore } from '@/tests/stubs/idempotencyStore.stub.js';
 import { createStubLogger } from '@/tests/stubs/logger.stub.js';
 import { StubNoteCommentPostGateway } from '@/tests/stubs/noteCommentPost.stub.js';
@@ -216,6 +218,10 @@ function createDeps(
     handlePlatformApproval: new HandlePlatformApprovalUseCase(trackingGateway),
     approvalRevocationGateway: new StubApprovalRevocationGateway(),
     getQualityThreshold: (): number | null => null,
+    guardDiffSize: new GuardDiffSizeUseCase({
+      changedFilesFetchGateway: new StubChangedFilesFetchGateway(),
+    }),
+    getMaxDiffLines: (): number => 2000,
     now: (): string => '2026-05-26T12:00:00.000Z',
     ...overrides,
   };

--- a/src/tests/units/modules/platform-integration/interface-adapters/gateways/changedFilesFetch.github.gateway.test.ts
+++ b/src/tests/units/modules/platform-integration/interface-adapters/gateways/changedFilesFetch.github.gateway.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+
+import { GitHubChangedFilesFetchGateway } from '@/modules/platform-integration/interface-adapters/gateways/changedFilesFetch.github.gateway.js';
+
+describe('GitHubChangedFilesFetchGateway', () => {
+  describe('fetchChangedFiles', () => {
+    it('maps filename to path from the GitHub pulls/files API', () => {
+      const stubExecutor = () =>
+        JSON.stringify([
+          { filename: 'src/a.ts', additions: 50, deletions: 10 },
+          { filename: 'yarn.lock', additions: 5000, deletions: 0 },
+        ]);
+
+      const gateway = new GitHubChangedFilesFetchGateway(stubExecutor);
+      const result = gateway.fetchChangedFiles('owner/repo', 42);
+
+      expect(result).toEqual([
+        { path: 'src/a.ts', additions: 50, deletions: 10 },
+        { path: 'yarn.lock', additions: 5000, deletions: 0 },
+      ]);
+    });
+
+    it('calls the paginated files endpoint for the pull request', () => {
+      let capturedCommand = '';
+      const stubExecutor = (command: string) => {
+        capturedCommand = command;
+        return JSON.stringify([]);
+      };
+
+      const gateway = new GitHubChangedFilesFetchGateway(stubExecutor);
+      gateway.fetchChangedFiles('owner/repo', 42);
+
+      expect(capturedCommand).toContain('--paginate');
+      expect(capturedCommand).toContain('repos/owner/repo/pulls/42/files');
+    });
+
+    it('returns null when the executor throws', () => {
+      const gateway = new GitHubChangedFilesFetchGateway(() => {
+        throw new Error('Network error');
+      });
+
+      expect(gateway.fetchChangedFiles('owner/repo', 42)).toBeNull();
+    });
+
+    it('returns null when the response is malformed JSON', () => {
+      const gateway = new GitHubChangedFilesFetchGateway(() => 'not valid json');
+
+      expect(gateway.fetchChangedFiles('owner/repo', 42)).toBeNull();
+    });
+
+    it('returns null when the response is not an array', () => {
+      const gateway = new GitHubChangedFilesFetchGateway(() => JSON.stringify({ message: 'nope' }));
+
+      expect(gateway.fetchChangedFiles('owner/repo', 42)).toBeNull();
+    });
+
+    it('returns null when an entry has a non-numeric additions field', () => {
+      const gateway = new GitHubChangedFilesFetchGateway(() =>
+        JSON.stringify([{ filename: 'src/a.ts', additions: 'lots', deletions: 0 }]),
+      );
+
+      expect(gateway.fetchChangedFiles('owner/repo', 42)).toBeNull();
+    });
+
+    it('returns an empty list for a pull request with no changed files', () => {
+      const gateway = new GitHubChangedFilesFetchGateway(() => JSON.stringify([]));
+
+      expect(gateway.fetchChangedFiles('owner/repo', 42)).toEqual([]);
+    });
+  });
+});

--- a/src/tests/units/modules/platform-integration/interface-adapters/gateways/changedFilesFetch.gitlab.gateway.test.ts
+++ b/src/tests/units/modules/platform-integration/interface-adapters/gateways/changedFilesFetch.gitlab.gateway.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+
+import { GitLabChangedFilesFetchGateway } from '@/modules/platform-integration/interface-adapters/gateways/changedFilesFetch.gitlab.gateway.js';
+
+function graphqlEnvelope(diffStats: unknown): string {
+  return JSON.stringify({ data: { project: { mergeRequest: { diffStats } } } });
+}
+
+describe('GitLabChangedFilesFetchGateway', () => {
+  describe('fetchChangedFiles', () => {
+    it('parses the per-file diffStats array from the GraphQL response', () => {
+      const stubExecutor = () =>
+        graphqlEnvelope([
+          { path: 'src/a.ts', additions: 50, deletions: 10 },
+          { path: 'yarn.lock', additions: 5000, deletions: 0 },
+        ]);
+
+      const gateway = new GitLabChangedFilesFetchGateway(stubExecutor);
+      const result = gateway.fetchChangedFiles('group/project', 42);
+
+      expect(result).toEqual([
+        { path: 'src/a.ts', additions: 50, deletions: 10 },
+        { path: 'yarn.lock', additions: 5000, deletions: 0 },
+      ]);
+    });
+
+    it('emits a GraphQL query with the raw project fullPath and merge request iid', () => {
+      let capturedCommand = '';
+      const stubExecutor = (command: string) => {
+        capturedCommand = command;
+        return graphqlEnvelope([]);
+      };
+
+      const gateway = new GitLabChangedFilesFetchGateway(stubExecutor);
+      gateway.fetchChangedFiles('group/project', 99);
+
+      expect(capturedCommand).toContain('graphql');
+      expect(capturedCommand).toContain('fullPath:"group/project"');
+      expect(capturedCommand).toContain('iid:"99"');
+    });
+
+    it('returns null when the executor throws', () => {
+      const stubExecutor = () => {
+        throw new Error('GraphQL API error');
+      };
+
+      const gateway = new GitLabChangedFilesFetchGateway(stubExecutor);
+
+      expect(gateway.fetchChangedFiles('group/project', 42)).toBeNull();
+    });
+
+    it('returns null when the response is malformed JSON', () => {
+      const gateway = new GitLabChangedFilesFetchGateway(() => 'not valid json');
+
+      expect(gateway.fetchChangedFiles('group/project', 42)).toBeNull();
+    });
+
+    it('returns null when diffStats is missing from the response', () => {
+      const gateway = new GitLabChangedFilesFetchGateway(() =>
+        JSON.stringify({ data: { project: { mergeRequest: null } } }),
+      );
+
+      expect(gateway.fetchChangedFiles('group/project', 42)).toBeNull();
+    });
+
+    it('returns null when a diffStats entry has a non-numeric additions field', () => {
+      const gateway = new GitLabChangedFilesFetchGateway(() =>
+        graphqlEnvelope([{ path: 'src/a.ts', additions: 'lots', deletions: 0 }]),
+      );
+
+      expect(gateway.fetchChangedFiles('group/project', 42)).toBeNull();
+    });
+
+    it('returns an empty list for a merge request with no changed files', () => {
+      const gateway = new GitLabChangedFilesFetchGateway(() => graphqlEnvelope([]));
+
+      expect(gateway.fetchChangedFiles('group/project', 42)).toEqual([]);
+    });
+  });
+});

--- a/src/tests/units/modules/platform-integration/usecases/guardDiffSize.usecase.test.ts
+++ b/src/tests/units/modules/platform-integration/usecases/guardDiffSize.usecase.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+
+import { GuardDiffSizeUseCase } from '@/modules/platform-integration/usecases/guardDiffSize.usecase.js';
+import { ChangedFilesFactory } from '@/tests/factories/changedFiles.factory.js';
+import { StubChangedFilesFetchGateway } from '@/tests/stubs/changedFilesFetch.stub.js';
+
+function buildUseCase(): {
+  gateway: StubChangedFilesFetchGateway;
+  useCase: GuardDiffSizeUseCase;
+} {
+  const gateway = new StubChangedFilesFetchGateway();
+  return { gateway, useCase: new GuardDiffSizeUseCase({ changedFilesFetchGateway: gateway }) };
+}
+
+describe('GuardDiffSizeUseCase', () => {
+  it('blocks an oversized merge request with counted lines and budget in the message', () => {
+    const { gateway, useCase } = buildUseCase();
+    gateway.setResponse(
+      42,
+      ChangedFilesFactory.list([{ path: 'src/big.ts', additions: 2000, deletions: 500 }]),
+    );
+
+    const verdict = useCase.execute({
+      projectIdentifier: 'group/project',
+      mergeRequestNumber: 42,
+      budget: 2000,
+    });
+
+    expect(verdict.kind).toBe('blocked');
+    if (verdict.kind === 'blocked') {
+      expect(verdict.countedLines).toBe(2500);
+      expect(verdict.budget).toBe(2000);
+      expect(verdict.message).toContain('2500');
+      expect(verdict.message).toContain('2000');
+    }
+  });
+
+  it('allows a merge request under the budget without a message', () => {
+    const { gateway, useCase } = buildUseCase();
+    gateway.setResponse(
+      42,
+      ChangedFilesFactory.list([{ path: 'src/a.ts', additions: 50, deletions: 10 }]),
+    );
+
+    const verdict = useCase.execute({
+      projectIdentifier: 'group/project',
+      mergeRequestNumber: 42,
+      budget: 2000,
+    });
+
+    expect(verdict).toEqual({ kind: 'allowed' });
+  });
+
+  it('posts a French split message mentioning actionable tips', () => {
+    const { gateway, useCase } = buildUseCase();
+    gateway.setResponse(
+      42,
+      ChangedFilesFactory.list([{ path: 'src/big.ts', additions: 2100, deletions: 0 }]),
+    );
+
+    const verdict = useCase.execute({
+      projectIdentifier: 'group/project',
+      mergeRequestNumber: 42,
+      budget: 2000,
+    });
+
+    expect(verdict.kind).toBe('blocked');
+    if (verdict.kind === 'blocked') {
+      expect(verdict.message).toContain('Revue refusée');
+      expect(verdict.message).toContain('découpez');
+    }
+  });
+
+  it('is fail-open when the gateway throws (processed normally, no message)', () => {
+    const { gateway, useCase } = buildUseCase();
+    gateway.setFailure(42);
+
+    const verdict = useCase.execute({
+      projectIdentifier: 'group/project',
+      mergeRequestNumber: 42,
+      budget: 2000,
+    });
+
+    expect(verdict).toEqual({ kind: 'allowed' });
+  });
+
+  it('is fail-open when the gateway returns null (no changed files available)', () => {
+    const { gateway, useCase } = buildUseCase();
+    gateway.setResponse(42, null);
+
+    const verdict = useCase.execute({
+      projectIdentifier: 'group/project',
+      mergeRequestNumber: 42,
+      budget: 2000,
+    });
+
+    expect(verdict).toEqual({ kind: 'allowed' });
+  });
+
+  it('blocks against a per-repo override budget below the counted size', () => {
+    const { gateway, useCase } = buildUseCase();
+    gateway.setResponse(
+      42,
+      ChangedFilesFactory.list([{ path: 'src/a.ts', additions: 800, deletions: 0 }]),
+    );
+
+    const verdict = useCase.execute({
+      projectIdentifier: 'group/project',
+      mergeRequestNumber: 42,
+      budget: 500,
+    });
+
+    expect(verdict.kind).toBe('blocked');
+  });
+
+  it('blocks against the default budget when counted size exceeds 2000', () => {
+    const { gateway, useCase } = buildUseCase();
+    gateway.setResponse(
+      42,
+      ChangedFilesFactory.list([{ path: 'src/a.ts', additions: 2100, deletions: 0 }]),
+    );
+
+    const verdict = useCase.execute({
+      projectIdentifier: 'group/project',
+      mergeRequestNumber: 42,
+      budget: 2000,
+    });
+
+    expect(verdict.kind).toBe('blocked');
+  });
+});

--- a/src/tests/units/modules/shared-kernel/entities/diffSizeGate/diffSizeGate.test.ts
+++ b/src/tests/units/modules/shared-kernel/entities/diffSizeGate/diffSizeGate.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+
+import { evaluateDiffSizeGate } from '@/modules/shared-kernel/entities/diffSizeGate/diffSizeGate.js';
+
+describe('evaluateDiffSizeGate', () => {
+  it('excludes lockfiles from the counted size', () => {
+    const result = evaluateDiffSizeGate({
+      files: [
+        { path: 'yarn.lock', additions: 5000, deletions: 0 },
+        { path: 'src/a.ts', additions: 30, deletions: 0 },
+      ],
+      budget: 2000,
+    });
+
+    expect(result.countedLines).toBe(30);
+    expect(result.oversized).toBe(false);
+  });
+
+  it('excludes package.json from the counted size', () => {
+    const result = evaluateDiffSizeGate({
+      files: [
+        { path: 'package.json', additions: 3000, deletions: 0 },
+        { path: 'src/a.ts', additions: 10, deletions: 0 },
+      ],
+      budget: 2000,
+    });
+
+    expect(result.countedLines).toBe(10);
+    expect(result.oversized).toBe(false);
+  });
+
+  it('excludes a lockfile referenced by a nested path (matched by basename)', () => {
+    const result = evaluateDiffSizeGate({
+      files: [
+        { path: 'frontend/yarn.lock', additions: 4000, deletions: 0 },
+        { path: 'src/a.ts', additions: 20, deletions: 5 },
+      ],
+      budget: 2000,
+    });
+
+    expect(result.countedLines).toBe(25);
+  });
+
+  it('sums additions and deletions over counted files', () => {
+    const result = evaluateDiffSizeGate({
+      files: [
+        { path: 'src/a.ts', additions: 50, deletions: 10 },
+        { path: 'src/b.ts', additions: 5, deletions: 5 },
+      ],
+      budget: 2000,
+    });
+
+    expect(result.countedLines).toBe(70);
+  });
+
+  it('is not oversized when the counted size equals the budget', () => {
+    const result = evaluateDiffSizeGate({
+      files: [{ path: 'src/a.ts', additions: 2000, deletions: 0 }],
+      budget: 2000,
+    });
+
+    expect(result.oversized).toBe(false);
+  });
+
+  it('is oversized when the counted size is strictly greater than the budget', () => {
+    const result = evaluateDiffSizeGate({
+      files: [{ path: 'src/a.ts', additions: 2000, deletions: 1 }],
+      budget: 2000,
+    });
+
+    expect(result.oversized).toBe(true);
+    expect(result.countedLines).toBe(2001);
+  });
+
+  it('returns zero counted lines for an empty file list', () => {
+    const result = evaluateDiffSizeGate({ files: [], budget: 2000 });
+
+    expect(result.countedLines).toBe(0);
+    expect(result.oversized).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements SPEC-209: a configurable line-size guard for merge/pull requests.

- Counted size = `additions + deletions` over changed files, excluding `package.json` and lock files (`yarn.lock`, `package-lock.json`, `pnpm-lock.yaml`)
- Budget resolved per-repo (`.claude/reviews/config.json` `maxDiffLines`) → global (`config.json`) → default `2000`
- Oversized MR: **review** blocked + FR split comment, **follow-up** blocked silently (anti-spam), **approval** revoked + FR comment
- **Fail-open**: a fetch failure never blocks an MR
- GitLab + GitHub (new per-file gateway: GraphQL `diffStats` / `gh api --paginate pulls/{n}/files`)

Reuses existing `ApprovalRevocationGateway`, `NoteCommentPostGateway`, the `handlePlatformApproval` verdict pattern, and the `getQualityThreshold` resolver pattern.

## Tests

`yarn verify` green: typecheck + lint + format + **3988 tests** (0 failures). New unit/usecase/gateway/helper tests + outer-loop acceptance test.

Spec: `docs/specs/209-mr-size-guard.md` · Plan: `docs/plans/209-mr-size-guard.plan.md` · Report: `docs/reports/209-mr-size-guard.report.md`