### PR TITLE
fix(claude-invocation): strip ANSI codes before parsing --bg session id

### DIFF
--- a/src/modules/claude-invocation/interface-adapters/gateways/claudeSession.cli.gateway.ts
+++ b/src/modules/claude-invocation/interface-adapters/gateways/claudeSession.cli.gateway.ts
@@ -41,10 +41,15 @@ export const RATE_LIMIT_DETECTION_REGEX = /\b(rate[\s-]?limit|429|throttl)/i;
 // Claude CLI (>= 2.1.x) outputs the new background session in the form:
 //   "backgrounded · <hexSessionId>"
 // followed by a multi-line "claude agents" hint block. The middle dot is
-// U+00B7 (·). The daemon spawns the CLI with a piped stdout, so no ANSI
-// colour codes wrap the id — interactive TTY output is not the dispatcher
-// path and is not handled here.
+// U+00B7 (·). Some CLI versions wrap the id in ANSI colour codes even with
+// piped, non-TTY stdout, so escape sequences are stripped before matching.
 const SESSION_ID_REGEX = /^backgrounded\s*[·]\s*([0-9a-f]+)/m;
+const ANSI_ESCAPE_SEQUENCE = String.fromCharCode(27);
+const ANSI_ESCAPE_REGEX = new RegExp(`${ANSI_ESCAPE_SEQUENCE}\\[[0-9;]*m`, 'g');
+
+function stripAnsi(value: string): string {
+  return value.replace(ANSI_ESCAPE_REGEX, '');
+}
 
 const agentEntrySchema = z.object({
   id: z.string().min(1),
@@ -128,7 +133,7 @@ export class ClaudeSessionCliGateway implements ClaudeSessionGateway {
       return { status: 'failed', rawStderr: result.stderr };
     }
 
-    const match = result.stdout.match(SESSION_ID_REGEX);
+    const match = stripAnsi(result.stdout).match(SESSION_ID_REGEX);
     if (!match) {
       return {
         status: 'failed',

--- a/src/tests/units/modules/claude-invocation/interface-adapters/gateways/claudeSession.cli.gateway.test.ts
+++ b/src/tests/units/modules/claude-invocation/interface-adapters/gateways/claudeSession.cli.gateway.test.ts
@@ -76,6 +76,25 @@ describe('ClaudeSessionCliGateway.dispatch', () => {
     expect(calls[0]?.args).not.toContain('--dangerously-skip-permissions');
   });
 
+  it('extracts the session id when the CLI wraps it in ANSI colour codes despite piped stdout', async () => {
+    const { runner } = createRunner([
+      {
+        stdout:
+          'backgrounded · [36mb252a492[39m\n[2m claude agents list sessions[22m\n[2m claude attach b252a492 open in this terminal[22m\n[2m claude logs b252a492 show recent output[22m\n[2m claude stop b252a492 stop this session[22m',
+        stderr: '',
+        exitCode: 0,
+      },
+    ]);
+    const gateway = new ClaudeSessionCliGateway(runner);
+
+    const result = await gateway.dispatch(baseDispatchInput);
+
+    expect(result.status).toBe('dispatched');
+    if (result.status === 'dispatched') {
+      expect(result.sessionId).toBe('b252a492');
+    }
+  });
+
   it('returns "rate-limited" when stderr matches a rate-limit pattern', async () => {
     const { runner } = createRunner([
       { stdout: '', stderr: 'HTTP 429 Too Many Requests', exitCode: 1 },


### PR DESCRIPTION
## Summary
- The Claude CLI now emits ANSI colour codes around the session id in the `backgrounded · <id>` banner even when stdout is piped (non-TTY), which the daemon relies on for `--bg` dispatch.
- `SESSION_ID_REGEX` never accounted for escape codes, so every dispatch failed with `unable to parse session id from stdout` — this affects both GitHub and GitLab reviews equally; it just happened to surface first on a GitHub-triggered job in this session.
- Strips ANSI escape sequences (`ESC[...m`) from `result.stdout` before matching, using a runtime-built `RegExp` (not a literal control-char regex) to satisfy `no-control-regex`.

## Test plan
- [x] Added regression test reproducing the exact ANSI-wrapped stdout observed in production
- [x] `yarn verify` (typecheck + lint + test:ci) green — 4122/4122 tests passing
- [x] Verified live: rebuilt, relinked, restarted the local daemon, dispatch now parses the session id correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)