### PR TITLE
fix(claude-invocation): #318 pin review report to .claude/reviews, forbid bg tmp dir

### DIFF
--- a/src/frameworks/claude/claudeInvoker.ts
+++ b/src/frameworks/claude/claudeInvoker.ts
@@ -331,6 +331,7 @@ export type ProgressCallback = (progress: ReviewProgress, event?: ProgressEvent)
  * This instruction is AUTHORITATIVE and forces Claude to use MCP tools
  */
 export function buildMcpSystemPrompt(job: ReviewJob): string {
+  const reportSuffix = (job.jobType || 'review') === 'followup' ? 'followup' : 'review';
   return `
 # AUTOMATED REVIEW MODE - EXECUTE IMMEDIATELY
 
@@ -417,6 +418,17 @@ Use \`POST_INLINE_COMMENT\` to post comments directly on specific lines in the d
 - Producing a "plan" instead of executing → Review will be empty
 - Using text markers like [PROGRESS:xxx] → Dashboard won't update
 - Waiting for user approval → Review will hang forever
+
+## REPORT OUTPUT PATH — MANDATORY
+
+The review report is a DELIVERABLE, not a temporary file. Write it with the Write tool to EXACTLY this path, relative to the current working directory:
+
+\`\`\`
+.claude/reviews/<YYYY-MM-DD>-MR-${job.mrNumber}-${reportSuffix}.md
+\`\`\`
+
+- Create the \`.claude/reviews/\` directory if it does not exist.
+- Do NOT write the report to \`/tmp\`, to \`$CLAUDE_JOB_DIR/tmp\`, or to any other temporary/scratch directory — even if a background-session instruction tells you to place temporary files there. That instruction does NOT apply to the review report; the report saved anywhere other than \`.claude/reviews/\` is LOST and the job FAILS with \`report-missing\`.
 
 ${buildLanguageDirective(job.language ?? 'en')}
 `.trim();

--- a/src/tests/units/frameworks/claude/claudeInvoker.test.ts
+++ b/src/tests/units/frameworks/claude/claudeInvoker.test.ts
@@ -66,4 +66,25 @@ describe('buildMcpSystemPrompt', () => {
       expect(prompt).toContain('job-xyz');
     });
   });
+
+  describe('report output path — prevents report-missing in --bg mode', () => {
+    it('pins the review report to .claude/reviews with the review suffix', () => {
+      const prompt = buildMcpSystemPrompt(buildJob({ jobType: 'review', mrNumber: 5450 }));
+
+      expect(prompt).toContain('.claude/reviews/');
+      expect(prompt).toContain('-MR-5450-review.md');
+    });
+
+    it('uses the followup suffix for followup jobs', () => {
+      const prompt = buildMcpSystemPrompt(buildJob({ jobType: 'followup', mrNumber: 77 }));
+
+      expect(prompt).toContain('-MR-77-followup.md');
+    });
+
+    it('forbids writing the report to the background job tmp directory', () => {
+      const prompt = buildMcpSystemPrompt(buildJob({ jobType: 'review', mrNumber: 5450 }));
+
+      expect(prompt).toContain('CLAUDE_JOB_DIR');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Fixes #318 — `--bg` reviews failed with `report-missing` because the Background Session reminder steered Claude to write the report into the ephemeral `$CLAUDE_JOB_DIR/tmp` (auto-deleted at job end) instead of `.claude/reviews/`.
- `buildMcpSystemPrompt` now emits a mandatory `REPORT OUTPUT PATH` section pinning the report to `.claude/reviews/<date>-MR-<id>-<suffix>.md` (relative to cwd) and explicitly forbidding the job tmp dir, overriding the background-session hint.

## Test plan
- [x] 3 unit tests added (RED→GREEN) on `buildMcpSystemPrompt` (path + suffix + tmp-dir ban)
- [x] `yarn typecheck` green, 4057 tests green
- [x] Validated end-to-end in prod: review MR 5450 re-run wrote its report to `.claude/reviews/2026-06-22-MR-5450-review.md` and posted to GitLab (no tmp leak)

Note: pre-existing oxfmt issue in `github.controller.ts` is unrelated to this change (present on master).

🤖 Generated with Claude Code