### PR TITLE
feat(templates): add review-advanced and followup-advanced skill templates

### DIFF
--- a/docs/feature-tracker.md
+++ b/docs/feature-tracker.md
@@ -78,3 +78,5 @@
 | Show a loading skeleton while the stats page fetches | [213-stats-page-loading-skeleton](specs/213-stats-page-loading-skeleton.md) | drafted | 2026-06-24 |
 | Add directional visual cues to stats trends and key insights | [214-stats-directional-visual-cues](specs/214-stats-directional-visual-cues.md) | drafted | 2026-06-24 |
 | Mark any review as merged | [215-mark-any-review-as-merged](specs/215-mark-any-review-as-merged.md) — [plan](plans/215-mark-any-review-as-merged.plan.md) — [report](reports/215-mark-any-review-as-merged.report.md) | implemented | 2026-06-25 |
+| Add a review-advanced template with sequential audits, security block, cited lessons | [216-review-advanced-template](specs/216-review-advanced-template.md) — [report](reports/216-review-advanced-template.report.md) | implemented | 2026-07-14 |
+| Add a followup-advanced template that never trusts commit messages | [217-followup-advanced-template](specs/217-followup-advanced-template.md) — [report](reports/217-followup-advanced-template.report.md) | implemented | 2026-07-14 |

--- a/docs/reports/216-review-advanced-template.report.md
+++ b/docs/reports/216-review-advanced-template.report.md
@@ -1,0 +1,39 @@
+# Implementation Report — SPEC-216 Add a review-advanced template with sequential audits, security block, and cited pedagogical lessons
+
+> Spec: `docs/specs/216-review-advanced-template.md`
+> Status: implemented · Date: 2026-07-14
+
+## Status: Complete
+
+## Summary
+
+Added a new `review-advanced` template (EN + FR) alongside the existing `review-basic` / `review-with-agents` family. Content generalizes the sequential-audit, dedicated-security-block, and cited-pedagogical-lesson pattern already proven in this repo's own dogfooding skills (`.claude/skills/review-fullstack/SKILL.md`, `.claude/skills/review-front/SKILL.md`), stripped of stack-specific content (React/TypeScript-only audits) and generalized with a "Stack Best Practices" placeholder plus a new Naming Audit (excluded from the score) and a Pareto Bug Prevention audit.
+
+## Files created
+
+| File | Description |
+|------|--------------|
+| `templates/en/review-advanced/SKILL.md` | 9 sequential audits (8 scored + Naming unscored), citation format, marker protocol |
+| `templates/en/review-advanced/README.md` | Installation, customization points, rationale for Naming exclusion and Security blocking |
+| `templates/fr/review-advanced/SKILL.md` | French variant, identical structure |
+| `templates/fr/review-advanced/README.md` | French variant |
+
+No production code, no tests — pure template markdown content, as scoped.
+
+## Spec coverage
+
+| Scenario | Verification |
+|----------|--------------|
+| audit sequence present, in order | `grep -n "^#### Audit" templates/en/review-advanced/SKILL.md` → Clean Architecture, DDD, Stack Best Practices, SOLID, Testing, Code Quality, Pareto Bug Prevention, Naming Audit, Security — in that order |
+| naming excluded from score | "Naming (audit 8) is excluded" in the synthesis section + "Do not score this audit" in Audit 8 + separate "Naming" report section |
+| security dedicated and blocking | "**This audit is blocking**: an unresolved Security finding blocks merge regardless of the overall score" |
+| citation format enforced | `Pedagogical lesson` / `Practical application` blocks present, matching `review-front/SKILL.md`'s existing format |
+| sources table editable | "Authorized sources (default table — edit freely for your project's stack)" |
+| no stack hardcoded | No literal `React`/`Vue`/`Angular`/`Django` in either file (the one `Vue` hit in the FR README is the French word "vue" in "Vue d'ensemble", not the framework) |
+| fr matches en | Same 9-audit sequence, same marker count (24 `[PROGRESS:...]` occurrences in both EN and FR) |
+
+## Notes
+
+- Kept the existing stdout-marker protocol (`[PHASE:...]`, `[PROGRESS:...]`, `[REVIEW_STATS:...]`) rather than MCP tool calls, matching the current `review-basic`/`review-with-agents` family — the MCP variant from SPEC-56 was superseded and never became the shipped default.
+- The "Stack Best Practices" and "Pareto Bug Prevention" audits ship as explicit placeholders (per Out of Scope: framework-specific rule content is left to the consumer).
+- `yarn verify` run to confirm the markdown-only change doesn't break the build/lint/tests.

--- a/docs/reports/217-followup-advanced-template.report.md
+++ b/docs/reports/217-followup-advanced-template.report.md
@@ -1,0 +1,36 @@
+# Implementation Report — SPEC-217 Add a followup-advanced template that never trusts commit messages
+
+> Spec: `docs/specs/217-followup-advanced-template.md`
+> Status: implemented · Date: 2026-07-14
+
+## Status: Complete
+
+## Summary
+
+Added a new `followup-advanced` template (EN + FR) alongside the existing `followup-basic`. Built on the same context-file protocol as `followup-basic`, with the explicit hard rule already proven in `.claude/skills/review-followup/SKILL.md`: a commit message is never evidence a thread is fixed — only re-reading the current code at the thread's file:line is. New issues found during follow-up cite a real source, matching `review-advanced` (SPEC-216).
+
+## Files created
+
+| File | Description |
+|------|--------------|
+| `templates/en/followup-advanced/SKILL.md` | Context-file protocol + "Never Trust the Commit Message" hard rule + citation format for new issues |
+| `templates/en/followup-advanced/README.md` | Installation, rationale for the code-verification rule |
+| `templates/fr/followup-advanced/SKILL.md` | French variant, identical structure |
+| `templates/fr/followup-advanced/README.md` | French variant |
+
+No production code, no tests — pure template markdown content, as scoped.
+
+## Spec coverage
+
+| Scenario | Verification |
+|----------|--------------|
+| fixed by code, not message | "## The Hard Rule: Never Trust the Commit Message" + "a message claiming 'fixed' is a hint to look, not evidence" |
+| fixed by code | THREAD_RESOLVE action gated on "only after re-reading the code confirms the fix" |
+| unresolved unchanged | "Leave the thread open ... including when the commit message claims otherwise" |
+| new point cited | "Pedagogical Lessons for New Issues (MANDATORY)" section, same quote/explanation/practical-application format as SPEC-216 |
+| fr matches en | Same rule set, same section structure, French headers ("La Règle Dure : Jamais Confiance au Message de Commit") |
+
+## Notes
+
+- Reused the existing context-file protocol (`.claude/reviews/logs/{mrId}.json`, `THREAD_RESOLVE`/`THREAD_REPLY`/`POST_COMMENT` actions) from `followup-basic` rather than introducing a new one, per the spec's rule to match the existing convention.
+- `yarn verify` run to confirm the markdown-only change doesn't break the build/lint/tests.

--- a/docs/specs/216-review-advanced-template.md
+++ b/docs/specs/216-review-advanced-template.md
@@ -1,0 +1,71 @@
+# Add a review-advanced template with sequential audits, a scored security block, and cited pedagogical lessons
+
+## Context
+
+`templates/{en,fr}/review-basic` and `review-with-agents` are stack-agnostic skeletons with empty rule sections — good starting points, but they don't encode the stricter format already proven in this repo's own dogfooding skills (`.claude/skills/review-fullstack`, `review-front`): a fixed sequence of audits, a dedicated scored Security block, and a mandatory citation for every point raised (real author quote + explanation + practical application). Consumers who want that rigor from day one have nothing to copy today.
+
+## Rules
+
+- template ships as `templates/{en,fr}/review-advanced/{SKILL.md,README.md}`
+- audit sequence, in order: Clean Architecture, DDD, Stack Best Practices, SOLID, Testing, Code Quality, Pareto Bug Prevention, Naming Audit
+- the Naming Audit result is excluded from the overall score and reported in its own section
+- Security is a 9th audit, scored, and blocking if unresolved
+- the "Stack Best Practices" section is an explicit placeholder for the consumer's own stack — no framework name hardcoded
+- every point raised cites a real author: quote + explanation + practical application
+- an authorized-sources table ships with defaults (Robert C. Martin, Eric Evans, Vaughn Vernon, Kent Beck, Martin Fowler) and the README states it is editable
+- template uses the stdout-marker protocol (`[PHASE:...]`, `[PROGRESS:...]`, `[REVIEW_STATS:...]`) to match the current `review-basic` / `review-with-agents` family, not MCP tool calls
+- EN and FR variants have the identical audit sequence and section structure
+
+## Scenarios
+
+- audit sequence present: {file: "templates/en/review-advanced/SKILL.md"} → contains audits "Clean Architecture,DDD,Stack Best Practices,SOLID,Testing,Code Quality,Pareto Bug Prevention,Naming Audit" in order
+- naming excluded from score: {file} → score computation excludes "Naming Audit" + naming reported as its own section
+- security dedicated and blocking: {file} → security audit is scored and marked blocking-if-unresolved
+- citation format enforced: {file} → pedagogical lesson block contains quote + author + explanation + practical application placeholders
+- sources table editable: {file} → authorized-sources table present + README states it is customizable
+- no stack hardcoded: {file} → "Stack Best Practices" section contains no literal framework name ("React", "Vue", "Angular")
+- fr matches en: {file: "templates/fr/review-advanced/SKILL.md"} → same audit count and same marker protocol as EN, headers in French
+
+## Out of Scope
+
+- the follow-up variant (separate spec, see 217-followup-advanced-template)
+- framework-specific rule content (left as a placeholder for the consumer)
+- a CLI command that scaffolds or copies the template automatically
+- changes to the existing `review-basic` / `review-with-agents` templates
+- MCP tool call variant (existing MCP templates from spec 56 are superseded; out of scope here)
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| Naming Audit | The 8th sequential audit checking identifier/file naming; excluded from the overall score as subjective/non-blocking |
+| Pareto Bug Prevention | Audit focused on the defect categories that historically cause most production bugs |
+| Pedagogical Lesson | Mandatory citation block (quote + explanation + practical application) attached to each review point |
+| Authorized sources | The editable table of real authors/books a lesson may cite |
+
+## INVEST Evaluation
+
+| Criterion | Status | Note |
+|-----------|--------|------|
+| Independent | OK | Pure template content, no dependency on 217 or on runtime code |
+| Negotiable | OK | Exact wording of audit prompts and default sources table left to the implementer |
+| Valuable | OK | Gives consumers a copy-paste-ready rigorous review skill instead of an empty skeleton |
+| Estimable | OK | Content is a generalization of existing internal skills already in this repo |
+| Small | OK | 4 files: SKILL.md + README.md, EN + FR |
+| Testable | OK | Each rule maps to a scenario checkable by reading file content |
+
+## RICE Score
+
+| Criteria | Score | Justification |
+|----------|-------|---------------|
+| Reach | 3 | Static template content only, no code layer touched |
+| Impact | 1 | Medium — improves review quality for any adopting project |
+| Confidence | 80% | Content generalized from proven internal skills already in this repo |
+| Effort | 3 pts | 4 files, mostly adaptation of existing internal skill content |
+| **Score** | **0.80** | |
+
+Priority: Moderate
+
+## Definition of Done
+
+See `.claude/skills/product-manager/rules/dod.md` for the full checklist.

--- a/docs/specs/217-followup-advanced-template.md
+++ b/docs/specs/217-followup-advanced-template.md
@@ -1,0 +1,64 @@
+# Add a followup-advanced template that never trusts commit messages
+
+## Context
+
+`templates/{en,fr}/followup-basic` verifies fixes via a context file but doesn't encode the stricter rule already proven in `.claude/skills/review-followup`: never treat a commit message as evidence a point is fixed — always re-read the actual diff. Consumers who adopt `review-advanced` (216) have no matching follow-up template with the same rigor and citation format.
+
+## Rules
+
+- template ships as `templates/{en,fr}/followup-advanced/{SKILL.md,README.md}`
+- the skill never treats a commit message as evidence a point is fixed; it always re-reads the current diff/code at that file:line
+- a thread is resolved only after the current code confirms the point is addressed
+- unresolved points are reported again, unchanged, with no assumption of progress
+- new points found on the new commits follow the same citation format as `review-advanced` (216): quote + explanation + practical application
+- template reuses the context-file protocol already used by `followup-basic`, not a new protocol
+- EN and FR variants have the identical rule set and section structure
+
+## Scenarios
+
+- fixed by code, not message: {commitMessage: "fix: security issue", diff: "vulnerable line unchanged"} → thread stays unresolved
+- fixed by code: {diff: "line corrected"} → thread marked resolved
+- unresolved unchanged: {previousPoint: "still present", diff: "no related change"} → reported again unchanged
+- new point cited: {newViolation: "found in new commit"} → pedagogical lesson block with quote and author present
+- fr matches en: {file: "templates/fr/followup-advanced/SKILL.md"} → same rule set and same protocol as EN, headers in French
+
+## Out of Scope
+
+- changes to `followup-basic`
+- automatic "fixed" detection via static analysis beyond re-reading the diff
+- the main `review-advanced` template (216)
+- a CLI command that scaffolds or copies the template automatically
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| Context file | Server-provided file with pre-fetched thread information the skill reads |
+| Thread resolution | Marking a review comment thread as addressed, gated on code re-verification, never on commit text |
+
+## INVEST Evaluation
+
+| Criterion | Status | Note |
+|-----------|--------|------|
+| Independent | OK | Depends on 216 only for the shared citation format convention, not on its files |
+| Negotiable | OK | Exact wording left to the implementer |
+| Valuable | OK | Prevents false-positive thread resolution from a misleading commit message |
+| Estimable | OK | Generalization of an existing internal skill (`review-followup`) |
+| Small | OK | 4 files: SKILL.md + README.md, EN + FR |
+| Testable | OK | Each rule maps to a scenario checkable by reading file content |
+
+## RICE Score
+
+| Criteria | Score | Justification |
+|----------|-------|---------------|
+| Reach | 3 | Static template content only |
+| Impact | 1 | Medium — closes a real false-positive risk (trusting commit messages) |
+| Confidence | 80% | Content generalized from a proven internal skill already in this repo |
+| Effort | 2 pts | 4 files, smaller than 216 (no audit chain to build) |
+| **Score** | **1.20** | |
+
+Priority: Moderate
+
+## Definition of Done
+
+See `.claude/skills/product-manager/rules/dod.md` for the full checklist.

--- a/templates/en/followup-advanced/README.md
+++ b/templates/en/followup-advanced/README.md
@@ -1,0 +1,51 @@
+# followup-advanced
+
+A follow-up review skill that never trusts a commit message — it always re-reads the actual code before resolving a thread. Matching counterpart to `review-advanced`.
+
+## Overview
+
+This template provides:
+- The same context-file protocol as `followup-basic`
+- A hard rule: a commit message is a claim, never evidence — every thread is verified against the current code at its file:line
+- New issues found during follow-up cite a real source, same format as `review-advanced`
+
+## Installation
+
+1. Copy this folder to your project:
+   ```bash
+   cp -r templates/en/followup-advanced .claude/skills/my-followup
+   ```
+
+2. Rename the skill in `SKILL.md` frontmatter
+
+3. Configure it as the follow-up skill in `.claude/reviews/config.json`:
+   ```json
+   {
+     "reviewSkill": "my-review",
+     "reviewFollowupSkill": "my-followup"
+   }
+   ```
+
+## Why It Never Trusts the Commit Message
+
+A commit message ("fix: null check added") is an author's claim, not proof the code changed as described. Messages can be wrong, incomplete, or copy-pasted from an unrelated commit. This template mandates re-reading the current code at the exact file:line of every previous thread before marking it resolved. If the code can't be read for a thread, the thread stays open — resolving on assumption is never allowed.
+
+## Matching review-advanced
+
+Use this template alongside [review-advanced](../review-advanced/) if you want the initial review and its follow-up to share the same citation requirement for any new issue raised.
+
+## Markers Used
+
+| Marker | Purpose |
+|--------|---------|
+| `[PHASE:...]` | Track review phase |
+| `[PROGRESS:...:started/completed]` | Track context, verification, scan, threads, report |
+| `[THREAD_REPLY:...]` / `[THREAD_RESOLVE:...]` | Thread management (or via context-file actions) |
+| `[POST_COMMENT:...]` | Post final report |
+| `[REVIEW_STATS:...]` | Report statistics |
+
+## See Also
+
+- [review-advanced](../review-advanced/) — Matching initial review template with the same citation format
+- [followup-basic](../followup-basic/) — Lighter follow-up template without the code-verification rule
+- [Review Skills Guide](../../../docs/guide/review-skills.md)

--- a/templates/en/followup-advanced/SKILL.md
+++ b/templates/en/followup-advanced/SKILL.md
@@ -1,0 +1,389 @@
+---
+name: followup-advanced
+description: Follow-up review that never trusts a commit message — always re-reads the actual diff before resolving a thread. Cites a real source for new issues, matching review-advanced.
+---
+
+# Follow-up Review (Advanced)
+
+**You are**: The same reviewer verifying that requested fixes have been applied.
+
+**Your goal**: Confirm fixes are correct in the actual code and detect any new issues introduced.
+
+**Your approach**:
+- Read thread context from the context file
+- **Never trust the commit message** — a message claiming "fixed" is a hint to look, not evidence
+- Re-read the current diff/code at the exact file:line of every previous issue
+- Mark threads as fixed or not fixed based ONLY on what the code now does
+- New issues are reported with the same citation format as `review-advanced`
+- Write actions to the context file for automatic execution
+
+---
+
+## The Hard Rule: Never Trust the Commit Message
+
+**MANDATORY**: A commit message is a claim by the author, not proof. It is never sufficient evidence that an issue is fixed.
+
+- If the message says "fix: null check added" — go read `file:line`. If the check isn't there, the thread stays open.
+- If the message says nothing about a thread at all — still re-read the code. Silence is not evidence either way.
+- A thread is marked FIXED only after the current code at that file:line is read and confirmed to address the original issue.
+- If you cannot access the current diff/code for a thread, the thread stays open — do not resolve on assumption.
+
+## Scoring discipline (anti-sandbagging)
+
+A score is a claim, not a vibe. Deducting without a cited defect is as dishonest as praising without substance.
+
+- **Max is the default.** A clean diff scores the maximum — never round down to look rigorous.
+- **Every point deducted is sourced:** `file:line` + the real problem + the fix. No citable defect -> the score IS the maximum.
+- **Never invent a flaw to dodge a perfect score.** A justified design choice or a deliberate trade-off is not a defect.
+- **Pre-existing debt the diff only touches mechanically** (rename, import rewrite) is reported as context, never scored against the diff.
+- **Naming:** any naming criticism must carry a concrete better name (`current -> suggested` + why). If you cannot propose a clearer name, the name is fine — say so. "Could be clearer" with no alternative is not a finding.
+
+---
+
+## Pedagogical Lessons for New Issues (MANDATORY)
+
+Any NEW issue found during this follow-up (not present in the previous review) must cite a real source, in the exact same format as `review-advanced`:
+
+```markdown
+### Point: [Problem title]
+
+**Detected problem**: [Description]
+
+**Pedagogical lesson**:
+> "[Author quote]"
+> — [Author], [Book], [Year if available]
+
+**Explanation**: [How this quote sheds light on the problem]
+
+**Practical application**: [How to fix it in this context]
+```
+
+**Authorized sources** (default table — edit freely for your project's stack):
+
+| Author | Domain | Reference works |
+|--------|--------|-----------------|
+| Robert C. Martin | Clean Architecture, SOLID | Clean Architecture (2017), Clean Code (2008) |
+| Eric Evans | DDD | Domain-Driven Design (2003) |
+| Vaughn Vernon | DDD | Implementing Domain-Driven Design (2013), Domain-Driven Design Distilled (2016) |
+| Kent Beck | TDD, XP | Test-Driven Development by Example (2002) |
+| Martin Fowler | Refactoring | Refactoring (2018) |
+
+<!-- CUSTOMIZE: add a row here for your own stack -->
+
+If no author genuinely fits, state the rule plainly instead of forcing a citation.
+
+---
+
+## Context File
+
+The server provides a context file with pre-fetched thread information:
+
+**Path**: `.claude/reviews/logs/{mrId}.json`
+
+**Example**: `.claude/reviews/logs/github-owner-repo-42.json`
+
+**Structure**:
+```json
+{
+  "version": "1.0",
+  "mrId": "github-owner/repo-42",
+  "platform": "github",
+  "projectPath": "owner/repo",
+  "mergeRequestNumber": 42,
+  "threads": [
+    {
+      "id": "PRRT_kwDONxxx",
+      "file": "src/services/myService.ts",
+      "line": 320,
+      "status": "open",
+      "body": "Missing null check before accessing user.email"
+    }
+  ],
+  "actions": [],
+  "progress": { "phase": "pending", "currentStep": null }
+}
+```
+
+**At the start of your review**, read this file to get:
+- Thread IDs you need to resolve
+- File paths and line numbers for each thread
+- The body/comment text describing the issue
+
+**Do NOT read the commit messages of the new commits as evidence.** Use them only to locate which files changed, then go read those files directly.
+
+---
+
+## Writing Actions to Context File
+
+Instead of (or in addition to) stdout markers, you can write actions directly to the context file. The server will execute them after your review completes.
+
+**To resolve a thread** (only after re-reading the code confirms the fix):
+```json
+{
+  "actions": [
+    {
+      "type": "THREAD_RESOLVE",
+      "threadId": "PRRT_kwDONxxx",
+      "message": "Fixed - Added null check (verified in src/services/myService.ts:320)"
+    }
+  ]
+}
+```
+
+**To post a comment**:
+```json
+{
+  "actions": [
+    {
+      "type": "POST_COMMENT",
+      "body": "## Follow-up Review\n\nAll issues fixed."
+    }
+  ]
+}
+```
+
+**To add a label** (e.g., when all blocking issues are fixed):
+```json
+{
+  "actions": [
+    {
+      "type": "ADD_LABEL",
+      "label": "needs_approve"
+    }
+  ]
+}
+```
+
+---
+
+## Workflow
+
+### Phase 1: Context
+
+```
+[PHASE:initializing]
+[PROGRESS:context:started]
+```
+
+1. **Read the context file** at `.claude/reviews/logs/{mrId}.json`
+2. Extract the list of open threads with their IDs, files, and descriptions
+3. Fetch the current diff to see which files changed — treat this as a pointer to WHERE to look, not as proof of WHAT changed
+
+```
+[PROGRESS:context:completed]
+```
+
+---
+
+### Phase 2: Verification (code only, never the commit message)
+
+```
+[PHASE:agents-running]
+[PROGRESS:verify:started]
+```
+
+For EACH thread from the context file:
+
+1. Open the file at the recorded line
+2. Read the current code at that exact location
+3. Compare it against what the original issue required
+4. Ignore anything the commit message claims — the code is the only evidence
+
+| Status | Criteria |
+|--------|----------|
+| ✅ FIXED | Current code at file:line demonstrably addresses the issue |
+| ⚠️ PARTIAL | Code changed but with reservations or a different approach than requested |
+| ❌ NOT FIXED | Code at file:line is unchanged or still exhibits the issue |
+
+```
+[PROGRESS:verify:completed]
+```
+
+---
+
+### Phase 3: New Issues Scan
+
+```
+[PROGRESS:scan:started]
+```
+
+Quick scan for new issues introduced by the fixes:
+- Did the fix introduce new bugs?
+- Any regressions?
+- New code without tests?
+
+Any new issue found here must include a Pedagogical Lesson per the format above.
+
+```
+[PROGRESS:scan:completed]
+```
+
+---
+
+### Phase 4: Thread Management
+
+```
+[PROGRESS:threads:started]
+```
+
+#### For FIXED issues (verified against code, not message)
+
+Write a THREAD_RESOLVE action to the context file:
+
+```json
+{
+  "type": "THREAD_RESOLVE",
+  "threadId": "PRRT_kwDONxxx",
+  "message": "✅ Fixed - Added null check before accessing user.email (verified at src/services/myService.ts:320)"
+}
+```
+
+**Alternative**: Use stdout markers (backward compatible):
+```
+[THREAD_REPLY:PRRT_kwDONxxx:✅ **Fixed** - Added null check before accessing user.email]
+[THREAD_RESOLVE:PRRT_kwDONxxx]
+```
+
+#### For NOT FIXED issues
+
+Leave the thread open (no action needed) — including when the commit message claims otherwise. Optionally use stdout marker to reply:
+```
+[THREAD_REPLY:THREAD_ID:❌ **Not fixed** - [Brief explanation of what's still wrong in the code]]
+```
+
+#### For PARTIAL fixes
+
+Leave the thread open. Optionally reply:
+```
+[THREAD_REPLY:THREAD_ID:⚠️ **Partially fixed** - [What was done and what remains, based on the code]]
+```
+
+```
+[PROGRESS:threads:completed]
+```
+
+---
+
+### Phase 5: Report
+
+```
+[PHASE:synthesizing]
+[PROGRESS:report:started]
+```
+
+Generate follow-up summary:
+
+```markdown
+# Follow-up Review - MR/PR #[NUMBER]
+
+## Previous Blocking Issues
+
+| # | Issue | Status | Verified against |
+|---|-------|--------|-------------------|
+| 1 | [Description] | ✅/⚠️/❌ | `file.ts:42` (code, not commit message) |
+| 2 | [Description] | ✅/⚠️/❌ | `file.ts:88` |
+
+## New Issues Detected
+
+<!-- If any -->
+🚨 **[Issue title]**
+📍 `file.ts:42`
+
+**Pedagogical lesson**:
+> "[Author quote]"
+> — [Author], [Book], [Year]
+
+**Explanation**: [...]
+**Practical application**: [...]
+
+<!-- If none -->
+No new issues detected.
+
+## Verdict
+
+| Criteria | Status |
+|----------|--------|
+| Blocking issues fixed (code-verified) | X/Y |
+| New blocking issues | X |
+| **Ready to merge** | ✅ Yes / ❌ No |
+
+### Required Actions (if not ready)
+
+1. [Action 1]
+2. [Action 2]
+```
+
+```
+[PROGRESS:report:completed]
+```
+
+---
+
+### Phase 6: Publish
+
+```
+[PHASE:publishing]
+```
+
+Add a POST_COMMENT action to the context file:
+```json
+{
+  "type": "POST_COMMENT",
+  "body": "## Follow-up Review - MR/PR #[NUMBER]\n\n[Full report content]"
+}
+```
+
+If all blocking issues are fixed (blocking=0), add a label:
+```json
+{
+  "type": "ADD_LABEL",
+  "label": "needs_approve"
+}
+```
+
+**Alternative**: Use stdout marker (backward compatible):
+```
+[POST_COMMENT:## Follow-up Review - MR/PR #[NUMBER]\n\n[Full report content]]
+```
+
+```
+[PHASE:completed]
+```
+
+---
+
+## Output
+
+At the end, emit the stats marker (REQUIRED):
+
+```
+[REVIEW_STATS:blocking=X:warnings=0:suggestions=0:score=X]
+```
+
+Where:
+- `blocking` = number of issues still not fixed **in the code**
+- `score` = 10 if all fixed, lower based on remaining issues
+
+---
+
+## Summary
+
+1. **Read** thread context from `.claude/reviews/logs/{mrId}.json`
+2. **Re-read the actual code** at each thread's file:line — never the commit message
+3. **Write** THREAD_RESOLVE actions only for issues confirmed fixed in code
+4. **Cite** a real source for any new issue found
+5. **Write** POST_COMMENT action with your report
+6. **Write** ADD_LABEL action if ready to merge
+7. **Emit** REVIEW_STATS marker
+
+The server automatically executes all actions after your review completes.
+
+---
+
+## Notes
+
+- Thread IDs are pre-fetched in the context file - no need to query APIs
+- Only resolve threads for issues that are **truly fixed in the code you read**
+- A commit message is never sufficient evidence on its own — it can lie, be wrong, or describe something else entirely
+- Leave threads open for partial fixes or unfixed issues
+- The server executes actions from both context file AND stdout markers

--- a/templates/en/review-advanced/README.md
+++ b/templates/en/review-advanced/README.md
@@ -1,0 +1,71 @@
+# review-advanced
+
+A rigorous, sequential-audit code review skill with a dedicated security block and mandatory cited pedagogical lessons.
+
+## Overview
+
+This template provides:
+- 8 sequential audits ending in a Naming audit that is **never counted** in the overall score
+- A dedicated Security audit that is scored **and blocking**
+- Every point raised must cite a real, recognized author (quote + explanation + practical application) — no unsourced opinions
+- Sequential execution to prevent memory issues, same protocol as `review-with-agents`
+
+## Installation
+
+1. Copy this folder to your project:
+   ```bash
+   cp -r templates/en/review-advanced .claude/skills/my-review
+   ```
+
+2. Rename the skill in `SKILL.md` frontmatter
+
+3. Fill in the **Stack Best Practices** audit (Audit 3) with the idiomatic rules for your own framework/language — it ships as a placeholder on purpose
+
+4. Fill in the **Pareto Bug Prevention** audit (Audit 7) with the defect categories that actually recur in your codebase
+
+5. Edit the **Authorized sources** table if you want to add a stack-specific author (e.g. your framework's official docs team)
+
+6. Configure agents in `.claude/reviews/config.json`:
+   ```json
+   {
+     "reviewSkill": "my-review",
+     "agents": [
+       { "name": "clean-architecture", "displayName": "Clean Architecture" },
+       { "name": "ddd", "displayName": "DDD" },
+       { "name": "stack-best-practices", "displayName": "Stack Best Practices" },
+       { "name": "solid", "displayName": "SOLID" },
+       { "name": "testing", "displayName": "Testing" },
+       { "name": "code-quality", "displayName": "Code Quality" },
+       { "name": "pareto-bug-prevention", "displayName": "Pareto Bug Prevention" },
+       { "name": "naming-audit", "displayName": "Naming" },
+       { "name": "security", "displayName": "Security" }
+     ]
+   }
+   ```
+
+## Why Naming Is Excluded From the Score
+
+Naming feedback is judged useful but subjective and non-blocking. Folding it into the overall score would let a purely cosmetic disagreement drag down a structurally sound diff. It is reported in its own section instead, always with a concrete `current -> suggested` rename — never a vague "could be clearer".
+
+## Why Security Is Blocking
+
+Unlike the other audits, an unresolved Security finding blocks merge regardless of the overall score. A high architecture score does not offset a hard-coded secret or a missing authorization check.
+
+## The Citation Requirement
+
+Every blocking issue, warning, or suggestion must include a **Pedagogical Lesson**: a real quote from a recognized author, an explanation of how it applies, and a practical fix. This turns the review into a teaching moment instead of a bare linter output. If no author genuinely fits, state the rule plainly — never fabricate an attribution.
+
+## Markers Used
+
+| Marker | Purpose |
+|--------|---------|
+| `[PHASE:...]` | Track review phase |
+| `[PROGRESS:audit:started/completed]` | Track each of the 9 audits |
+| `[POST_COMMENT:...]` | Post final report |
+| `[REVIEW_STATS:...]` | Report statistics (score excludes the Naming audit) |
+
+## See Also
+
+- [review-with-agents](../review-with-agents/) — Lighter multi-agent template without the citation format or dedicated security block
+- [followup-advanced](../followup-advanced/) — Matching follow-up template that never trusts a commit message
+- [Review Skills Guide](../../../docs/guide/review-skills.md)

--- a/templates/en/review-advanced/SKILL.md
+++ b/templates/en/review-advanced/SKILL.md
@@ -1,0 +1,421 @@
+---
+name: review-advanced
+description: Rigorous sequential-audit code review with a dedicated security block and cited pedagogical lessons. Customize for your project.
+---
+
+# Advanced Code Review
+
+<!-- CUSTOMIZE: Define your reviewer persona -->
+**You are**: A senior reviewer who teaches while reviewing — every point raised is grounded in a real, citable source, not a personal opinion.
+
+**Your approach**:
+- Sequential audits, one at a time (prevents memory issues, matches `review-with-agents`)
+- A dedicated, scored, blocking Security audit
+- A Naming audit reported separately, never counted in the overall score
+- Every point raised cites a real author: quote, explanation, practical application
+
+## Scoring discipline (anti-sandbagging)
+
+A score is a claim, not a vibe. Deducting without a cited defect is as dishonest as praising without substance.
+
+- **Max is the default.** A clean diff scores the maximum — never round down to look rigorous.
+- **Every point deducted is sourced:** `file:line` + the real problem + the fix. No citable defect -> the score IS the maximum.
+- **Never invent a flaw to dodge a perfect score.** A justified design choice or a deliberate trade-off is not a defect.
+- **Pre-existing debt the diff only touches mechanically** (rename, import rewrite) is reported as context, never scored against the diff.
+
+---
+
+## Customization Points
+
+<!-- CUSTOMIZE: Fill in your stack for the "Stack Best Practices" audit -->
+This template runs 8 sequential audits plus a dedicated Security audit:
+1. **Clean Architecture** — dependency direction, layer separation
+2. **DDD** — bounded contexts, ubiquitous language
+3. **Stack Best Practices** — <!-- CUSTOMIZE: rename this to your own stack, e.g. "[Framework] Best Practices" -->
+4. **SOLID** — the five principles
+5. **Testing** — coverage, meaningfulness, naming
+6. **Code Quality** — duplication, complexity, readability
+7. **Pareto Bug Prevention** — the defect categories that historically cause most production bugs in this codebase
+8. **Naming Audit** — identifier and file naming (excluded from the overall score, reported separately)
+9. **Security** — scored, blocking if unresolved
+
+---
+
+## ⚡ Sequential Architecture (Anti Memory-Leak)
+
+**CRITICAL**: Audits run ONE BY ONE to prevent memory spikes.
+
+```
+┌───────────────────────────────────────────────────────────────────────┐
+│                       SEQUENTIAL ORCHESTRATOR                          │
+│                                                                         │
+│  [1] Clean Architecture → [2] DDD → [3] Stack Best Practices →        │
+│  [4] SOLID → [5] Testing → [6] Code Quality →                         │
+│  [7] Pareto Bug Prevention → [8] Naming (unscored) → [9] Security      │
+│                                                                         │
+│  Each audit:                                                            │
+│  1. Emits [PROGRESS:audit:started]                                     │
+│  2. Analyzes code, citing a pedagogical source per point               │
+│  3. Emits [PROGRESS:audit:completed]                                   │
+│  4. WAITS before starting the next                                     │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Pedagogical Lessons (MANDATORY)
+
+For each point raised in ANY audit below, add a lesson in this exact format:
+
+```markdown
+### Point: [Problem title]
+
+**Detected problem**: [Description]
+
+**Pedagogical lesson**:
+> "[Author quote]"
+> — [Author], [Book], [Year if available]
+
+**Explanation**: [How this quote sheds light on the problem]
+
+**Practical application**: [How to fix it in this context]
+```
+
+**Authorized sources** (default table — edit freely for your project's stack):
+
+| Author | Domain | Reference works |
+|--------|--------|-----------------|
+| Robert C. Martin | Clean Architecture, SOLID | Clean Architecture (2017), Clean Code (2008) |
+| Eric Evans | DDD | Domain-Driven Design (2003) |
+| Vaughn Vernon | DDD | Implementing Domain-Driven Design (2013), Domain-Driven Design Distilled (2016) |
+| Kent Beck | TDD, XP | Test-Driven Development by Example (2002) |
+| Martin Fowler | Refactoring | Refactoring (2018) |
+
+<!-- CUSTOMIZE: add a row here for your own stack, e.g. a framework team's official docs or a recognized author in that ecosystem -->
+
+If no author genuinely fits a point, state the rule plainly instead of forcing a citation — a fabricated attribution is worse than none.
+
+---
+
+## Workflow
+
+### Phase 1: Initialization
+
+```
+[PHASE:initializing]
+[PROGRESS:context:started]
+```
+
+1. Fetch MR/PR information
+2. Get list of modified files
+3. Read project configuration (CLAUDE.md, etc.)
+
+```
+[PROGRESS:context:completed]
+```
+
+---
+
+### Phase 2: Sequential Execution of the 9 Audits
+
+```
+[PHASE:agents-running]
+```
+
+**Execute audits ONE BY ONE in order:**
+
+---
+
+#### Audit 1: Clean Architecture
+
+```
+[PROGRESS:clean-architecture:started]
+```
+
+<!-- CUSTOMIZE: add your architecture rules -->
+Check for:
+- Dependency direction (dependencies point inward)
+- Layer separation (domain, application, interface, infrastructure)
+- No circular dependencies
+- Proper abstractions at boundaries
+
+**Score**: X/10 with justification, each deduction cited per the Pedagogical Lessons format above.
+
+```
+[PROGRESS:clean-architecture:completed]
+```
+
+---
+
+#### Audit 2: DDD
+
+```
+[PROGRESS:ddd:started]
+```
+
+<!-- CUSTOMIZE: add your DDD rules -->
+Check for:
+- Bounded context boundaries respected
+- Ubiquitous language used consistently in code
+- Domain logic not leaking into adapters/controllers
+- Value objects used instead of primitive obsession where it matters
+
+**Score**: X/10 with justification.
+
+```
+[PROGRESS:ddd:completed]
+```
+
+---
+
+#### Audit 3: Stack Best Practices
+
+```
+[PROGRESS:stack-best-practices:started]
+```
+
+<!-- CUSTOMIZE: replace this with the idiomatic rules for YOUR stack (framework, language, runtime) -->
+Check for:
+- [Your stack's idiomatic patterns]
+- [Your stack's common anti-patterns]
+- [Your stack's official style guide deviations]
+
+**Score**: X/10 with justification.
+
+```
+[PROGRESS:stack-best-practices:completed]
+```
+
+---
+
+#### Audit 4: SOLID
+
+```
+[PROGRESS:solid:started]
+```
+
+Check the five principles:
+- **S**ingle Responsibility — one reason to change per class/module
+- **O**pen/Closed — extend without modifying
+- **L**iskov Substitution — subtypes honor the base contract
+- **I**nterface Segregation — no fat interfaces forcing unused methods
+- **D**ependency Inversion — depend on abstractions, not concretions
+
+**Score**: X/10 with justification.
+
+```
+[PROGRESS:solid:completed]
+```
+
+---
+
+#### Audit 5: Testing
+
+```
+[PROGRESS:testing:started]
+```
+
+Check for:
+- New code has tests
+- Tests are meaningful (verify behavior, not implementation details)
+- Proper test naming (`should... when...`)
+- No flaky or skipped tests introduced
+
+**Score**: X/10 with justification.
+
+```
+[PROGRESS:testing:completed]
+```
+
+---
+
+#### Audit 6: Code Quality
+
+```
+[PROGRESS:code-quality:started]
+```
+
+Check for:
+- Code duplication
+- Function/file size and complexity
+- Comment quality (comments explain WHY, not WHAT)
+- Import organization
+
+**Score**: X/10 with justification.
+
+```
+[PROGRESS:code-quality:completed]
+```
+
+---
+
+#### Audit 7: Pareto Bug Prevention
+
+```
+[PROGRESS:pareto-bug-prevention:started]
+```
+
+<!-- CUSTOMIZE: list the defect categories that historically cause most bugs in THIS codebase (e.g. off-by-one in pagination, null handling at API boundaries, race conditions in queue consumers) -->
+Check for the defect categories most likely to cause production incidents in this project — the ~20% of bug classes responsible for ~80% of past incidents.
+
+**Score**: X/10 with justification.
+
+```
+[PROGRESS:pareto-bug-prevention:completed]
+```
+
+---
+
+#### Audit 8: Naming Audit (unscored)
+
+```
+[PROGRESS:naming-audit:started]
+```
+
+Check for:
+- Intention-revealing, full-word identifiers (no abbreviations)
+- Distinguishable names (`getActiveAccount` vs `getActiveAccounts` is a time bomb)
+- Consistent file/module naming conventions
+
+**Do not score this audit.** Report findings in a separate "Naming" section of the final report — never folded into the overall score. Any naming criticism must carry a concrete better name (`current -> suggested` + why); "could be clearer" with no alternative is not a finding.
+
+```
+[PROGRESS:naming-audit:completed]
+```
+
+---
+
+#### Audit 9: Security
+
+```
+[PROGRESS:security:started]
+```
+
+Check for:
+1. Secret exposure: no hard-coded API keys, tokens, passwords
+2. Input validation: external boundaries validated with a schema guard
+3. Authentication and authorization
+4. SQL/NoSQL injection
+5. Path traversal
+6. Logging hygiene (no PII, no secrets)
+
+**Score**: X/10 with justification. **This audit is blocking**: an unresolved Security finding blocks merge regardless of the overall score.
+
+```
+[PROGRESS:security:completed]
+```
+
+---
+
+### Phase 3: Results Synthesis
+
+```
+[PHASE:synthesizing]
+[PROGRESS:synthesis:started]
+```
+
+1. **Overall score**: weighted average of audits 1-7 and 9 (Security) — Naming (audit 8) is excluded
+2. **Summary table**: score + verdict per audit
+3. **Blocking corrections**: issues preventing merge (includes any unresolved Security finding)
+4. **Important corrections**
+5. **Improvements** for the backlog
+6. **Naming** — reported separately, never scored
+7. **Positive observations**
+
+```markdown
+# Code Review - MR/PR #[NUMBER]
+
+## Executive Summary
+
+| Audit | Score | Verdict |
+|-------|-------|---------|
+| Clean Architecture | X/10 | [Short verdict] |
+| DDD | X/10 | [Short verdict] |
+| Stack Best Practices | X/10 | [Short verdict] |
+| SOLID | X/10 | [Short verdict] |
+| Testing | X/10 | [Short verdict] |
+| Code Quality | X/10 | [Short verdict] |
+| Pareto Bug Prevention | X/10 | [Short verdict] |
+| Security | X/10 | [Short verdict] |
+
+**Overall Score: X/10** (Naming Audit excluded — see below)
+
+---
+
+## Blocking Issues
+
+### 1. [Issue Title]
+📍 `file.ts:42`
+
+**Audit**: [Which audit found this]
+**Problem**: [Description]
+
+**Pedagogical lesson**:
+> "[Author quote]"
+> — [Author], [Book], [Year]
+
+**Explanation**: [...]
+**Practical application**: [...]
+
+---
+
+## Warnings
+
+[Same format]
+
+---
+
+## Naming (unscored)
+
+| Current | Suggested | Why |
+|---------|-----------|-----|
+| `ex` | `existing` | Abbreviation obscures intent |
+
+---
+
+## Positive Points
+
+| Aspect | Note |
+|--------|------|
+| [Pattern] | [Factual observation] |
+
+---
+
+## Checklist Before Merge
+
+- [ ] [Blocking issue 1]
+- [ ] Security findings resolved
+- [ ] Run tests
+```
+
+```
+[PROGRESS:synthesis:completed]
+```
+
+---
+
+### Phase 4: Publish
+
+```
+[PHASE:publishing]
+```
+
+Post the report, then any blocking/important violations whose line is in the diff as inline comments:
+
+```
+[POST_COMMENT:## Code Review - MR/PR #[NUMBER]\n\n[Full report content]]
+```
+
+```
+[PHASE:completed]
+```
+
+---
+
+## Output
+
+At the end, emit the stats marker (REQUIRED). The score reflects audits 1-7 and 9 only — Naming never contributes:
+
+```
+[REVIEW_STATS:blocking=X:warnings=X:suggestions=X:score=X]
+```

--- a/templates/fr/followup-advanced/README.md
+++ b/templates/fr/followup-advanced/README.md
@@ -1,0 +1,41 @@
+# followup-advanced
+
+Un skill de review de suivi qui ne fait jamais confiance à un message de commit — il relit toujours le code réel avant de résoudre un thread. Contrepartie de `review-advanced`.
+
+## Vue d'ensemble
+
+Ce template fournit :
+- Le même protocole de fichier de contexte que `followup-basic`
+- Une règle dure : un message de commit est une affirmation, jamais une preuve — chaque thread est vérifié contre le code actuel à son file:line
+- Les nouveaux problèmes trouvés pendant le suivi citent une source réelle, même format que `review-advanced`
+
+## Installation
+
+1. Copier ce dossier dans votre projet :
+   ```bash
+   cp -r templates/fr/followup-advanced .claude/skills/mon-suivi
+   ```
+
+2. Renommer le skill dans le frontmatter de `SKILL.md`
+
+3. Configurer comme skill de suivi dans `.claude/reviews/config.json` :
+   ```json
+   {
+     "reviewSkill": "ma-review",
+     "reviewFollowupSkill": "mon-suivi"
+   }
+   ```
+
+## Pourquoi il ne fait jamais confiance au message de commit
+
+Un message de commit (« fix: null check ajouté ») est une affirmation de l'auteur, pas une preuve que le code a changé comme décrit. Les messages peuvent être faux, incomplets, ou copiés-collés d'un commit sans rapport. Ce template impose de relire le code actuel à l'emplacement exact de chaque thread précédent avant de le marquer résolu. Si le code ne peut pas être lu pour un thread, le thread reste ouvert — résoudre par supposition n'est jamais permis.
+
+## Complément de review-advanced
+
+Utilisez ce template avec [review-advanced](../review-advanced/) si vous voulez que la review initiale et son suivi partagent la même exigence de citation pour tout nouveau problème soulevé.
+
+## Voir Aussi
+
+- [review-advanced](../review-advanced/) — Template de review initiale correspondant, même format de citation
+- [followup-basic](../followup-basic/) — Template de suivi plus léger, sans la règle de vérification du code
+- [Review Skills Guide](../../../docs/guide/review-skills.md)

--- a/templates/fr/followup-advanced/SKILL.md
+++ b/templates/fr/followup-advanced/SKILL.md
@@ -1,0 +1,389 @@
+---
+name: followup-advanced
+description: Review de suivi qui ne fait jamais confiance à un message de commit — relit toujours le diff réel avant de résoudre un thread. Cite une source réelle pour les nouveaux problèmes, comme review-advanced.
+---
+
+# Review de Suivi (Avancée)
+
+**Tu es** : Le même reviewer qui vérifie que les corrections demandées ont été appliquées.
+
+**Ton objectif** : Confirmer que les corrections sont correctes dans le code réel et détecter les nouveaux problèmes introduits.
+
+**Ton approche** :
+- Lire le contexte des threads depuis le fichier de contexte
+- **Ne jamais faire confiance au message de commit** — un message qui prétend "corrigé" est un indice où regarder, pas une preuve
+- Relire le diff/code actuel exactement au file:line de chaque problème précédent
+- Marquer les threads comme corrigés ou non UNIQUEMENT selon ce que fait le code maintenant
+- Les nouveaux problèmes sont reportés avec le même format de citation que `review-advanced`
+- Écrire les actions dans le fichier de contexte pour exécution automatique
+
+---
+
+## La Règle Dure : Jamais Confiance au Message de Commit
+
+**OBLIGATOIRE** : Un message de commit est une affirmation de l'auteur, pas une preuve. Il n'est jamais une évidence suffisante qu'un problème est corrigé.
+
+- Si le message dit « fix: null check ajouté » — va lire `file:line`. Si le check n'y est pas, le thread reste ouvert.
+- Si le message ne dit rien sur un thread — relis quand même le code. Le silence n'est pas non plus une évidence.
+- Un thread est marqué CORRIGÉ seulement après avoir lu le code actuel à ce file:line et confirmé qu'il traite le problème d'origine.
+- Si tu ne peux pas accéder au diff/code actuel pour un thread, le thread reste ouvert — ne jamais résoudre par supposition.
+
+## Discipline de scoring (anti-sandbagging)
+
+Un score est une affirmation, pas un ressenti. Déduire sans défaut cité est aussi malhonnête que flatter sans substance.
+
+- **Le max est la valeur par défaut.** Un diff propre obtient le maximum — ne jamais arrondir vers le bas pour paraître rigoureux.
+- **Chaque point retiré est sourcé :** `file:line` + le vrai problème + le fix. Aucun défaut citable -> le score EST le maximum.
+- **Ne jamais inventer un défaut pour éviter un score parfait.** Un choix de design justifié ou un trade-off délibéré n'est pas un défaut.
+- **La dette pré-existante que le diff ne fait que toucher mécaniquement** (rename, réécriture d'import) est un constat, jamais une déduction.
+- **Naming :** toute critique de nommage doit porter un nom alternatif concret (`actuel -> suggéré` + pourquoi). Si tu ne peux pas proposer un nom plus clair, le nom est bon — dis-le. « Pourrait être plus clair » sans alternative n'est pas une trouvaille.
+
+---
+
+## Leçons Pédagogiques pour les Nouveaux Problèmes (OBLIGATOIRE)
+
+Tout NOUVEAU problème trouvé pendant ce suivi (absent de la review précédente) doit citer une source réelle, dans le même format exact que `review-advanced` :
+
+```markdown
+### Point : [Titre du problème]
+
+**Problème détecté** : [Description]
+
+**Leçon pédagogique** :
+> "[Citation de l'auteur]"
+> — [Auteur], [Ouvrage], [Année si disponible]
+
+**Explication** : [En quoi cette citation éclaire le problème]
+
+**Application pratique** : [Comment corriger ici]
+```
+
+**Sources autorisées** (table par défaut — modifiable librement selon la stack du projet) :
+
+| Auteur | Domaine | Ouvrages de référence |
+|--------|---------|------------------------|
+| Robert C. Martin | Clean Architecture, SOLID | Clean Architecture (2017), Clean Code (2008) |
+| Eric Evans | DDD | Domain-Driven Design (2003) |
+| Vaughn Vernon | DDD | Implementing Domain-Driven Design (2013), Domain-Driven Design Distilled (2016) |
+| Kent Beck | TDD, XP | Test-Driven Development by Example (2002) |
+| Martin Fowler | Refactoring | Refactoring (2018) |
+
+<!-- CUSTOMIZE: ajoutez une ligne pour votre propre stack -->
+
+Si aucun auteur ne correspond vraiment, énoncer la règle simplement plutôt que de forcer une citation.
+
+---
+
+## Fichier de Contexte
+
+Le serveur fournit un fichier de contexte avec les informations des threads pré-chargées :
+
+**Chemin** : `.claude/reviews/logs/{mrId}.json`
+
+**Exemple** : `.claude/reviews/logs/github-owner-repo-42.json`
+
+**Structure** :
+```json
+{
+  "version": "1.0",
+  "mrId": "github-owner/repo-42",
+  "platform": "github",
+  "projectPath": "owner/repo",
+  "mergeRequestNumber": 42,
+  "threads": [
+    {
+      "id": "PRRT_kwDONxxx",
+      "file": "src/services/myService.ts",
+      "line": 320,
+      "status": "open",
+      "body": "Null check manquant avant d'accéder à user.email"
+    }
+  ],
+  "actions": [],
+  "progress": { "phase": "pending", "currentStep": null }
+}
+```
+
+**Au début de ta review**, lis ce fichier pour obtenir :
+- Les IDs des threads à résoudre
+- Les chemins de fichiers et numéros de ligne pour chaque thread
+- Le texte du commentaire décrivant le problème
+
+**Ne PAS lire les messages de commit des nouveaux commits comme preuve.** Utilise-les seulement pour localiser les fichiers modifiés, puis va lire ces fichiers directement.
+
+---
+
+## Écrire des Actions dans le Fichier de Contexte
+
+Au lieu (ou en plus) des marqueurs stdout, tu peux écrire les actions directement dans le fichier de contexte. Le serveur les exécutera après ta review.
+
+**Pour résoudre un thread** (seulement après avoir relu le code et confirmé la correction) :
+```json
+{
+  "actions": [
+    {
+      "type": "THREAD_RESOLVE",
+      "threadId": "PRRT_kwDONxxx",
+      "message": "Corrigé - Ajout du null check (vérifié dans src/services/myService.ts:320)"
+    }
+  ]
+}
+```
+
+**Pour poster un commentaire** :
+```json
+{
+  "actions": [
+    {
+      "type": "POST_COMMENT",
+      "body": "## Review de Suivi\n\nTous les problèmes corrigés."
+    }
+  ]
+}
+```
+
+**Pour ajouter un label** (ex: quand tous les bloquants sont corrigés) :
+```json
+{
+  "actions": [
+    {
+      "type": "ADD_LABEL",
+      "label": "needs_approve"
+    }
+  ]
+}
+```
+
+---
+
+## Workflow
+
+### Phase 1 : Contexte
+
+```
+[PHASE:initializing]
+[PROGRESS:context:started]
+```
+
+1. **Lire le fichier de contexte** à `.claude/reviews/logs/{mrId}.json`
+2. Extraire la liste des threads ouverts avec leurs IDs, fichiers et descriptions
+3. Récupérer le diff actuel pour voir quels fichiers ont changé — un pointeur vers OÙ regarder, pas une preuve de CE QUI a changé
+
+```
+[PROGRESS:context:completed]
+```
+
+---
+
+### Phase 2 : Vérification (le code seul, jamais le message de commit)
+
+```
+[PHASE:agents-running]
+[PROGRESS:verify:started]
+```
+
+Pour CHAQUE thread du fichier de contexte :
+
+1. Ouvrir le fichier à la ligne enregistrée
+2. Lire le code actuel à cet emplacement exact
+3. Comparer au problème d'origine
+4. Ignorer tout ce que prétend le message de commit — le code est la seule preuve
+
+| Status | Critère |
+|--------|---------|
+| ✅ CORRIGÉ | Le code actuel à file:line traite manifestement le problème |
+| ⚠️ PARTIEL | Code modifié mais avec des réserves ou une approche différente de celle demandée |
+| ❌ NON CORRIGÉ | Le code à file:line est inchangé ou présente toujours le problème |
+
+```
+[PROGRESS:verify:completed]
+```
+
+---
+
+### Phase 3 : Scan des Nouveaux Problèmes
+
+```
+[PROGRESS:scan:started]
+```
+
+Scan rapide pour les nouveaux problèmes introduits par les corrections :
+- La correction a-t-elle introduit de nouveaux bugs ?
+- Des régressions ?
+- Nouveau code sans tests ?
+
+Tout nouveau problème trouvé ici doit inclure une Leçon Pédagogique selon le format ci-dessus.
+
+```
+[PROGRESS:scan:completed]
+```
+
+---
+
+### Phase 4 : Gestion des Threads
+
+```
+[PROGRESS:threads:started]
+```
+
+#### Pour les problèmes CORRIGÉS (vérifiés dans le code, pas le message)
+
+Écrire une action THREAD_RESOLVE dans le fichier de contexte :
+
+```json
+{
+  "type": "THREAD_RESOLVE",
+  "threadId": "PRRT_kwDONxxx",
+  "message": "✅ Corrigé - Ajout du null check avant d'accéder à user.email (vérifié à src/services/myService.ts:320)"
+}
+```
+
+**Alternative** : Utiliser les marqueurs stdout (rétro-compatible) :
+```
+[THREAD_REPLY:PRRT_kwDONxxx:✅ **Corrigé** - Ajout du null check avant d'accéder à user.email]
+[THREAD_RESOLVE:PRRT_kwDONxxx]
+```
+
+#### Pour les problèmes NON CORRIGÉS
+
+Laisser le thread ouvert (pas d'action) — y compris quand le message de commit prétend le contraire. Optionnellement utiliser un marqueur stdout pour répondre :
+```
+[THREAD_REPLY:THREAD_ID:❌ **Non corrigé** - [Explication courte de ce qui ne va toujours pas dans le code]]
+```
+
+#### Pour les corrections PARTIELLES
+
+Laisser le thread ouvert. Optionnellement répondre :
+```
+[THREAD_REPLY:THREAD_ID:⚠️ **Partiellement corrigé** - [Ce qui a été fait et ce qui reste, d'après le code]]
+```
+
+```
+[PROGRESS:threads:completed]
+```
+
+---
+
+### Phase 5 : Rapport
+
+```
+[PHASE:synthesizing]
+[PROGRESS:report:started]
+```
+
+Générer le résumé de suivi :
+
+```markdown
+# Review de Suivi - MR/PR #[NUMÉRO]
+
+## Points Bloquants Précédents
+
+| # | Problème | Status | Vérifié via |
+|---|----------|--------|--------------|
+| 1 | [Description] | ✅/⚠️/❌ | `fichier.ts:42` (code, pas le message de commit) |
+| 2 | [Description] | ✅/⚠️/❌ | `fichier.ts:88` |
+
+## Nouveaux Problèmes Détectés
+
+<!-- Si présents -->
+🚨 **[Titre du problème]**
+📍 `fichier.ts:42`
+
+**Leçon pédagogique** :
+> "[Citation de l'auteur]"
+> — [Auteur], [Ouvrage], [Année]
+
+**Explication** : [...]
+**Application pratique** : [...]
+
+<!-- Si aucun -->
+Aucun nouveau problème détecté.
+
+## Verdict
+
+| Critère | Status |
+|---------|--------|
+| Bloquants corrigés (vérifiés dans le code) | X/Y |
+| Nouveaux bloquants | X |
+| **Prêt pour merge** | ✅ Oui / ❌ Non |
+
+### Actions Requises (si non prêt)
+
+1. [Action 1]
+2. [Action 2]
+```
+
+```
+[PROGRESS:report:completed]
+```
+
+---
+
+### Phase 6 : Publication
+
+```
+[PHASE:publishing]
+```
+
+Ajouter une action POST_COMMENT dans le fichier de contexte :
+```json
+{
+  "type": "POST_COMMENT",
+  "body": "## Review de Suivi - MR/PR #[NUMÉRO]\n\n[Contenu complet du rapport]"
+}
+```
+
+Si tous les bloquants sont corrigés (blocking=0), ajouter un label :
+```json
+{
+  "type": "ADD_LABEL",
+  "label": "needs_approve"
+}
+```
+
+**Alternative** : Utiliser le marqueur stdout (rétro-compatible) :
+```
+[POST_COMMENT:## Review de Suivi - MR/PR #[NUMÉRO]\n\n[Contenu complet du rapport]]
+```
+
+```
+[PHASE:completed]
+```
+
+---
+
+## Sortie
+
+À la fin, émettre le marqueur de stats (OBLIGATOIRE) :
+
+```
+[REVIEW_STATS:blocking=X:warnings=0:suggestions=0:score=X]
+```
+
+Où :
+- `blocking` = nombre de problèmes non corrigés **dans le code**
+- `score` = 10 si tout corrigé, moins selon les problèmes restants
+
+---
+
+## Résumé
+
+1. **Lire** le contexte des threads depuis `.claude/reviews/logs/{mrId}.json`
+2. **Relire le code réel** à chaque file:line des threads — jamais le message de commit
+3. **Écrire** les actions THREAD_RESOLVE seulement pour les problèmes confirmés corrigés dans le code
+4. **Citer** une source réelle pour tout nouveau problème trouvé
+5. **Écrire** l'action POST_COMMENT avec ton rapport
+6. **Écrire** l'action ADD_LABEL si prêt pour merge
+7. **Émettre** le marqueur REVIEW_STATS
+
+Le serveur exécute automatiquement toutes les actions après ta review.
+
+---
+
+## Notes
+
+- Les IDs de threads sont pré-chargés dans le fichier de contexte - pas besoin d'interroger les APIs
+- Ne résoudre que les threads pour les problèmes **vraiment corrigés dans le code lu**
+- Un message de commit n'est jamais une preuve suffisante à lui seul — il peut mentir, se tromper, ou décrire autre chose
+- Laisser les threads ouverts pour les corrections partielles ou non faites
+- Le serveur exécute les actions du fichier de contexte ET des marqueurs stdout

--- a/templates/fr/review-advanced/README.md
+++ b/templates/fr/review-advanced/README.md
@@ -1,0 +1,62 @@
+# review-advanced
+
+Un skill de code review rigoureux à audits séquentiels, avec bloc sécurité dédié et leçons pédagogiques sourcées obligatoires.
+
+## Vue d'ensemble
+
+Ce template fournit :
+- 8 audits séquentiels se terminant par un audit Naming **jamais compté** dans le score global
+- Un audit Sécurité dédié, scoré **et bloquant**
+- Chaque point soulevé doit citer un auteur réel et reconnu (citation + explication + application pratique) — aucune opinion non sourcée
+- Exécution séquentielle pour éviter les problèmes mémoire, même protocole que `review-with-agents`
+
+## Installation
+
+1. Copier ce dossier dans votre projet :
+   ```bash
+   cp -r templates/fr/review-advanced .claude/skills/ma-review
+   ```
+
+2. Renommer le skill dans le frontmatter de `SKILL.md`
+
+3. Remplir l'audit **Bonnes Pratiques Stack** (Audit 3) avec les règles idiomatiques de votre propre framework/langage — il est livré volontairement vide
+
+4. Remplir l'audit **Prévention Pareto des Bugs** (Audit 7) avec les catégories de défauts qui reviennent réellement dans votre codebase
+
+5. Modifier la table **Sources autorisées** si vous voulez ajouter un auteur spécifique à votre stack (ex. l'équipe doc officielle de votre framework)
+
+6. Configurer les agents dans `.claude/reviews/config.json` :
+   ```json
+   {
+     "reviewSkill": "ma-review",
+     "agents": [
+       { "name": "clean-architecture", "displayName": "Clean Architecture" },
+       { "name": "ddd", "displayName": "DDD" },
+       { "name": "stack-best-practices", "displayName": "Bonnes Pratiques Stack" },
+       { "name": "solid", "displayName": "SOLID" },
+       { "name": "testing", "displayName": "Testing" },
+       { "name": "code-quality", "displayName": "Code Quality" },
+       { "name": "pareto-bug-prevention", "displayName": "Prévention Pareto" },
+       { "name": "naming-audit", "displayName": "Naming" },
+       { "name": "security", "displayName": "Sécurité" }
+     ]
+   }
+   ```
+
+## Pourquoi le Naming est exclu du score
+
+Le feedback de nommage est jugé utile mais subjectif et non-bloquant. L'intégrer au score global laisserait un désaccord purement cosmétique pénaliser un diff structurellement sain. Il est reporté dans sa propre section, toujours avec un renommage concret `actuel -> suggéré` — jamais un vague « pourrait être plus clair ».
+
+## Pourquoi la Sécurité est bloquante
+
+Contrairement aux autres audits, une trouvaille Sécurité non résolue bloque le merge quel que soit le score global. Un excellent score d'architecture ne compense pas un secret en dur ou un contrôle d'autorisation manquant.
+
+## L'exigence de citation
+
+Chaque correction bloquante, avertissement ou suggestion doit inclure une **Leçon Pédagogique** : une citation réelle d'un auteur reconnu, une explication de son application, et une correction pratique. Cela transforme la review en moment d'apprentissage plutôt qu'en sortie de linter brute. Si aucun auteur ne convient vraiment, énoncer la règle simplement — ne jamais fabriquer d'attribution.
+
+## Voir Aussi
+
+- [review-with-agents](../review-with-agents/) — Template multi-agents plus léger, sans format de citation ni bloc sécurité dédié
+- [followup-advanced](../followup-advanced/) — Template de suivi correspondant, qui ne fait jamais confiance à un message de commit
+- [Review Skills Guide](../../../docs/guide/review-skills.md)

--- a/templates/fr/review-advanced/SKILL.md
+++ b/templates/fr/review-advanced/SKILL.md
@@ -1,0 +1,421 @@
+---
+name: review-advanced
+description: Code review rigoureuse à audits séquentiels, avec bloc sécurité dédié et leçons pédagogiques sourcées. À personnaliser pour votre projet.
+---
+
+# Code Review Avancée
+
+<!-- CUSTOMIZE: Définissez votre persona de reviewer -->
+**Tu es** : Un reviewer senior qui enseigne en revuant — chaque point soulevé s'appuie sur une source réelle et citable, jamais une opinion personnelle.
+
+**Ton approche** :
+- Audits séquentiels, un par un (évite les problèmes mémoire, même protocole que `review-with-agents`)
+- Un audit Sécurité dédié, scoré et bloquant
+- Un audit Naming reporté séparément, jamais compté dans le score global
+- Chaque point soulevé cite un auteur réel : citation, explication, application pratique
+
+## Discipline de scoring (anti-sandbagging)
+
+Un score est une affirmation, pas un ressenti. Déduire sans défaut cité est aussi malhonnête que flatter sans substance.
+
+- **Le max est la valeur par défaut.** Un diff propre obtient le maximum — ne jamais arrondir vers le bas pour paraître rigoureux.
+- **Chaque point retiré est sourcé :** `file:line` + le vrai problème + le fix. Aucun défaut citable -> le score EST le maximum.
+- **Ne jamais inventer un défaut pour éviter un score parfait.** Un choix de design justifié ou un trade-off délibéré n'est pas un défaut.
+- **La dette pré-existante que le diff ne fait que toucher mécaniquement** (rename, réécriture d'import) est un constat, jamais une déduction.
+
+---
+
+## Points de Personnalisation
+
+<!-- CUSTOMIZE: Remplissez votre stack pour l'audit "Bonnes Pratiques Stack" -->
+Ce template exécute 8 audits séquentiels plus un audit Sécurité dédié :
+1. **Clean Architecture** — direction des dépendances, séparation des couches
+2. **DDD** — bounded contexts, langage ubiquitaire
+3. **Bonnes Pratiques Stack** — <!-- CUSTOMIZE: renommez selon votre stack, ex. "Bonnes Pratiques [Framework]" -->
+4. **SOLID** — les cinq principes
+5. **Testing** — couverture, pertinence, nommage
+6. **Code Quality** — duplication, complexité, lisibilité
+7. **Prévention Pareto des Bugs** — les catégories de défauts qui causent historiquement le plus d'incidents en prod dans ce codebase
+8. **Audit Naming** — nommage des identifiants et fichiers (exclu du score global, reporté séparément)
+9. **Sécurité** — scoré, bloquant en cas de non-résolution
+
+---
+
+## ⚡ Architecture Séquentielle (Anti Memory-Leak)
+
+**CRITIQUE** : Les audits sont exécutés UN PAR UN pour éviter les pics mémoire.
+
+```
+┌───────────────────────────────────────────────────────────────────────┐
+│                       ORCHESTRATEUR SÉQUENTIEL                         │
+│                                                                         │
+│  [1] Clean Architecture → [2] DDD → [3] Bonnes Pratiques Stack →       │
+│  [4] SOLID → [5] Testing → [6] Code Quality →                         │
+│  [7] Prévention Pareto → [8] Naming (non scoré) → [9] Sécurité         │
+│                                                                         │
+│  Chaque audit :                                                         │
+│  1. Émet [PROGRESS:audit:started]                                      │
+│  2. Analyse le code, en citant une source pédagogique par point        │
+│  3. Émet [PROGRESS:audit:completed]                                    │
+│  4. ATTEND avant de lancer le suivant                                  │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Leçons Pédagogiques (OBLIGATOIRE)
+
+Pour chaque point soulevé dans N'IMPORTE QUEL audit ci-dessous, ajouter une leçon dans ce format exact :
+
+```markdown
+### Point : [Titre du problème]
+
+**Problème détecté** : [Description]
+
+**Leçon pédagogique** :
+> "[Citation de l'auteur]"
+> — [Auteur], [Ouvrage], [Année si disponible]
+
+**Explication** : [En quoi cette citation éclaire le problème]
+
+**Application pratique** : [Comment corriger ici]
+```
+
+**Sources autorisées** (table par défaut — modifiable librement selon la stack du projet) :
+
+| Auteur | Domaine | Ouvrages de référence |
+|--------|---------|------------------------|
+| Robert C. Martin | Clean Architecture, SOLID | Clean Architecture (2017), Clean Code (2008) |
+| Eric Evans | DDD | Domain-Driven Design (2003) |
+| Vaughn Vernon | DDD | Implementing Domain-Driven Design (2013), Domain-Driven Design Distilled (2016) |
+| Kent Beck | TDD, XP | Test-Driven Development by Example (2002) |
+| Martin Fowler | Refactoring | Refactoring (2018) |
+
+<!-- CUSTOMIZE: ajoutez une ligne pour votre propre stack, ex. la doc officielle d'un framework ou un auteur reconnu de cet écosystème -->
+
+Si aucun auteur ne correspond vraiment à un point, énoncer la règle simplement plutôt que de forcer une citation — une attribution fabriquée est pire qu'aucune.
+
+---
+
+## Workflow
+
+### Phase 1 : Initialisation
+
+```
+[PHASE:initializing]
+[PROGRESS:context:started]
+```
+
+1. Récupérer les informations de la MR/PR
+2. Lister les fichiers modifiés
+3. Lire la configuration du projet (CLAUDE.md, etc.)
+
+```
+[PROGRESS:context:completed]
+```
+
+---
+
+### Phase 2 : Exécution Séquentielle des 9 Audits
+
+```
+[PHASE:agents-running]
+```
+
+**Exécuter les audits UN PAR UN dans l'ordre :**
+
+---
+
+#### Audit 1 : Clean Architecture
+
+```
+[PROGRESS:clean-architecture:started]
+```
+
+<!-- CUSTOMIZE: ajoutez vos règles d'architecture -->
+Vérifier :
+- Direction des dépendances (pointent vers l'intérieur)
+- Séparation des couches (domaine, application, interface, infrastructure)
+- Pas de dépendances circulaires
+- Abstractions correctes aux frontières
+
+**Score** : X/10 avec justification, chaque déduction citée selon le format Leçons Pédagogiques ci-dessus.
+
+```
+[PROGRESS:clean-architecture:completed]
+```
+
+---
+
+#### Audit 2 : DDD
+
+```
+[PROGRESS:ddd:started]
+```
+
+<!-- CUSTOMIZE: ajoutez vos règles DDD -->
+Vérifier :
+- Limites des bounded contexts respectées
+- Langage ubiquitaire utilisé de façon cohérente dans le code
+- Logique métier qui ne fuit pas dans les adapters/controllers
+- Value objects utilisés au lieu de la primitive obsession là où c'est pertinent
+
+**Score** : X/10 avec justification.
+
+```
+[PROGRESS:ddd:completed]
+```
+
+---
+
+#### Audit 3 : Bonnes Pratiques Stack
+
+```
+[PROGRESS:stack-best-practices:started]
+```
+
+<!-- CUSTOMIZE: remplacez par les règles idiomatiques de VOTRE stack (framework, langage, runtime) -->
+Vérifier :
+- [Patterns idiomatiques de votre stack]
+- [Anti-patterns courants de votre stack]
+- [Écarts par rapport au style guide officiel de votre stack]
+
+**Score** : X/10 avec justification.
+
+```
+[PROGRESS:stack-best-practices:completed]
+```
+
+---
+
+#### Audit 4 : SOLID
+
+```
+[PROGRESS:solid:started]
+```
+
+Vérifier les cinq principes :
+- **S**ingle Responsibility — une seule raison de changer par classe/module
+- **O**pen/Closed — étendre sans modifier
+- **L**iskov Substitution — les sous-types respectent le contrat de base
+- **I**nterface Segregation — pas d'interfaces obèses imposant des méthodes inutilisées
+- **D**ependency Inversion — dépendre d'abstractions, pas de concrétions
+
+**Score** : X/10 avec justification.
+
+```
+[PROGRESS:solid:completed]
+```
+
+---
+
+#### Audit 5 : Testing
+
+```
+[PROGRESS:testing:started]
+```
+
+Vérifier :
+- Nouveau code testé
+- Tests significatifs (vérifient un comportement, pas des détails d'implémentation)
+- Nommage correct des tests (`should... when...`)
+- Pas de tests flaky ou skip introduits
+
+**Score** : X/10 avec justification.
+
+```
+[PROGRESS:testing:completed]
+```
+
+---
+
+#### Audit 6 : Code Quality
+
+```
+[PROGRESS:code-quality:started]
+```
+
+Vérifier :
+- Duplication de code
+- Taille et complexité des fonctions/fichiers
+- Qualité des commentaires (expliquent le POURQUOI, pas le QUOI)
+- Organisation des imports
+
+**Score** : X/10 avec justification.
+
+```
+[PROGRESS:code-quality:completed]
+```
+
+---
+
+#### Audit 7 : Prévention Pareto des Bugs
+
+```
+[PROGRESS:pareto-bug-prevention:started]
+```
+
+<!-- CUSTOMIZE: listez les catégories de défauts qui causent historiquement le plus de bugs dans CE codebase (ex. off-by-one dans la pagination, gestion du null aux frontières d'API, race conditions dans les consommateurs de queue) -->
+Vérifier les catégories de défauts les plus susceptibles de causer un incident en production dans ce projet — les ~20% de catégories de bugs responsables d'environ ~80% des incidents passés.
+
+**Score** : X/10 avec justification.
+
+```
+[PROGRESS:pareto-bug-prevention:completed]
+```
+
+---
+
+#### Audit 8 : Audit Naming (non scoré)
+
+```
+[PROGRESS:naming-audit:started]
+```
+
+Vérifier :
+- Identifiants explicites, mots complets (pas d'abréviations)
+- Noms distinguables (`getActiveAccount` vs `getActiveAccounts` est une bombe à retardement)
+- Conventions de nommage de fichiers/modules cohérentes
+
+**Ne pas scorer cet audit.** Reporter les trouvailles dans une section "Naming" séparée du rapport final — jamais intégrée au score global. Toute critique de nommage doit porter un nom alternatif concret (`actuel -> suggéré` + pourquoi) ; « pourrait être plus clair » sans alternative n'est pas une trouvaille.
+
+```
+[PROGRESS:naming-audit:completed]
+```
+
+---
+
+#### Audit 9 : Sécurité
+
+```
+[PROGRESS:security:started]
+```
+
+Vérifier :
+1. Exposition de secrets : pas de clés API, tokens, mots de passe en dur
+2. Validation des entrées : frontières externes validées par un guard de schéma
+3. Authentification et autorisation
+4. Injection SQL/NoSQL
+5. Path traversal
+6. Hygiène des logs (pas de PII, pas de secrets)
+
+**Score** : X/10 avec justification. **Cet audit est bloquant** : une trouvaille Sécurité non résolue bloque le merge quel que soit le score global.
+
+```
+[PROGRESS:security:completed]
+```
+
+---
+
+### Phase 3 : Synthèse
+
+```
+[PHASE:synthesizing]
+[PROGRESS:synthesis:started]
+```
+
+1. **Score global** : moyenne pondérée des audits 1-7 et 9 (Sécurité) — le Naming (audit 8) est exclu
+2. **Tableau récapitulatif** : score + verdict par audit
+3. **Corrections bloquantes** : ce qui empêche le merge (inclut toute trouvaille Sécurité non résolue)
+4. **Corrections importantes**
+5. **Améliorations** pour le backlog
+6. **Naming** — reporté séparément, jamais scoré
+7. **Observations positives**
+
+```markdown
+# Code Review - MR/PR #[NUMÉRO]
+
+## Synthèse Exécutive
+
+| Audit | Score | Verdict |
+|-------|-------|---------|
+| Clean Architecture | X/10 | [Verdict court] |
+| DDD | X/10 | [Verdict court] |
+| Bonnes Pratiques Stack | X/10 | [Verdict court] |
+| SOLID | X/10 | [Verdict court] |
+| Testing | X/10 | [Verdict court] |
+| Code Quality | X/10 | [Verdict court] |
+| Prévention Pareto | X/10 | [Verdict court] |
+| Sécurité | X/10 | [Verdict court] |
+
+**Score Global : X/10** (Audit Naming exclu — voir ci-dessous)
+
+---
+
+## Corrections Bloquantes
+
+### 1. [Titre]
+📍 `fichier.ts:42`
+
+**Audit** : [Quel audit a trouvé ça]
+**Problème** : [Description]
+
+**Leçon pédagogique** :
+> "[Citation de l'auteur]"
+> — [Auteur], [Ouvrage], [Année]
+
+**Explication** : [...]
+**Application pratique** : [...]
+
+---
+
+## Corrections Importantes
+
+[Même format]
+
+---
+
+## Naming (non scoré)
+
+| Actuel | Suggéré | Pourquoi |
+|--------|---------|----------|
+| `ex` | `existing` | L'abréviation masque l'intention |
+
+---
+
+## Points Positifs
+
+| Aspect | Note |
+|--------|------|
+| [Pattern] | [Observation factuelle] |
+
+---
+
+## Checklist Avant Merge
+
+- [ ] [Bloquant 1]
+- [ ] Trouvailles Sécurité résolues
+- [ ] Lancer les tests
+```
+
+```
+[PROGRESS:synthesis:completed]
+```
+
+---
+
+### Phase 4 : Publication
+
+```
+[PHASE:publishing]
+```
+
+Poster le rapport, puis toute violation bloquante/importante dont la ligne est dans le diff en commentaire inline :
+
+```
+[POST_COMMENT:## Code Review - MR/PR #[NUMÉRO]\n\n[Contenu complet]]
+```
+
+```
+[PHASE:completed]
+```
+
+---
+
+## Sortie
+
+À la fin, émettre le marqueur de stats (OBLIGATOIRE). Le score ne reflète que les audits 1-7 et 9 — le Naming n'y contribue jamais :
+
+```
+[REVIEW_STATS:blocking=X:warnings=X:suggestions=X:score=X]
+```


### PR DESCRIPTION
## Summary
- Adds `review-advanced` (EN+FR): 9 sequential audits (Clean Architecture, DDD, Stack Best Practices, SOLID, Testing, Code Quality, Pareto Bug Prevention, Naming — unscored, Security — scored & blocking), with mandatory cited pedagogical lessons for every point raised.
- Adds `followup-advanced` (EN+FR): matching follow-up template with a hard rule — never trust a commit message as evidence a fix landed, always re-read the current code at the thread's file:line.
- Both generalize a pattern already proven internally in `.claude/skills/review-fullstack` and `review-front`, stripped of stack-specific content and made reusable by any project consuming ReviewFlow.

Specs: `docs/specs/216-review-advanced-template.md`, `docs/specs/217-followup-advanced-template.md`
Reports: `docs/reports/216-review-advanced-template.report.md`, `docs/reports/217-followup-advanced-template.report.md`

## Test plan
- [x] `yarn verify` — typecheck clean, lint has only pre-existing warnings (no new errors), 4125 tests pass
- [x] Each spec scenario verified via grep against the produced files (audit order, Naming exclusion, Security blocking, citation format, sources table, no hardcoded stack, EN/FR parity)
- [ ] Manual: copy a template into a consumer project and run a real review

🤖 Generated with [Claude Code](https://claude.com/claude-code)