### PR TITLE
fix: trigger mode chip + macOS desktop notifications

### DIFF
--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -3472,6 +3472,7 @@
     window.checkClaudeStatus = checkClaudeStatus;
     window.toggleLogs = toggleLogs;
     window.changeModel = changeModel;
+    window.changeTriggerMode = changeTriggerMode;
     window.changeReviewTimeout = changeReviewTimeout;
     window.changeLanguage = changeLanguage;
     window.toggleReviewAccordion = toggleReviewAccordion;

--- a/src/frameworks/claude/claudeInvoker.ts
+++ b/src/frameworks/claude/claudeInvoker.ts
@@ -8,6 +8,7 @@ import type { Logger } from 'pino';
 import { getProjectAgents, getFollowupAgents, loadProjectConfig } from '@/config/projectConfig.js';
 import { buildAuditScopeDirective } from '@/frameworks/claude/auditScopeDirective.js';
 import { broadcastBudgetAfterUsage } from '@/frameworks/claude/broadcastBudgetAfterUsage.js';
+import { buildDesktopNotificationCommand } from '@/frameworks/claude/desktopNotification.js';
 import { buildLanguageDirective } from '@/frameworks/claude/languageDirective.js';
 import { logInfo, logWarn, logError } from '@/frameworks/logging/logBuffer.js';
 import { getModel, getReviewTimeoutMs } from '@/frameworks/settings/runtimeSettings.js';
@@ -809,20 +810,14 @@ async function invokeViaBackgroundSession(
  * Send desktop notification
  */
 export function sendNotification(title: string, message: string, logger: Logger): void {
+  const { command, args } = buildDesktopNotificationCommand(process.platform, title, message);
   try {
-    // Use notify-send on Linux
-    const child = spawn('notify-send', [
-      '--app-name=Claude Review',
-      '--urgency=normal',
-      '--icon=dialog-information',
-      title,
-      message,
-    ]);
+    const child = spawn(command, args);
 
     child.on('error', (error) => {
-      logger.warn({ error }, 'Notification desktop non disponible');
+      logger.warn({ error, command }, 'Notification desktop non disponible');
     });
-  } catch {
-    logger.warn('notify-send non disponible');
+  } catch (error) {
+    logger.warn({ error, command }, 'Notification desktop non disponible');
   }
 }

--- a/src/frameworks/claude/desktopNotification.ts
+++ b/src/frameworks/claude/desktopNotification.ts
@@ -1,0 +1,44 @@
+export type DesktopNotificationCommand = {
+  command: string;
+  args: string[];
+};
+
+/**
+ * AppleScript takes the notification as a quoted string literal inside a single
+ * `-e` argument, so quotes and backslashes have to be escaped and newlines
+ * removed — a raw newline would terminate the statement. Backslashes are
+ * escaped first, otherwise the backslash added for a quote would itself be
+ * doubled.
+ */
+function toAppleScriptLiteral(value: string): string {
+  return value
+    .replaceAll('\\', '\\\\')
+    .replaceAll('"', '\\"')
+    .replaceAll(/[\r\n]+/g, ' ');
+}
+
+/**
+ * macOS has no `notify-send`; `osascript` is part of the base system. Linux and
+ * anything else keeps `notify-send`, which is where it is expected to exist.
+ */
+export function buildDesktopNotificationCommand(
+  platform: NodeJS.Platform,
+  title: string,
+  message: string,
+): DesktopNotificationCommand {
+  if (platform === 'darwin') {
+    const script = `display notification "${toAppleScriptLiteral(message)}" with title "${toAppleScriptLiteral(title)}"`;
+    return { command: 'osascript', args: ['-e', script] };
+  }
+
+  return {
+    command: 'notify-send',
+    args: [
+      '--app-name=Claude Review',
+      '--urgency=normal',
+      '--icon=dialog-information',
+      title,
+      message,
+    ],
+  };
+}

--- a/src/tests/units/dashboard/inlineHandlerExports.test.ts
+++ b/src/tests/units/dashboard/inlineHandlerExports.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Issue #366 — inline `onchange` / `onclick` attributes resolve identifiers in
+ * GLOBAL scope, but the dashboard script is `type="module"`, so every handler
+ * referenced from an inline attribute must be assigned onto `window`.
+ *
+ * Structural assertion on src/dashboard/index.html via raw-string + regex,
+ * matching the precedent of dashboardLayout.test.ts.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const PROJECT_ROOT = join(__dirname, '..', '..', '..', '..');
+const INDEX_HTML_PATH = join(PROJECT_ROOT, 'src', 'dashboard', 'index.html');
+
+function readIndexHtml(): string {
+  return readFileSync(INDEX_HTML_PATH, 'utf-8');
+}
+
+function collectInlineHandlerNames(html: string): string[] {
+  const names = new Set<string>();
+  for (const match of html.matchAll(/\son(?:change|click|input|submit)="([a-zA-Z_$][\w$]*)\(/g)) {
+    const name = match[1];
+    if (name) names.add(name);
+  }
+  return [...names].sort();
+}
+
+function collectWindowExports(html: string): string[] {
+  const names = new Set<string>();
+  for (const match of html.matchAll(/window\.([a-zA-Z_$][\w$]*)\s*=/g)) {
+    const name = match[1];
+    if (name) names.add(name);
+  }
+  return [...names].sort();
+}
+
+describe('dashboard inline handler exports', () => {
+  it('exposes changeTriggerMode on window so the trigger mode chip works', () => {
+    expect(collectWindowExports(readIndexHtml())).toContain('changeTriggerMode');
+  });
+
+  it('exposes every function referenced by an inline handler attribute', () => {
+    const html = readIndexHtml();
+    const exported = new Set(collectWindowExports(html));
+    const missing = collectInlineHandlerNames(html).filter((name) => !exported.has(name));
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/src/tests/units/frameworks/claude/desktopNotification.test.ts
+++ b/src/tests/units/frameworks/claude/desktopNotification.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildDesktopNotificationCommand } from '@/frameworks/claude/desktopNotification.js';
+
+describe('buildDesktopNotificationCommand', () => {
+  describe('on macOS', () => {
+    it('uses osascript, which ships with the OS', () => {
+      const command = buildDesktopNotificationCommand('darwin', 'Review terminée', 'MR !42');
+
+      expect(command.command).toBe('osascript');
+      expect(command.args).toEqual([
+        '-e',
+        'display notification "MR !42" with title "Review terminée"',
+      ]);
+    });
+
+    it('escapes double quotes so a quoted MR title cannot break the AppleScript', () => {
+      const command = buildDesktopNotificationCommand('darwin', 'Review', 'MR "quoted" title');
+
+      expect(command.args[1]).toBe(
+        'display notification "MR \\"quoted\\" title" with title "Review"',
+      );
+    });
+
+    it('escapes backslashes before quotes so escaping cannot be smuggled', () => {
+      const command = buildDesktopNotificationCommand('darwin', 'Review', 'path\\to\\file');
+
+      expect(command.args[1]).toBe('display notification "path\\\\to\\\\file" with title "Review"');
+    });
+
+    it('strips newlines, which would terminate the AppleScript statement', () => {
+      const command = buildDesktopNotificationCommand('darwin', 'Review', 'line one\nline two');
+
+      expect(command.args[1]).toBe('display notification "line one line two" with title "Review"');
+    });
+  });
+
+  describe('on Linux', () => {
+    it('keeps notify-send with the existing flags', () => {
+      const command = buildDesktopNotificationCommand('linux', 'Review terminée', 'MR !42');
+
+      expect(command.command).toBe('notify-send');
+      expect(command.args).toEqual([
+        '--app-name=Claude Review',
+        '--urgency=normal',
+        '--icon=dialog-information',
+        'Review terminée',
+        'MR !42',
+      ]);
+    });
+
+    it('passes title and message through untouched, since they are separate argv entries', () => {
+      const command = buildDesktopNotificationCommand('linux', 'Review', 'MR "quoted" title');
+
+      expect(command.args.at(-1)).toBe('MR "quoted" title');
+    });
+  });
+
+  it('falls back to notify-send on other platforms', () => {
+    expect(buildDesktopNotificationCommand('freebsd', 'Review', 'MR !42').command).toBe(
+      'notify-send',
+    );
+  });
+});


### PR DESCRIPTION
Closes #366. Closes #367.

Two independent bugs, one commit each. Grouped in a single PR because both are small and were diagnosed in the same session — say the word and I'll split them.

## #366 — trigger mode chip was a no-op

`src/dashboard/index.html` serves its script as `type="module"`, so inline `onchange` attributes resolve identifiers in **global** scope only. `changeTriggerMode` was never added to the `window` export list, so selecting `Semi-auto` threw a `ReferenceError` and never issued the POST — semi-auto was unreachable from the UI.

Verified live on the running dashboard before the fix:

```js
typeof changeTriggerMode   // "undefined"  <- inline onchange cannot resolve it
typeof changeModel         // "function"
typeof changeReviewTimeout // "function"
```

`git log -S"window.changeTriggerMode"` returns nothing, so this never worked — it is not a regression.

The test guards the whole class of bug rather than this one handler: it cross-checks every function referenced by an inline handler attribute against the `window` export list. `changeTriggerMode` was the only gap.

## #367 — desktop notifications never fired on macOS

`sendNotification` spawned `notify-send` unconditionally. Linux-only binary, absent on macOS, so every spawn failed with `ENOENT` and `child.on('error')` swallowed it. The only trace was `WARN: Notification desktop non disponible` in the daemon log.

The platform branch is extracted into a pure `buildDesktopNotificationCommand`, so it is unit-tested without spawning. On `darwin` it builds `osascript -e 'display notification "…" with title "…"'`; everything else keeps `notify-send` with its existing flags.

AppleScript takes the notification as a quoted literal inside one `-e` argument, so backslashes are escaped first, then quotes, and newlines are stripped — a quoted MR title would otherwise break the statement. Verified on macOS 24.6.0: `osascript -e 'display notification …'` exits 0 and displays.

The `catch` block now logs the same message as the error handler; it previously named `notify-send` specifically, which is misleading on macOS.

Unrelated note: the dashboard's **browser** notification path (`desktopNotifications.js`) already worked on macOS — verified by constructing a `Notification` live (`permission: "granted"`, `onshow` fired). But it needs the dashboard tab open. `notify-send` was the OS-level path that worked without a browser, and that is what macOS users had lost.

## Verification

`yarn verify` → 506 files, 4256 tests passing, typecheck and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)