### PR TITLE
feat(webhook): trigger GitHub reviews on draft PRs

### DIFF
--- a/src/modules/platform-integration/interface-adapters/controllers/webhook/eventFilter.ts
+++ b/src/modules/platform-integration/interface-adapters/controllers/webhook/eventFilter.ts
@@ -316,11 +316,6 @@ export function filterGitHubEvent(event: GitHubPullRequestEvent): FilterResult {
     return { shouldProcess: false, reason: `PR state is ${pr.state}, not open` };
   }
 
-  // Skip draft PRs
-  if (pr.draft) {
-    return { shouldProcess: false, reason: 'PR is a draft' };
-  }
-
   // Check if I was the one requested
   // GitHub sends "requested_reviewer" in the event payload
   if (event.requested_reviewer?.login !== myUsername) {
@@ -415,11 +410,6 @@ export function filterGitHubLabelEvent(event: GitHubPullRequestEvent): FilterRes
   // PR must be open
   if (pr.state !== 'open') {
     return { shouldProcess: false, reason: `PR state is ${pr.state}, not open` };
-  }
-
-  // Skip draft PRs
-  if (pr.draft) {
-    return { shouldProcess: false, reason: 'PR is a draft' };
   }
 
   // Check if the added label is our trigger label

--- a/src/tests/units/interface-adapters/controllers/webhook/eventFilter.test.ts
+++ b/src/tests/units/interface-adapters/controllers/webhook/eventFilter.test.ts
@@ -347,7 +347,7 @@ describe('filterGitHubEvent', () => {
   });
 
   describe('when PR is draft', () => {
-    it('should not process draft PRs even with review requested', () => {
+    it('should process draft PRs when review is requested', () => {
       const event = GitHubEventFactory.createPullRequestEvent({
         action: 'review_requested',
         requested_reviewer: { login: 'claude-reviewer' },
@@ -356,8 +356,7 @@ describe('filterGitHubEvent', () => {
 
       const result = filterGitHubEvent(event);
 
-      expect(result.shouldProcess).toBe(false);
-      expect(result.reason).toContain('draft');
+      expect(result.shouldProcess).toBe(true);
     });
   });
 
@@ -467,14 +466,14 @@ describe('filterGitHubLabelEvent', () => {
   });
 
   describe('when PR is draft', () => {
-    it('should not process draft PRs', () => {
+    it('should process draft PRs when the needs-review label is added', () => {
       const event = GitHubEventFactory.createLabeledPr(REVIEW_TRIGGER_LABEL);
       event.pull_request.draft = true;
 
       const result = filterGitHubLabelEvent(event);
 
-      expect(result.shouldProcess).toBe(false);
-      expect(result.reason).toContain('draft');
+      expect(result.shouldProcess).toBe(true);
+      expect(result.reason).toContain(REVIEW_TRIGGER_LABEL);
     });
   });
 


### PR DESCRIPTION
## Bug
A draft PR explicitly tagged with the `needs-review` label (or with a review requested) never triggered a review: `filterGitHubEvent` and `filterGitHubLabelEvent` skipped all draft PRs, so the event never reached the semi-auto gate and produced no dashboard entry.

## Fix
Drafts are a legitimate review target when explicitly triggered. Removed the draft skip from both explicit-trigger paths (review_requested + `needs-review` label).

**Intentionally unchanged:** followup-on-push (`filterGitHubPrUpdate`) still skips drafts, and GitLab draft handling (title `Draft:`/`WIP:`) is untouched.

## Tests
TDD RED→GREEN. `yarn verify` green — 4182 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)