### PR TITLE
fix(setup): stop validating global config against the wrong file

### DIFF
--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -2461,6 +2461,13 @@
 
     function syncAvailableRepositoriesFromResponse(payload) {
       availableRepositories = Array.isArray(payload?.repositories) ? payload.repositories : [];
+      updateSetupCtaVisibility();
+    }
+
+    function updateSetupCtaVisibility() {
+      const cta = document.getElementById('setup-cta');
+      if (!cta) return;
+      cta.classList.toggle('hidden', availableRepositories.length > 0);
     }
 
     function renderCardCounters() {
@@ -2734,6 +2741,7 @@
 
     async function initOverviewAndTabs() {
       await fetchAvailableRepositories();
+      updateSetupCtaVisibility();
       renderManagePanel();
       bindManagePanelToggle();
       bindSettingsModalTrigger();

--- a/src/modules/setup-wizard/interface-adapters/gateways/validation.adapter.gateway.ts
+++ b/src/modules/setup-wizard/interface-adapters/gateways/validation.adapter.gateway.ts
@@ -1,5 +1,4 @@
 import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
 import { ValidateConfigUseCase } from '@/modules/cli-configuration/usecases/cli/validateConfig.usecase.js';
 import type {
@@ -15,11 +14,17 @@ interface ValidationAdapterGatewayDependencies {
 export class ValidationAdapterGateway implements ValidationGateway {
   constructor(private readonly deps: ValidationAdapterGatewayDependencies) {}
 
-  validate(projectPath: string): ValidationReport {
+  // `projectPath` is part of the ValidationGateway contract but unused here: this
+  // gateway validates the global CLI config (server/user/queue), never the
+  // per-project `.claude/reviews/config.json` (github/gitlab/reviewSkill schema).
+  // Swapping in the project file used to make this check fail for every
+  // already-configured project, since that file never has a server/user/queue section.
+  validate(_projectPath: string): ValidationReport {
     const useCase = new ValidateConfigUseCase({ existsSync, readFileSync });
-    const projectConfigPath = join(projectPath, '.claude', 'reviews', 'config.json');
-    const cliConfigPath = existsSync(projectConfigPath) ? projectConfigPath : this.deps.configPath;
-    const result = useCase.execute({ configPath: cliConfigPath, envPath: this.deps.envPath });
+    const result = useCase.execute({
+      configPath: this.deps.configPath,
+      envPath: this.deps.envPath,
+    });
     return {
       status: result.status,
       issues: result.issues.map((issue) => ({

--- a/src/tests/units/modules/setup-wizard/interface-adapters/gateways/validation.adapter.gateway.test.ts
+++ b/src/tests/units/modules/setup-wizard/interface-adapters/gateways/validation.adapter.gateway.test.ts
@@ -12,6 +12,16 @@ const VALID_CONFIG = {
   queue: { concurrency: 1 },
 };
 
+// Shape written by GenerateFilesStep into every configured project's
+// .claude/reviews/config.json — deliberately has no server/user/queue section.
+const REAL_PROJECT_REVIEW_CONFIG = {
+  github: true,
+  gitlab: false,
+  defaultModel: 'sonnet',
+  reviewSkill: 'review-code',
+  reviewFollowupSkill: 'review-followup',
+};
+
 function writeJson(path: string, value: unknown): void {
   writeFileSync(path, JSON.stringify(value));
 }
@@ -19,14 +29,14 @@ function writeJson(path: string, value: unknown): void {
 describe('ValidationAdapterGateway (integration with real filesystem)', () => {
   let rootDir: string;
   let projectPath: string;
-  let fallbackConfigPath: string;
+  let configPath: string;
   let envPath: string;
 
   beforeEach(() => {
     rootDir = mkdtempSync(join(tmpdir(), 'reviewflow-validation-adapter-'));
     projectPath = join(rootDir, 'project');
     mkdirSync(projectPath, { recursive: true });
-    fallbackConfigPath = join(rootDir, 'fallback-config.json');
+    configPath = join(rootDir, 'config.json');
     envPath = join(rootDir, '.env');
   });
 
@@ -34,32 +44,32 @@ describe('ValidationAdapterGateway (integration with real filesystem)', () => {
     rmSync(rootDir, { recursive: true, force: true });
   });
 
-  it('reports valid when the project config and env file are present and correct', () => {
-    const projectConfigPath = join(projectPath, '.claude', 'reviews', 'config.json');
+  it('validates the global CLI config regardless of the project path', () => {
+    writeJson(configPath, VALID_CONFIG);
+    writeFileSync(envPath, 'TOKEN=value\n');
+
+    const gateway = new ValidationAdapterGateway({ configPath, envPath });
+    const report = gateway.validate(projectPath);
+
+    expect(report.status).toBe('valid');
+    expect(report.issues).toEqual([]);
+  });
+
+  it('does not mistake a per-project .claude/reviews/config.json for the global config', () => {
     mkdirSync(join(projectPath, '.claude', 'reviews'), { recursive: true });
-    writeJson(projectConfigPath, VALID_CONFIG);
+    writeJson(join(projectPath, '.claude', 'reviews', 'config.json'), REAL_PROJECT_REVIEW_CONFIG);
+    writeJson(configPath, VALID_CONFIG);
     writeFileSync(envPath, 'TOKEN=value\n');
 
-    const gateway = new ValidationAdapterGateway({ configPath: fallbackConfigPath, envPath });
+    const gateway = new ValidationAdapterGateway({ configPath, envPath });
     const report = gateway.validate(projectPath);
 
     expect(report.status).toBe('valid');
     expect(report.issues).toEqual([]);
   });
 
-  it('falls back to the dependency config path when the project config is absent', () => {
-    writeJson(fallbackConfigPath, VALID_CONFIG);
-    writeFileSync(envPath, 'TOKEN=value\n');
-
-    const gateway = new ValidationAdapterGateway({ configPath: fallbackConfigPath, envPath });
-    const report = gateway.validate(projectPath);
-
-    expect(report.status).toBe('valid');
-    expect(report.issues).toEqual([]);
-  });
-
-  it('reports not-found when neither project nor fallback config exists', () => {
-    const gateway = new ValidationAdapterGateway({ configPath: fallbackConfigPath, envPath });
+  it('reports not-found when the global config does not exist', () => {
+    const gateway = new ValidationAdapterGateway({ configPath, envPath });
     const report = gateway.validate(projectPath);
 
     expect(report.status).toBe('not-found');
@@ -67,9 +77,9 @@ describe('ValidationAdapterGateway (integration with real filesystem)', () => {
   });
 
   it('maps each validation issue field, message and severity', () => {
-    writeJson(fallbackConfigPath, { server: { port: 70000 } });
+    writeJson(configPath, { server: { port: 70000 } });
 
-    const gateway = new ValidationAdapterGateway({ configPath: fallbackConfigPath, envPath });
+    const gateway = new ValidationAdapterGateway({ configPath, envPath });
     const report = gateway.validate(projectPath);
 
     expect(report.status).toBe('invalid');


### PR DESCRIPTION
## Summary
- `ValidationAdapterGateway` swapped in the project's `.claude/reviews/config.json` (github/gitlab/reviewSkill/agents schema) for the global CLI config whenever that file existed, then ran it through `ValidateConfigUseCase` which only understands the global `server`/`user`/`queue` schema. Since `GenerateFilesStep` writes that file for every configured project, the final "Validation finale" step of `reviewflow setup` failed on **every** already-configured project with a bogus `server: Missing server section; user: ...; queue: ...` error.
- Repro: fresh install → `reviewflow init -y` → `reviewflow setup /path/to/project` (fullstack/en) → step 10/10 blocks with that error, even though `reviewflow validate` reports the real config as valid.
- Fix: always validate `deps.configPath` (the global config); drop the per-project file swap. Updated the existing test that had baked in the old (wrong) behavior, and added a regression test using a realistic per-project config shape.
- Also: the "SETUP REQUIRED — Lancer le wizard" header CTA was a static element with no show/hide logic, so it stayed on forever, reading as a persistent error even once a project is registered. Now hidden once `availableRepositories.length > 0`, kept in sync on add/remove/toggle project.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint` (no new warnings)
- [x] `yarn test:ci` (489 files / 4121 tests pass)
- [x] Manually reproduced against a real GitHub-backed project via the dashboard, confirmed wizard step 10/10 now succeeds and the header CTA hides once the project is registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)