### PR TITLE
fix(docs): unbreak VitePress build (spec-209 plan unclosed tag)

### DIFF
--- a/docs/plans/209-mr-size-guard.plan.md
+++ b/docs/plans/209-mr-size-guard.plan.md
@@ -99,7 +99,7 @@ DESIGN NOTE — keep budget resolution OUT of these files. Resolution (per-proje
     4. if oversized → `{ kind: 'blocked', countedLines, budget, message: buildSplitMessage(countedLines, budget) }`
   `buildSplitMessage(countedLines, budget)` — free function in the usecase file (mirrors `buildRevertMessage`):
     concise FR comment stating `countedLines` vs `budget` + 2-3 split tips. NOT verbose. Draft:
-    > « Revue refusée : cette MR fait <countedLines> lignes comptées (budget <budget>). Pour faciliter la revue, découpez-la : 1) séparez refactorings et nouvelles fonctionnalités, 2) extrayez les changements indépendants dans des MR dédiées, 3) limitez chaque MR à une seule intention. »
+    > « Revue refusée : cette MR fait &lt;countedLines&gt; lignes comptées (budget &lt;budget&gt;). Pour faciliter la revue, découpez-la : 1) séparez refactorings et nouvelles fonctionnalités, 2) extrayez les changements indépendants dans des MR dédiées, 3) limitez chaque MR à une seule intention. »
     (tips wording left negotiable per spec.)
 
 ## SHARED HELPER (controller-level, DRY across 6 sites)


### PR DESCRIPTION
## Problem
The "Deploy Docs" workflow has failed on every push to master since 2026-06-22 (spec-209 merge); last green was spec-208. Root cause: `docs/plans/209-mr-size-guard.plan.md` has a blockquote with `<countedLines>`/`<budget>` placeholders that the Vue markdown compiler reads as unclosed HTML tags → `Element is missing end tag`.

## Fix
Escape the two placeholders as `&lt;…&gt;`. One line, no content change.

## Verification
`yarn docs:build` → `build complete in 21.97s` (was: build error). Not caused by the recent stats merge; this just resurfaced the pre-existing breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)