### PR TITLE
fix(webhook): soften the oversized-MR split message tone

### DIFF
--- a/src/modules/platform-integration/usecases/guardDiffSize.usecase.ts
+++ b/src/modules/platform-integration/usecases/guardDiffSize.usecase.ts
@@ -18,11 +18,14 @@ interface GuardDiffSizeDependencies {
 
 function buildSplitMessage(countedLines: number, budget: number): string {
   return (
-    `Revue refusée : cette merge request fait ${countedLines} lignes comptées ` +
-    `(budget ${budget}). Pour faciliter la revue, découpez-la : ` +
+    `Petite pause avant la revue : cette merge request compte ${countedLines} lignes ` +
+    `(budget ${budget}), un peu trop pour une revue de qualité en une seule fois. ` +
+    'Découpée en plus petits morceaux, elle sera revue plus vite, plus finement, ' +
+    'et bien plus simple à corriger si besoin. Une piste pour la découper : ' +
     '1) séparez les refactorings des nouvelles fonctionnalités, ' +
     '2) extrayez les changements indépendants dans des MR dédiées, ' +
-    '3) limitez chaque MR à une seule intention.'
+    '3) limitez chaque MR à une seule intention. ' +
+    'Merci pour le travail, hâte de la relire découpée !'
   );
 }
 

--- a/src/tests/units/modules/platform-integration/usecases/guardDiffSize.usecase.test.ts
+++ b/src/tests/units/modules/platform-integration/usecases/guardDiffSize.usecase.test.ts
@@ -51,7 +51,7 @@ describe('GuardDiffSizeUseCase', () => {
     expect(verdict).toEqual({ kind: 'allowed' });
   });
 
-  it('posts a French split message mentioning actionable tips', () => {
+  it('posts a kind French split message mentioning actionable tips, not a harsh rejection', () => {
     const { gateway, useCase } = buildUseCase();
     gateway.setResponse(
       42,
@@ -66,8 +66,9 @@ describe('GuardDiffSizeUseCase', () => {
 
     expect(verdict.kind).toBe('blocked');
     if (verdict.kind === 'blocked') {
-      expect(verdict.message).toContain('Revue refusée');
-      expect(verdict.message).toContain('découpez');
+      expect(verdict.message).not.toContain('Revue refusée');
+      expect(verdict.message).toContain('découp');
+      expect(verdict.message).toContain('Merci');
     }
   });
 


### PR DESCRIPTION
## Summary
- The oversized-diff guard's comment (SPEC-209) opened with "Revue refusée" and read as a flat rejection.
- Reworded to explain *why* splitting helps (faster, more thorough review, easier fixes) and closes on a friendly note, keeping the same three actionable split tips.

## Test plan
- [x] Updated the existing unit test to assert the harsh opening is gone and the message stays kind + actionable
- [x] `yarn verify` — 4127 tests pass, no new lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)