### PR TITLE
fix(setup): project review-config now matches the schema the engine reads

### DIFF
--- a/src/modules/setup-wizard/entities/projectConfig/projectConfig.gateway.ts
+++ b/src/modules/setup-wizard/entities/projectConfig/projectConfig.gateway.ts
@@ -1,12 +1,21 @@
-import type {
-  Preset,
-  Language,
-} from '@/modules/setup-wizard/entities/projectContext/projectContext.schema.js';
+import type { Language } from '@/modules/setup-wizard/entities/projectContext/projectContext.schema.js';
 
+export interface ProjectConfigAgent {
+  name: string;
+  displayName: string;
+}
+
+// Shape consumed by the review engine at @/config/projectConfig.js
+// (github/gitlab/defaultModel/reviewSkill/reviewFollowupSkill are required
+// fields there — this must stay in sync with parseProjectConfig).
 export interface ProjectConfigContents {
-  preset: Preset;
+  github: boolean;
+  gitlab: boolean;
+  defaultModel: 'sonnet' | 'opus' | 'haiku';
+  reviewSkill: string;
+  reviewFollowupSkill: string;
   language: Language;
-  agents: string[];
+  agents?: ProjectConfigAgent[];
 }
 
 export interface ProjectConfigGateway {

--- a/src/modules/setup-wizard/entities/projectContext/projectContext.schema.ts
+++ b/src/modules/setup-wizard/entities/projectContext/projectContext.schema.ts
@@ -12,12 +12,19 @@ export const languageSchema = z.enum(['en', 'fr']);
 
 export type Language = z.infer<typeof languageSchema>;
 
+export const agentDefinitionSchema = z.object({
+  name: z.string(),
+  displayName: z.string(),
+});
+
 export const projectContextSchema = z.object({
   localPath: z.string().nullable(),
   platform: platformSchema.nullable(),
   preset: presetSchema.nullable(),
   language: languageSchema.nullable(),
   remoteUrl: z.string().nullable(),
+  // Optional: absent from state files persisted before this field existed.
+  agents: z.array(agentDefinitionSchema).nullable().optional(),
 });
 
 export type ProjectContext = z.infer<typeof projectContextSchema>;

--- a/src/modules/setup-wizard/interface-adapters/gateways/projectConfig.fileSystem.gateway.ts
+++ b/src/modules/setup-wizard/interface-adapters/gateways/projectConfig.fileSystem.gateway.ts
@@ -15,10 +15,19 @@ import type {
   ProjectConfigContents,
 } from '@/modules/setup-wizard/entities/projectConfig/projectConfig.gateway.js';
 
+const projectConfigAgentSchema = z.object({
+  name: z.string().min(1),
+  displayName: z.string().min(1),
+});
+
 const projectConfigSchema = z.object({
-  preset: z.enum(['backend', 'frontend', 'fullstack', 'basic', 'custom']),
+  github: z.boolean(),
+  gitlab: z.boolean(),
+  defaultModel: z.enum(['sonnet', 'opus', 'haiku']),
+  reviewSkill: z.string().min(1),
+  reviewFollowupSkill: z.string().min(1),
   language: z.enum(['en', 'fr']),
-  agents: z.array(z.string()),
+  agents: z.array(projectConfigAgentSchema).optional(),
 });
 
 function resolveConfigPath(projectPath: string): string {

--- a/src/modules/setup-wizard/services/agentPresetCatalog.ts
+++ b/src/modules/setup-wizard/services/agentPresetCatalog.ts
@@ -1,45 +1,52 @@
+import type { AgentDefinition } from '@/modules/review-execution/entities/progress/agentDefinition.type.js';
+import {
+  DEFAULT_BACK_AGENTS,
+  DEFAULT_FRONT_AGENTS,
+  DEFAULT_FULLSTACK_AGENTS,
+} from '@/modules/review-execution/entities/progress/agentDefinition.type.js';
 import type { Preset } from '@/modules/setup-wizard/entities/projectContext/projectContext.schema.js';
 
-const PRESET_AGENTS: Record<Preset, string[]> = {
-  backend: [
-    'architecture',
-    'solid',
-    'testing',
-    'code-quality',
-    'security',
-    'ddd',
-    'clean-architecture',
-  ],
-  frontend: ['architecture', 'testing', 'code-quality', 'react-best-practices'],
-  fullstack: [
-    'architecture',
-    'solid',
-    'testing',
-    'code-quality',
-    'security',
-    'react-best-practices',
-  ],
+// Reuses the same agent catalog the review engine falls back to
+// (see getProjectAgentsOrFocusDefaults / DEFAULT_AGENTS) so a project
+// configured through this wizard ends up with an agent list the engine
+// actually recognizes, pipeline stages ('threads', 'report') included.
+const PRESET_AGENTS: Record<Preset, AgentDefinition[]> = {
+  backend: DEFAULT_BACK_AGENTS,
+  frontend: DEFAULT_FRONT_AGENTS,
+  fullstack: DEFAULT_FULLSTACK_AGENTS,
   basic: [],
   custom: [],
 };
 
-const FULL_CATALOG = [
-  'architecture',
-  'solid',
-  'testing',
-  'code-quality',
-  'security',
-  'ddd',
-  'clean-architecture',
-  'react-best-practices',
-  'documentation',
-  'performance',
+// Pipeline-internal stages, appended automatically to a custom selection —
+// not meaningful as a user-pickable "review dimension".
+const PIPELINE_AGENTS: AgentDefinition[] = [
+  { name: 'threads', displayName: 'Threads' },
+  { name: 'report', displayName: 'Rapport' },
 ];
 
-export function getAgentsForPreset(preset: Preset): string[] {
+function dedupByName(agents: AgentDefinition[]): AgentDefinition[] {
+  const byName = new Map(agents.map((agent) => [agent.name, agent]));
+  return [...byName.values()];
+}
+
+const FULL_CATALOG: AgentDefinition[] = dedupByName([
+  ...DEFAULT_BACK_AGENTS,
+  ...DEFAULT_FRONT_AGENTS,
+]).filter((agent) => !PIPELINE_AGENTS.some((pipeline) => pipeline.name === agent.name));
+
+export function getAgentsForPreset(preset: Preset): AgentDefinition[] {
   return [...PRESET_AGENTS[preset]];
 }
 
-export function getFullAgentCatalog(): string[] {
+export function getFullAgentCatalog(): AgentDefinition[] {
   return [...FULL_CATALOG];
+}
+
+export function buildCustomAgents(selectedNames: string[]): AgentDefinition[] {
+  const catalogByName = new Map(FULL_CATALOG.map((agent) => [agent.name, agent]));
+  const selected = selectedNames
+    .map((name) => catalogByName.get(name))
+    .filter((agent): agent is AgentDefinition => Boolean(agent));
+  return dedupByName([...selected, ...PIPELINE_AGENTS]);
 }

--- a/src/modules/setup-wizard/usecases/steps/configurePipeline.step.ts
+++ b/src/modules/setup-wizard/usecases/steps/configurePipeline.step.ts
@@ -9,6 +9,7 @@ import type { WizardContext } from '@/modules/setup-wizard/entities/wizardContex
 import {
   getAgentsForPreset,
   getFullAgentCatalog,
+  buildCustomAgents,
 } from '@/modules/setup-wizard/services/agentPresetCatalog.js';
 
 function isPreset(value: string): value is Preset {
@@ -55,7 +56,7 @@ export class ConfigurePipelineStep implements SetupStep {
       const catalog = getFullAgentCatalog();
       const selected = await context.gateways.prompt.askMultiSelect(
         'Sélectionnez les agents:',
-        catalog.map((agent) => ({ label: agent, value: agent })),
+        catalog.map((agent) => ({ label: agent.displayName, value: agent.name })),
       );
       if (selected.length === 0) {
         return blocked(
@@ -63,7 +64,7 @@ export class ConfigurePipelineStep implements SetupStep {
           'Relancez et cochez un ou plusieurs agents',
         );
       }
-      agents = selected;
+      agents = buildCustomAgents(selected);
     }
 
     const languageChoice = context.flags.yes
@@ -76,11 +77,12 @@ export class ConfigurePipelineStep implements SetupStep {
 
     context.project.preset = presetChoice;
     context.project.language = language;
+    context.project.agents = agents;
 
     return succeeded(`Pipeline configuré: ${presetChoice} / ${language}`, {
       preset: presetChoice,
       language,
-      agents,
+      agents: agents.map((agent) => agent.name),
     });
   }
 }

--- a/src/modules/setup-wizard/usecases/steps/generateFiles.step.ts
+++ b/src/modules/setup-wizard/usecases/steps/generateFiles.step.ts
@@ -8,6 +8,10 @@ import type { StepOutcome } from '@/modules/setup-wizard/entities/stepOutcome/st
 import type { WizardContext } from '@/modules/setup-wizard/entities/wizardContext/wizardContext.js';
 import { getAgentsForPreset } from '@/modules/setup-wizard/services/agentPresetCatalog.js';
 
+const DEFAULT_MODEL = 'sonnet';
+const REVIEW_SKILL = 'review-code';
+const REVIEW_FOLLOWUP_SKILL = 'review-followup';
+
 export class GenerateFilesStep implements SetupStep {
   readonly id = 'generate-files' as const;
   readonly title = 'Génération des fichiers projet';
@@ -29,7 +33,11 @@ export class GenerateFilesStep implements SetupStep {
     }
     const preset = context.project.preset ?? 'backend';
     const language = context.project.language ?? 'en';
-    const agents = getAgentsForPreset(preset);
+    // Prefer the selection ConfigurePipelineStep resolved (honors a custom
+    // pick); fall back to the preset default when resuming a run where that
+    // step's context was not carried over.
+    const agents = context.project.agents ?? getAgentsForPreset(preset);
+    const platform = context.project.platform;
 
     const projectConfig = context.gateways.projectConfig;
     const alreadyExists = projectConfig.exists(path);
@@ -47,9 +55,17 @@ export class GenerateFilesStep implements SetupStep {
     }
 
     try {
-      projectConfig.write(path, { preset, language, agents });
-      context.gateways.skillTemplate.writeSkill(path, 'review-code', language);
-      context.gateways.skillTemplate.writeSkill(path, 'review-followup', language);
+      projectConfig.write(path, {
+        github: platform === 'github',
+        gitlab: platform === 'gitlab',
+        defaultModel: DEFAULT_MODEL,
+        reviewSkill: REVIEW_SKILL,
+        reviewFollowupSkill: REVIEW_FOLLOWUP_SKILL,
+        language,
+        ...(agents.length > 0 ? { agents } : {}),
+      });
+      context.gateways.skillTemplate.writeSkill(path, REVIEW_SKILL, language);
+      context.gateways.skillTemplate.writeSkill(path, REVIEW_FOLLOWUP_SKILL, language);
       context.gateways.skillTemplate.writeMcpJson(path);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -62,14 +78,15 @@ export class GenerateFilesStep implements SetupStep {
       return blocked(`Échec d'écriture: ${message}`, 'Vérifiez les permissions du dossier');
     }
 
+    const agentNames = agents.map((agent) => agent.name);
     if (backupPath) {
       return succeeded(`Fichiers projet régénérés (sauvegarde: ${backupPath})`, {
         preset,
         language,
-        agents,
+        agents: agentNames,
         backupPath,
       });
     }
-    return succeeded('Fichiers projet générés', { preset, language, agents });
+    return succeeded('Fichiers projet générés', { preset, language, agents: agentNames });
   }
 }

--- a/src/tests/stubs/setup-wizard/projectConfig.stub.ts
+++ b/src/tests/stubs/setup-wizard/projectConfig.stub.ts
@@ -33,6 +33,14 @@ export class StubProjectConfigGateway implements ProjectConfigGateway {
   }
 
   seedExisting(projectPath: string): void {
-    this.store.set(projectPath, { preset: 'backend', language: 'en', agents: ['architecture'] });
+    this.store.set(projectPath, {
+      github: true,
+      gitlab: false,
+      defaultModel: 'sonnet',
+      reviewSkill: 'review-code',
+      reviewFollowupSkill: 'review-followup',
+      language: 'en',
+      agents: [{ name: 'clean-architecture', displayName: 'Clean Archi' }],
+    });
   }
 }

--- a/src/tests/units/modules/setup-wizard/interface-adapters/gateways/projectConfig.fileSystem.gateway.test.ts
+++ b/src/tests/units/modules/setup-wizard/interface-adapters/gateways/projectConfig.fileSystem.gateway.test.ts
@@ -6,6 +6,15 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 import { ProjectConfigFileSystemGateway } from '@/modules/setup-wizard/interface-adapters/gateways/projectConfig.fileSystem.gateway.js';
 
+const BASE_CONFIG = {
+  github: true,
+  gitlab: false,
+  defaultModel: 'sonnet' as const,
+  reviewSkill: 'review-code',
+  reviewFollowupSkill: 'review-followup',
+  language: 'en' as const,
+};
+
 describe('ProjectConfigFileSystemGateway', () => {
   let rootDir: string;
 
@@ -24,33 +33,43 @@ describe('ProjectConfigFileSystemGateway', () => {
 
   it('writes config under .claude/reviews/config.json', () => {
     const gateway = new ProjectConfigFileSystemGateway();
-    gateway.write(rootDir, { preset: 'backend', language: 'en', agents: ['architecture'] });
+    gateway.write(rootDir, {
+      ...BASE_CONFIG,
+      agents: [{ name: 'clean-architecture', displayName: 'Clean Archi' }],
+    });
     expect(existsSync(join(rootDir, '.claude', 'reviews', 'config.json'))).toBe(true);
   });
 
   it('reads back what it wrote', () => {
     const gateway = new ProjectConfigFileSystemGateway();
-    gateway.write(rootDir, {
-      preset: 'fullstack',
-      language: 'fr',
-      agents: ['testing', 'security'],
-    });
+    const config = {
+      ...BASE_CONFIG,
+      gitlab: false,
+      language: 'fr' as const,
+      agents: [
+        { name: 'testing', displayName: 'Testing' },
+        { name: 'security', displayName: 'Security' },
+      ],
+    };
+    gateway.write(rootDir, config);
     const reloaded = gateway.read(rootDir);
-    expect(reloaded).toEqual({
-      preset: 'fullstack',
-      language: 'fr',
-      agents: ['testing', 'security'],
-    });
+    expect(reloaded).toEqual(config);
+  });
+
+  it('reads back a config with no agents field (falls back to engine defaults)', () => {
+    const gateway = new ProjectConfigFileSystemGateway();
+    gateway.write(rootDir, BASE_CONFIG);
+    expect(gateway.read(rootDir)).toEqual(BASE_CONFIG);
   });
 
   it('creates a .bak file when backup is requested on existing config', () => {
     const gateway = new ProjectConfigFileSystemGateway();
-    gateway.write(rootDir, { preset: 'backend', language: 'en', agents: [] });
+    gateway.write(rootDir, BASE_CONFIG);
     const backupPath = gateway.backup(rootDir);
     expect(backupPath).not.toBeNull();
     if (backupPath) {
       expect(existsSync(backupPath)).toBe(true);
-      expect(readFileSync(backupPath, 'utf-8')).toContain('"preset"');
+      expect(readFileSync(backupPath, 'utf-8')).toContain('"reviewSkill"');
     }
   });
 

--- a/src/tests/units/modules/setup-wizard/services/agentPresetCatalog.test.ts
+++ b/src/tests/units/modules/setup-wizard/services/agentPresetCatalog.test.ts
@@ -3,18 +3,25 @@ import { describe, it, expect } from 'vitest';
 import {
   getAgentsForPreset,
   getFullAgentCatalog,
+  buildCustomAgents,
 } from '@/modules/setup-wizard/services/agentPresetCatalog.js';
 
+function names(agents: { name: string }[]): string[] {
+  return agents.map((agent) => agent.name);
+}
+
 describe('agentPresetCatalog', () => {
-  it('returns specific agents for the backend preset', () => {
-    const agents = getAgentsForPreset('backend');
-    expect(agents).toContain('architecture');
+  it('returns specific agents for the backend preset, including pipeline stages', () => {
+    const agents = names(getAgentsForPreset('backend'));
+    expect(agents).toContain('clean-architecture');
     expect(agents).toContain('solid');
     expect(agents).toContain('testing');
+    expect(agents).toContain('threads');
+    expect(agents).toContain('report');
   });
 
   it('returns react-best-practices in the frontend preset', () => {
-    expect(getAgentsForPreset('frontend')).toContain('react-best-practices');
+    expect(names(getAgentsForPreset('frontend'))).toContain('react-best-practices');
   });
 
   it('returns an empty list for the basic preset', () => {
@@ -25,16 +32,30 @@ describe('agentPresetCatalog', () => {
     expect(getAgentsForPreset('custom')).toEqual([]);
   });
 
-  it('returns a deduplicated agent catalog', () => {
+  it('returns a deduplicated agent catalog, excluding pipeline-internal stages', () => {
     const catalog = getFullAgentCatalog();
     expect(catalog.length).toBeGreaterThan(0);
-    expect(new Set(catalog).size).toBe(catalog.length);
+    expect(new Set(names(catalog)).size).toBe(catalog.length);
+    expect(names(catalog)).not.toContain('threads');
+    expect(names(catalog)).not.toContain('report');
   });
 
   it('returns a defensive copy that callers can mutate without affecting the source', () => {
     const a = getFullAgentCatalog();
-    a.push('mutation');
+    a.push({ name: 'mutation', displayName: 'Mutation' });
     const b = getFullAgentCatalog();
-    expect(b).not.toContain('mutation');
+    expect(names(b)).not.toContain('mutation');
+  });
+
+  it('resolves selected catalog names to agent definitions and appends pipeline stages', () => {
+    const agents = buildCustomAgents(['solid', 'security']);
+    expect(names(agents)).toEqual(
+      expect.arrayContaining(['solid', 'security', 'threads', 'report']),
+    );
+  });
+
+  it('ignores unknown agent names and de-duplicates the result', () => {
+    const agents = buildCustomAgents(['solid', 'solid', 'not-a-real-agent']);
+    expect(names(agents)).toEqual(['solid', 'threads', 'report']);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #331. Fixing that validation bug surfaced the real issue underneath: `reviewflow setup` never generated a project config the review engine can actually use.

- `GenerateFilesStep` wrote `.claude/reviews/config.json` as `{ preset, language, agents: string[] }`. The engine (`@/config/projectConfig.ts`, `parseProjectConfig`) requires `{ github, gitlab, defaultModel, reviewSkill, reviewFollowupSkill, agents: {name,displayName}[] }`. Every project set up via the wizard got a config the engine rejects — before #331 this was masked by the wizard's own validation bug always failing first; after #331 it surfaces as `Missing fields: github, gitlab, defaultModel, reviewFollowupSkill` in the dashboard.
- `agentPresetCatalog`'s ids never matched the engine's real catalog (`agentDefinition.type.ts`): `'architecture'` vs `'clean-architecture'`, missing `'ddd'`/`'performance'`, and missing the `'threads'`/`'report'` pipeline stages — which matters because an explicit `agents` array **replaces** the engine's defaults rather than extending them (`createInitialProgress`), so omitting those two would have silently dropped comment-posting/report-finalizing for any preset-configured project. Presets now reuse `DEFAULT_BACK_AGENTS`/`DEFAULT_FRONT_AGENTS`/`DEFAULT_FULLSTACK_AGENTS` directly.
- Also: a custom agent selection made in `ConfigurePipelineStep` was silently discarded — `GenerateFilesStep` recomputed `agents` from the preset alone and never read the user's picks. `ProjectContext` now carries the resolved list across steps (added as an optional field so existing persisted `setup-state.json` files still parse).

Repro: `reviewflow setup /path/to/project` → pick Fullstack → dashboard project tab shows `Missing fields: github, gitlab, defaultModel, reviewFollowupSkill`, and GitHub CLI status card is stuck on "Load a project...".

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint` (no new warnings beyond pre-existing `max-lines-per-function` noise already present throughout the codebase)
- [x] `yarn test:ci` (489 files / 4124 tests pass)
- [x] Manually reproduced end-to-end against a real GitHub-backed project: regenerated its `.claude/reviews/config.json` with the fixed shape, restarted the daemon on the fixed build, confirmed in the dashboard that the "Missing fields" error is gone and the GitHub CLI card now shows as operational instead of "Load a project..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)