### PR TITLE
fix: #359 write resolved config port to daemon pid file

### DIFF
--- a/src/main/commands/start.command.ts
+++ b/src/main/commands/start.command.ts
@@ -49,7 +49,7 @@ export function executeStart(
 
   if (daemon) {
     const usecase = new StartDaemonUseCase(deps.startDaemonDeps);
-    const result = usecase.execute({ daemon: true, port });
+    const result = usecase.execute({ daemon: true, port: resolvedPort });
 
     switch (result.status) {
       case 'started':

--- a/src/tests/units/main/executeStart.test.ts
+++ b/src/tests/units/main/executeStart.test.ts
@@ -198,4 +198,19 @@ describe('executeStart', () => {
       expect(deps.log).toHaveBeenCalledWith(expect.stringContaining('8080'));
     });
   });
+
+  it('should write the config default port to the pid file when no port is specified', () => {
+    const writePidFile = vi.fn();
+    const deps = createFakeDeps({
+      startDaemonDeps: createFakeStartDaemonDeps({ writePidFile }),
+      loadStartupInfo: () => ({
+        enabledPlatforms: [] as Array<'gitlab' | 'github'>,
+        defaultPort: 3847,
+      }),
+    });
+
+    executeStart(true, true, undefined, false, deps);
+
+    expect(writePidFile).toHaveBeenCalledWith(expect.objectContaining({ port: 3847 }));
+  });
 });


### PR DESCRIPTION
Closes #359

## Problem

`executeStart` resolves `resolvedPort = port ?? config.server.port` for the startup banner, but passes the **raw** CLI `port` to `StartDaemonUseCase`. With no `--port` flag that value is `undefined`, so the use case falls back to its hardcoded `DEFAULT_PORT = 3000` and writes it to the pid file — while the spawned daemon re-reads the config and binds the real port.

Result: banner right, pid file wrong. `reviewflow status` reported 3000 for a daemon listening on 3847.

## Fix

One line — pass `resolvedPort` instead of `port` to the use case (`src/main/commands/start.command.ts:52`).

`StartDaemonUseCase` keeps its `DEFAULT_PORT` fallback as a safety net; `spawnDaemon` now receives an explicit `--port`, which resolves to the same value the config would have produced.

## Test

RED test added in `src/tests/units/main/executeStart.test.ts` — daemon mode with no `--port` and `defaultPort: 3847` must write `port: 3847` to the pid file. Failed with 3000 before the fix.

`yarn verify` green: 4230 tests, 503 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)