### PR TITLE
fix(worktree): self-heal orphaned dirs flagged as branch-not-found

### DIFF
--- a/src/modules/worktree-management/interface-adapters/gateways/worktree.fileSystem.gateway.ts
+++ b/src/modules/worktree-management/interface-adapters/gateways/worktree.fileSystem.gateway.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, rmSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 import type { GitCommandExecutor } from '@/modules/worktree-management/entities/gitCommand/gitCommand.gateway.js';
@@ -50,6 +50,7 @@ export class WorktreeFileSystemGateway implements WorktreeGateway {
       {
         executor: this.executor,
         worktreeExists: async (path) => existsSync(path),
+        removeDirectory: async (path) => rmSync(path, { recursive: true, force: true }),
         writeWorktreeSettings,
       },
     );

--- a/src/modules/worktree-management/usecases/ensureWorktree.usecase.ts
+++ b/src/modules/worktree-management/usecases/ensureWorktree.usecase.ts
@@ -28,11 +28,24 @@ export interface WorktreeSettingsWriteResult {
 export interface EnsureWorktreeDependencies {
   executor: GitCommandExecutor;
   worktreeExists: (path: WorktreePath) => Promise<boolean>;
+  removeDirectory: (path: WorktreePath) => Promise<void>;
   writeWorktreeSettings: (path: WorktreePath) => Promise<WorktreeSettingsWriteResult>;
 }
 
 function isFetchFailure(result: GitCommandResult): boolean {
   return result.exitCode !== 0;
+}
+
+async function isHealthyWorktree(
+  executor: GitCommandExecutor,
+  targetPath: WorktreePath,
+): Promise<boolean> {
+  const result = await executor.execute({
+    kind: 'rev-parse-toplevel',
+    args: ['rev-parse', '--show-toplevel'],
+    cwd: targetPath,
+  });
+  return result.exitCode === 0;
 }
 
 export async function ensureWorktree(
@@ -50,7 +63,7 @@ export async function ensureWorktree(
 
   const alreadyExists = await deps.worktreeExists(targetPath);
 
-  if (alreadyExists) {
+  if (alreadyExists && (await isHealthyWorktree(deps.executor, targetPath))) {
     const fetchInsideResult = await deps.executor.execute({
       kind: 'fetch',
       args: ['fetch', fetchRef.remote, fetchRef.refspec],
@@ -70,6 +83,15 @@ export async function ensureWorktree(
     }
 
     return { status: 'reused', path: targetPath };
+  }
+
+  if (alreadyExists) {
+    await deps.removeDirectory(targetPath);
+    await deps.executor.execute({
+      kind: 'worktree-prune',
+      args: ['worktree', 'prune'],
+      cwd: input.sourceCheckoutPath,
+    });
   }
 
   const fetchResult = await deps.executor.execute({

--- a/src/tests/acceptance/170-prebuilt-worktree-lifecycle.acceptance.test.ts
+++ b/src/tests/acceptance/170-prebuilt-worktree-lifecycle.acceptance.test.ts
@@ -62,6 +62,7 @@ describe('Acceptance — SPEC-170: Pre-built Worktree Lifecycle', () => {
         {
           executor,
           worktreeExists: async () => false,
+          removeDirectory: async () => {},
           writeWorktreeSettings: async (path) => {
             writeSettingsCalls.push(path);
             return { status: 'ok' };
@@ -109,6 +110,7 @@ describe('Acceptance — SPEC-170: Pre-built Worktree Lifecycle', () => {
         {
           executor,
           worktreeExists: async () => true,
+          removeDirectory: async () => {},
           writeWorktreeSettings: async (path) => {
             writeSettingsCalls.push(path);
             return { status: 'ok' };
@@ -385,6 +387,7 @@ describe('Acceptance — SPEC-170: Pre-built Worktree Lifecycle', () => {
         {
           executor,
           worktreeExists: async () => false,
+          removeDirectory: async () => {},
           writeWorktreeSettings: async () => ({ status: 'ok' }),
         },
       );

--- a/src/tests/units/modules/worktree-management/usecases/ensureWorktree.usecase.test.ts
+++ b/src/tests/units/modules/worktree-management/usecases/ensureWorktree.usecase.test.ts
@@ -2,16 +2,40 @@ import { describe, it, expect, beforeEach } from 'vitest';
 
 import { deriveWorktreePath } from '@/modules/worktree-management/entities/worktree/worktree.js';
 import type { WorktreeIdentity } from '@/modules/worktree-management/entities/worktree/worktree.schema.js';
-import { ensureWorktree } from '@/modules/worktree-management/usecases/ensureWorktree.usecase.js';
+import {
+  ensureWorktree,
+  type EnsureWorktreeDependencies,
+} from '@/modules/worktree-management/usecases/ensureWorktree.usecase.js';
 import { StubGitCommandExecutor } from '@/tests/stubs/gitCommandExecutor.stub.js';
 
 interface StubFileSystem {
   existingPaths: Set<string>;
   settingsWrites: { path: string; content: string }[];
+  removedDirectories: string[];
 }
 
 function buildStubFileSystem(): StubFileSystem {
-  return { existingPaths: new Set(), settingsWrites: [] };
+  return { existingPaths: new Set(), settingsWrites: [], removedDirectories: [] };
+}
+
+function buildDeps(
+  executor: StubGitCommandExecutor,
+  fileSystem: StubFileSystem,
+  overrides: Partial<EnsureWorktreeDependencies> = {},
+): EnsureWorktreeDependencies {
+  return {
+    executor,
+    worktreeExists: async (path) => fileSystem.existingPaths.has(path),
+    removeDirectory: async (path) => {
+      fileSystem.removedDirectories.push(path);
+      fileSystem.existingPaths.delete(path);
+    },
+    writeWorktreeSettings: async (path) => {
+      fileSystem.settingsWrites.push({ path, content: 'settings' });
+      return { status: 'ok' };
+    },
+    ...overrides,
+  };
 }
 
 const identity: WorktreeIdentity = {
@@ -38,14 +62,7 @@ describe('ensureWorktree use case', () => {
         source: { kind: 'origin' },
         sourceCheckoutPath: '/repo',
       },
-      {
-        executor,
-        worktreeExists: async (path) => fileSystem.existingPaths.has(path),
-        writeWorktreeSettings: async (path) => {
-          fileSystem.settingsWrites.push({ path, content: 'settings' });
-          return { status: 'ok' };
-        },
-      },
+      buildDeps(executor, fileSystem),
     );
 
     expect(result).toEqual({ status: 'created', path: expectedPath, settingsWarning: null });
@@ -55,7 +72,7 @@ describe('ensureWorktree use case', () => {
     expect(fileSystem.settingsWrites).toEqual([{ path: expectedPath, content: 'settings' }]);
   });
 
-  it('reuses an existing worktree by fast-forwarding it', async () => {
+  it('reuses a healthy existing worktree by fast-forwarding it', async () => {
     fileSystem.existingPaths.add(expectedPath);
 
     const result = await ensureWorktree(
@@ -65,20 +82,45 @@ describe('ensureWorktree use case', () => {
         source: { kind: 'origin' },
         sourceCheckoutPath: '/repo',
       },
-      {
-        executor,
-        worktreeExists: async (path) => fileSystem.existingPaths.has(path),
-        writeWorktreeSettings: async (path) => {
-          fileSystem.settingsWrites.push({ path, content: 'settings' });
-          return { status: 'ok' };
-        },
-      },
+      buildDeps(executor, fileSystem),
     );
 
     expect(result).toEqual({ status: 'reused', path: expectedPath });
     const kinds = executor.calls.map((c) => c.kind);
-    expect(kinds).toEqual(['worktree-prune', 'fetch', 'reset-hard']);
+    expect(kinds).toEqual(['worktree-prune', 'rev-parse-toplevel', 'fetch', 'reset-hard']);
     expect(executor.callsOfKind('worktree-add')).toHaveLength(0);
+    expect(fileSystem.removedDirectories).toEqual([]);
+  });
+
+  it('self-heals a broken worktree directory by removing it and recreating', async () => {
+    fileSystem.existingPaths.add(expectedPath);
+    executor.programResponse('rev-parse-toplevel', {
+      exitCode: 128,
+      stdout: '',
+      stderr: 'fatal: not a git repository',
+    });
+
+    const result = await ensureWorktree(
+      {
+        identity,
+        sourceBranch: 'feat/x',
+        source: { kind: 'origin' },
+        sourceCheckoutPath: '/repo',
+      },
+      buildDeps(executor, fileSystem),
+    );
+
+    expect(result).toEqual({ status: 'created', path: expectedPath, settingsWarning: null });
+    expect(fileSystem.removedDirectories).toEqual([expectedPath]);
+    const kinds = executor.calls.map((c) => c.kind);
+    expect(kinds).toEqual([
+      'worktree-prune',
+      'rev-parse-toplevel',
+      'worktree-prune',
+      'fetch',
+      'worktree-add',
+    ]);
+    expect(executor.callsOfKind('worktree-add')[0]?.cwd).toBe('/repo');
   });
 
   it('uses the fork URL as remote when the source is a fork', async () => {
@@ -89,11 +131,7 @@ describe('ensureWorktree use case', () => {
         source: { kind: 'fork', cloneUrl: 'https://github.com/contributor/fork.git' },
         sourceCheckoutPath: '/repo',
       },
-      {
-        executor,
-        worktreeExists: async (path) => fileSystem.existingPaths.has(path),
-        writeWorktreeSettings: async () => ({ status: 'ok' }),
-      },
+      buildDeps(executor, fileSystem),
     );
 
     const fetchCall = executor.callsOfKind('fetch')[0];
@@ -103,7 +141,7 @@ describe('ensureWorktree use case', () => {
     expect(addCall?.args).toContain(`refs/remotes/pr-${identity.mrNumber}/head`);
   });
 
-  it('returns branch-not-found when the fetch fails', async () => {
+  it('returns branch-not-found when the fetch fails on a fresh create', async () => {
     executor.programResponse('fetch', {
       exitCode: 128,
       stdout: '',
@@ -117,17 +155,39 @@ describe('ensureWorktree use case', () => {
         source: { kind: 'origin' },
         sourceCheckoutPath: '/repo',
       },
-      {
-        executor,
-        worktreeExists: async () => false,
-        writeWorktreeSettings: async () => ({ status: 'ok' }),
-      },
+      buildDeps(executor, fileSystem),
     );
 
     expect(result.status).toBe('failed');
     if (result.status === 'failed') {
       expect(result.reason).toBe('branch-not-found');
     }
+    expect(executor.callsOfKind('worktree-add')).toHaveLength(0);
+  });
+
+  it('returns branch-not-found when a healthy worktree branch was deleted on the remote', async () => {
+    fileSystem.existingPaths.add(expectedPath);
+    executor.programResponse('fetch', {
+      exitCode: 128,
+      stdout: '',
+      stderr: "fatal: couldn't find remote ref feat/x",
+    });
+
+    const result = await ensureWorktree(
+      {
+        identity,
+        sourceBranch: 'feat/x',
+        source: { kind: 'origin' },
+        sourceCheckoutPath: '/repo',
+      },
+      buildDeps(executor, fileSystem),
+    );
+
+    expect(result.status).toBe('failed');
+    if (result.status === 'failed') {
+      expect(result.reason).toBe('branch-not-found');
+    }
+    expect(fileSystem.removedDirectories).toEqual([]);
     expect(executor.callsOfKind('worktree-add')).toHaveLength(0);
   });
 
@@ -139,11 +199,9 @@ describe('ensureWorktree use case', () => {
         source: { kind: 'origin' },
         sourceCheckoutPath: '/repo',
       },
-      {
-        executor,
-        worktreeExists: async () => false,
+      buildDeps(executor, fileSystem, {
         writeWorktreeSettings: async () => ({ status: 'failed', reason: 'disk-full' }),
-      },
+      }),
     );
 
     expect(result.status).toBe('created');


### PR DESCRIPTION
## Summary
- `ensureWorktree` only checked directory existence before fetching inside it. An orphaned worktree dir (deregistered from git, no `.git` link — e.g. left behind by a manual `git worktree prune`/`remove` during a debug session) passed that check, so `git fetch` ran in a non-git directory, failed with exit 128, and was mislabeled as `branch-not-found`.
- Real-world impact: GitLab MR 5455 review failed with `branch-not-found` even though the branch existed.
- Reuse path now probes worktree health via `git rev-parse --show-toplevel`:
  - **Healthy** → fetch + reset as before (a genuinely deleted remote branch still yields a legitimate `branch-not-found`, worktree not destroyed).
  - **Broken/orphaned** → `removeDirectory` + `prune`, then recreate via the create path (**self-heal**).
- New gateway dependency `removeDirectory` (`rmSync` recursive/force).

## Test plan
- [x] TDD: RED → GREEN (self-heal, branch-not-found on healthy deleted branch, reuse unchanged)
- [x] `yarn typecheck` green
- [x] `yarn test:ci` green (4061 tests)
- [ ] Note: `yarn verify` has a pre-existing unrelated format drift in `github.controller.ts` (committed on master, untouched here)

🤖 Generated with Claude Code