### PR TITLE
fix: #339 dashboard loading state stuck after successful fetch

### DIFF
--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -1046,11 +1046,11 @@
         const response = await fetch(url);
         const data = await response.json();
         currentData.reviewFiles = data.reviews || [];
-        updateReviewFilesUI();
       } catch (error) {
         console.error('Error fetching review files:', error);
       } finally {
         setLoadingFlag('reviewFiles', false);
+        updateReviewFilesUI();
       }
     }
 
@@ -1990,11 +1990,11 @@
           currentData.pendingApproval = data.pendingApproval || [];
           currentData.merged = data.merged || [];
         }
-        updateMrTrackingUI();
       } catch (error) {
         console.error('Error fetching MR tracking:', error);
       } finally {
         setLoadingFlag('mrTracking', false);
+        updateMrTrackingUI();
       }
     }
 

--- a/src/tests/units/dashboard/dashboardLoadingRace.test.ts
+++ b/src/tests/units/dashboard/dashboardLoadingRace.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Regression test for issue #339 — Priority Lanes and Completed Reviews stuck
+ * on "Loading..." forever.
+ *
+ * Structural assertions on src/dashboard/index.html via raw-string + regex,
+ * matching the precedent of dashboardLayout.test.ts (no jsdom dependency).
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { beforeAll, describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const PROJECT_ROOT = join(__dirname, '..', '..', '..', '..');
+const INDEX_HTML_PATH = join(PROJECT_ROOT, 'src', 'dashboard', 'index.html');
+
+function extractFunctionBody(source: string, functionName: string): string {
+  const signatureIndex = source.indexOf(`function ${functionName}(`);
+  if (signatureIndex === -1) return '';
+  const firstBraceIndex = source.indexOf('{', signatureIndex);
+  if (firstBraceIndex === -1) return '';
+  let depth = 1;
+  let cursor = firstBraceIndex + 1;
+  while (depth > 0 && cursor < source.length) {
+    const char = source[cursor];
+    if (char === '{') depth += 1;
+    if (char === '}') depth -= 1;
+    cursor += 1;
+  }
+  return source.substring(signatureIndex, cursor);
+}
+
+describe('Issue #339 — dashboard loading state race', () => {
+  let indexHtml: string;
+
+  beforeAll(() => {
+    indexHtml = readFileSync(INDEX_HTML_PATH, 'utf-8');
+  });
+
+  it('fetchMrTracking renders after clearing the mrTracking loading flag, not before', () => {
+    const functionBody = extractFunctionBody(indexHtml, 'fetchMrTracking');
+    expect(functionBody).not.toBe('');
+
+    const clearFlagIndex = functionBody.lastIndexOf("setLoadingFlag('mrTracking', false)");
+    const renderCallIndex = functionBody.lastIndexOf('updateMrTrackingUI()');
+
+    expect(clearFlagIndex).toBeGreaterThan(-1);
+    expect(renderCallIndex).toBeGreaterThan(-1);
+    expect(renderCallIndex).toBeGreaterThan(clearFlagIndex);
+  });
+
+  it('fetchReviewFiles renders after clearing the reviewFiles loading flag, not before', () => {
+    const functionBody = extractFunctionBody(indexHtml, 'fetchReviewFiles');
+    expect(functionBody).not.toBe('');
+
+    const clearFlagIndex = functionBody.indexOf("setLoadingFlag('reviewFiles', false)");
+    const renderCallIndex = functionBody.lastIndexOf('updateReviewFilesUI()');
+
+    expect(clearFlagIndex).toBeGreaterThan(-1);
+    expect(renderCallIndex).toBeGreaterThan(-1);
+    expect(renderCallIndex).toBeGreaterThan(clearFlagIndex);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #339: the Priority Lanes and Completed Reviews dashboard panels showed "Loading…" forever, even after their data fetches succeeded with valid responses.
- Root cause: `fetchMrTracking()` and `fetchReviewFiles()` called their render function (`updateMrTrackingUI()` / `updateReviewFilesUI()`) inside the `try` block, before the `finally` cleared the corresponding `loadingState` flag — so the render always saw `loading=true`, and nothing re-rendered once the flag was actually cleared.
- Fix: moved both render calls into `finally`, after the flag is cleared.

## Test plan
- [x] Added a regression test (`src/tests/units/dashboard/dashboardLoadingRace.test.ts`) asserting the render call happens after the loading-flag clear, for both functions — RED on the old code, GREEN after the fix
- [x] `yarn verify` — typecheck clean, lint has only pre-existing warnings (no new errors), 4127 tests pass (490 files)
- [x] Verified live via the dashboard in Chrome — panels previously stuck on "Loading…" now render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)