### PR TITLE
fix: close follow-up threads and reply inside the conversation on GitHub

### DIFF
--- a/src/main/executeReviewWiring.ts
+++ b/src/main/executeReviewWiring.ts
@@ -37,6 +37,7 @@ import type { DiffStatsFetchGateway } from '@/modules/shared-kernel/entities/dif
 import type { Platform } from '@/modules/tracking/entities/tracking/reviewRequestTracking.gateway.js';
 import type { RecordReviewCompletionUseCase } from '@/modules/tracking/usecases/tracking/recordReviewCompletion.usecase.js';
 import type { SyncThreadsUseCase } from '@/modules/tracking/usecases/tracking/syncThreads.usecase.js';
+import { countSucceeded, emptyExecutionResult } from '@/shared/foundation/executionGateway.base.js';
 
 const progressWatcher = {
   start: startWatchingReviewContext,
@@ -170,9 +171,6 @@ export function buildExecuteReview(wiring: ExecuteReviewWiringDependencies): Exe
     sendNotification: (title, message) => sendNotification(title, message, logger),
     resolveThreads,
     executeContextActions: async ({ context, localPath, baseUrl }) => {
-      const threadsClosed = context.actions.filter(
-        (action) => action.type === 'THREAD_RESOLVE',
-      ).length;
       const result = await executeActionsFromContext(
         context,
         localPath,
@@ -181,16 +179,13 @@ export function buildExecuteReview(wiring: ExecuteReviewWiringDependencies): Exe
         baseUrl,
         noteCommentPostGateway,
       );
-      return { result, threadsClosed };
+      return { result, threadsClosed: countSucceeded(result, 'THREAD_RESOLVE') };
     },
     executeFallbackActions: async ({ stdout, job }) => {
       const threadActions = parseThreadActions(stdout);
       if (threadActions.length === 0) {
-        return { result: { total: 0, succeeded: 0, failed: 0, skipped: 0 }, threadsClosed: 0 };
+        return { result: emptyExecutionResult(), threadsClosed: 0 };
       }
-      const threadsClosed = threadActions.filter(
-        (action) => action.type === 'THREAD_RESOLVE',
-      ).length;
       const result = await dispatchConstrainedActions(threadActions, {
         context: {
           platform,
@@ -204,7 +199,7 @@ export function buildExecuteReview(wiring: ExecuteReviewWiringDependencies): Exe
         executor: defaultCommandExecutor,
         postGateway: noteCommentPostGateway,
       });
-      return { result, threadsClosed };
+      return { result, threadsClosed: countSucceeded(result, 'THREAD_RESOLVE') };
     },
     fetchDiffMetadata: (projectPath, mergeRequestNumber) =>
       diffMetadataFetchGateway.fetchDiffMetadata(projectPath, mergeRequestNumber),

--- a/src/modules/platform-integration/entities/noteComment/noteCommentPost.gateway.ts
+++ b/src/modules/platform-integration/entities/noteComment/noteCommentPost.gateway.ts
@@ -4,6 +4,11 @@ export interface NoteCommentPostInput {
   body: string;
 }
 
+export interface NoteCommentThreadReplyInput extends NoteCommentPostInput {
+  threadId: string;
+}
+
 export interface NoteCommentPostGateway {
   postComment(input: NoteCommentPostInput): Promise<void>;
+  postThreadReply(input: NoteCommentThreadReplyInput): Promise<void>;
 }

--- a/src/modules/platform-integration/interface-adapters/gateways/cli/noteCommentPost.github.cli.gateway.ts
+++ b/src/modules/platform-integration/interface-adapters/gateways/cli/noteCommentPost.github.cli.gateway.ts
@@ -1,17 +1,34 @@
 import type {
   NoteCommentPostGateway,
   NoteCommentPostInput,
+  NoteCommentThreadReplyInput,
 } from '@/modules/platform-integration/entities/noteComment/noteCommentPost.gateway.js';
 import type { CommandExecutor } from '@/modules/platform-integration/interface-adapters/gateways/threadFetch.github.gateway.js';
+
+// Single-quote for the shell: the executor runs this string through /bin/sh,
+// and a markdown body (backticks, $(), parens) must not be interpreted/injected.
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+const ADD_THREAD_REPLY_MUTATION =
+  'mutation($threadId: ID!, $body: String!) { addPullRequestReviewThreadReply(input: { pullRequestReviewThreadId: $threadId, body: $body }) { comment { id } } }';
 
 export class GitHubNoteCommentPostCliGateway implements NoteCommentPostGateway {
   constructor(private readonly executor: CommandExecutor) {}
 
   async postComment(input: NoteCommentPostInput): Promise<void> {
-    // Single-quote for the shell: the executor runs this string through /bin/sh,
-    // and a markdown body (backticks, $(), parens) must not be interpreted/injected.
-    const quotedBody = `'${input.body.replace(/'/g, "'\\''")}'`;
-    const command = `gh api --method POST repos/${input.projectPath}/issues/${input.mrNumber}/comments --field body=${quotedBody}`;
+    const command = `gh api --method POST repos/${input.projectPath}/issues/${input.mrNumber}/comments --field body=${shellQuote(input.body)}`;
+    this.executor(command);
+  }
+
+  /**
+   * Replies inside the review thread itself. The thread is addressed by its GraphQL
+   * node id (`PRRT_…`), which the REST comment endpoints cannot target — hence the
+   * mutation rather than a `--field in_reply_to`.
+   */
+  async postThreadReply(input: NoteCommentThreadReplyInput): Promise<void> {
+    const command = `gh api graphql -f query=${shellQuote(ADD_THREAD_REPLY_MUTATION)} -f threadId=${shellQuote(input.threadId)} -f body=${shellQuote(input.body)}`;
     this.executor(command);
   }
 }

--- a/src/modules/platform-integration/interface-adapters/gateways/cli/noteCommentPost.gitlab.cli.gateway.ts
+++ b/src/modules/platform-integration/interface-adapters/gateways/cli/noteCommentPost.gitlab.cli.gateway.ts
@@ -1,18 +1,28 @@
 import type {
   NoteCommentPostGateway,
   NoteCommentPostInput,
+  NoteCommentThreadReplyInput,
 } from '@/modules/platform-integration/entities/noteComment/noteCommentPost.gateway.js';
 import type { CommandExecutor } from '@/modules/platform-integration/interface-adapters/gateways/threadFetch.gitlab.gateway.js';
+
+// Single-quote for the shell: the executor runs this string through /bin/sh,
+// and a markdown body (backticks, $(), parens) must not be interpreted/injected.
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
 
 export class GitLabNoteCommentPostCliGateway implements NoteCommentPostGateway {
   constructor(private readonly executor: CommandExecutor) {}
 
   async postComment(input: NoteCommentPostInput): Promise<void> {
     const encodedProject = input.projectPath.replace(/\//g, '%2F');
-    // Single-quote for the shell: the executor runs this string through /bin/sh,
-    // and a markdown body (backticks, $(), parens) must not be interpreted/injected.
-    const quotedBody = `'${input.body.replace(/'/g, "'\\''")}'`;
-    const command = `glab api --method POST projects/${encodedProject}/merge_requests/${input.mrNumber}/notes --field body=${quotedBody}`;
+    const command = `glab api --method POST projects/${encodedProject}/merge_requests/${input.mrNumber}/notes --field body=${shellQuote(input.body)}`;
+    this.executor(command);
+  }
+
+  async postThreadReply(input: NoteCommentThreadReplyInput): Promise<void> {
+    const encodedProject = input.projectPath.replace(/\//g, '%2F');
+    const command = `glab api --method POST projects/${encodedProject}/merge_requests/${input.mrNumber}/discussions/${input.threadId}/notes --field body=${shellQuote(input.body)}`;
     this.executor(command);
   }
 }

--- a/src/modules/platform-integration/interface-adapters/gateways/egressScanned.noteCommentPost.gateway.ts
+++ b/src/modules/platform-integration/interface-adapters/gateways/egressScanned.noteCommentPost.gateway.ts
@@ -3,6 +3,7 @@ import type { EgressTraceGateway } from '@/modules/platform-integration/entities
 import type {
   NoteCommentPostGateway,
   NoteCommentPostInput,
+  NoteCommentThreadReplyInput,
 } from '@/modules/platform-integration/entities/noteComment/noteCommentPost.gateway.js';
 
 export class EgressBlockedError extends Error {
@@ -38,5 +39,24 @@ export class EgressScannedNoteCommentPostGateway implements NoteCommentPostGatew
     }
 
     await this.sink.postComment({ ...input, body: result.body });
+  }
+
+  async postThreadReply(input: NoteCommentThreadReplyInput): Promise<void> {
+    const result = this.scanner.scan({
+      body: input.body,
+      channel: 'THREAD_REPLY',
+      projectPath: input.projectPath,
+    });
+
+    if (result.decision === 'block') {
+      this.trace.record(result.trace);
+      throw new EgressBlockedError(result.trace.channel);
+    }
+
+    if (result.decision === 'redact') {
+      this.trace.record(result.trace);
+    }
+
+    await this.sink.postThreadReply({ ...input, body: result.body });
   }
 }

--- a/src/modules/review-execution/services/actionExecutionReport.ts
+++ b/src/modules/review-execution/services/actionExecutionReport.ts
@@ -1,0 +1,42 @@
+import type { ReviewAction } from '@/modules/review-execution/entities/reviewAction/reviewAction.js';
+import type { ExecutionResult } from '@/shared/foundation/executionGateway.base.js';
+
+interface FailureLogger {
+  error: (obj: object, msg: string) => void;
+}
+
+/**
+ * A platform command that fails leaves no trace of its own — the gateway records the
+ * outcome but writes nothing. Without this, a resolve rejected by the API is reported
+ * exactly like one that landed.
+ */
+export function logExecutionFailures(result: ExecutionResult, logger: FailureLogger): void {
+  for (const outcome of result.outcomes) {
+    if (outcome.status === 'failed') {
+      logger.error(
+        { actionType: outcome.type, error: outcome.message },
+        'Review action command failed',
+      );
+    }
+  }
+}
+
+/**
+ * Public-output actions bypass the CLI gateway for the scanned post sink, which either
+ * delivers or throws. Fold them back in so the caller sees one outcome per action.
+ */
+export function mergeSinkedOutcomes(
+  cliResult: ExecutionResult,
+  sinkedActions: ReviewAction[],
+): ExecutionResult {
+  return {
+    total: cliResult.total + sinkedActions.length,
+    succeeded: cliResult.succeeded + sinkedActions.length,
+    failed: cliResult.failed,
+    skipped: cliResult.skipped,
+    outcomes: [
+      ...cliResult.outcomes,
+      ...sinkedActions.map((action) => ({ type: action.type, status: 'succeeded' as const })),
+    ],
+  };
+}

--- a/src/modules/review-execution/services/contextActionsExecutor.ts
+++ b/src/modules/review-execution/services/contextActionsExecutor.ts
@@ -5,6 +5,10 @@ import type { ReviewContext } from '@/modules/review-execution/entities/reviewCo
 import { GitHubReviewActionCliGateway } from '@/modules/review-execution/interface-adapters/gateways/cli/reviewAction.github.cli.gateway.js';
 import { GitLabReviewActionCliGateway } from '@/modules/review-execution/interface-adapters/gateways/cli/reviewAction.gitlab.cli.gateway.js';
 import {
+  logExecutionFailures,
+  mergeSinkedOutcomes,
+} from '@/modules/review-execution/services/actionExecutionReport.js';
+import {
   executePublicOutput,
   isPublicOutputAction,
 } from '@/modules/review-execution/services/publicOutputExecutor.js';
@@ -91,7 +95,9 @@ export async function executeActionsFromContext(
       : new GitHubReviewActionCliGateway(executor);
 
   if (postGateway === null) {
-    return gateway.execute(allowed, gatewayContext);
+    const result = await gateway.execute(allowed, gatewayContext);
+    logExecutionFailures(result, logger);
+    return result;
   }
 
   const publicOutputActions = allowed.filter(isPublicOutputAction);
@@ -104,11 +110,7 @@ export async function executeActionsFromContext(
   );
 
   const cliResult = await gateway.execute(remainingActions, gatewayContext);
+  logExecutionFailures(cliResult, logger);
 
-  return {
-    total: allowed.length,
-    succeeded: cliResult.succeeded + publicOutputActions.length,
-    failed: cliResult.failed,
-    skipped: cliResult.skipped,
-  };
+  return mergeSinkedOutcomes(cliResult, publicOutputActions);
 }

--- a/src/modules/review-execution/services/publicOutputExecutor.ts
+++ b/src/modules/review-execution/services/publicOutputExecutor.ts
@@ -23,6 +23,11 @@ export function isPublicOutputAction(action: ReviewAction): boolean {
   return publicOutputBody(action) !== null;
 }
 
+/**
+ * Every public-output body goes through the scanned sink, but the destination differs:
+ * a THREAD_REPLY belongs inside its thread. Posting it as a top-level note would keep
+ * the scan and lose the conversation it answers.
+ */
 export async function executePublicOutput(
   actions: PublicOutputAction[],
   context: PublicOutputContext,
@@ -33,6 +38,17 @@ export async function executePublicOutput(
     if (body === null) {
       continue;
     }
+
+    if (action.type === 'THREAD_REPLY') {
+      await postGateway.postThreadReply({
+        projectPath: context.projectPath,
+        mrNumber: context.mrNumber,
+        threadId: action.threadId,
+        body,
+      });
+      continue;
+    }
+
     await postGateway.postComment({
       projectPath: context.projectPath,
       mrNumber: context.mrNumber,

--- a/src/modules/review-execution/services/threadActionsExecutor.ts
+++ b/src/modules/review-execution/services/threadActionsExecutor.ts
@@ -8,6 +8,10 @@ import type { DiffMetadata } from '@/modules/review-execution/entities/reviewCon
 import { GitHubReviewActionCliGateway } from '@/modules/review-execution/interface-adapters/gateways/cli/reviewAction.github.cli.gateway.js';
 import { GitLabReviewActionCliGateway } from '@/modules/review-execution/interface-adapters/gateways/cli/reviewAction.gitlab.cli.gateway.js';
 import {
+  logExecutionFailures,
+  mergeSinkedOutcomes,
+} from '@/modules/review-execution/services/actionExecutionReport.js';
+import {
   executePublicOutput,
   isPublicOutputAction,
 } from '@/modules/review-execution/services/publicOutputExecutor.js';
@@ -87,7 +91,9 @@ export async function executeThreadActions(
       : new GitHubReviewActionCliGateway(executor);
 
   if (postGateway === null) {
-    return gateway.execute(effectiveActions, gatewayContext);
+    const result = await gateway.execute(effectiveActions, gatewayContext);
+    logExecutionFailures(result, logger);
+    return result;
   }
 
   const publicOutputActions = effectiveActions.filter(isPublicOutputAction);
@@ -100,13 +106,9 @@ export async function executeThreadActions(
   );
 
   const cliResult = await gateway.execute(remainingActions, gatewayContext);
+  logExecutionFailures(cliResult, logger);
 
-  return {
-    total: effectiveActions.length,
-    succeeded: cliResult.succeeded + publicOutputActions.length,
-    failed: cliResult.failed,
-    skipped: cliResult.skipped,
-  };
+  return mergeSinkedOutcomes(cliResult, publicOutputActions);
 }
 
 export const defaultCommandExecutor: CommandExecutor = (

--- a/src/modules/review-execution/usecases/executeReview.usecase.ts
+++ b/src/modules/review-execution/usecases/executeReview.usecase.ts
@@ -155,16 +155,38 @@ function buildProgressReporter(
   };
 }
 
+/**
+ * Claude reaches the platform only by appending actions to the review context file
+ * (the MCP `add_action` tool); the prompt forbids stdout markers. An unreadable context
+ * therefore means every action Claude asked for is already lost — no thread resolved,
+ * no reply, no report. That is a failed review, not a case for the marker fallback,
+ * which would report success while publishing nothing.
+ */
+const CONTEXT_UNREADABLE_REASON =
+  'review context is unreadable after the run: every requested action was lost';
+
 async function executePostReviewActions(
   input: ExecuteReviewInput,
   deps: ExecuteReviewDependencies,
   mergeRequestId: string,
   stdout: string,
-): Promise<number> {
+): Promise<number | null> {
   const { job, platform } = input;
   const context = deps.reviewContextGateway.read(job.localPath, mergeRequestId);
 
-  if (context && context.actions.length > 0) {
+  if (!context) {
+    deps.logger.error(
+      {
+        mrNumber: job.mrNumber,
+        localPath: job.localPath,
+        contextFilePath: deps.reviewContextGateway.getFilePath(job.localPath, mergeRequestId),
+      },
+      CONTEXT_UNREADABLE_REASON,
+    );
+    return null;
+  }
+
+  if (context.actions.length > 0) {
     const outcome = await deps.executeContextActions({
       context,
       localPath: job.localPath,
@@ -241,6 +263,11 @@ export async function executeReview(
 
   const parsed = parseReviewOutput(result.stdout);
   const threadsClosed = await executePostReviewActions(input, deps, mergeRequestId, result.stdout);
+
+  if (threadsClosed === null) {
+    deps.sendNotification(`Review ${followupSuffix}échouée`, messageTarget);
+    return { status: 'failed', reason: CONTEXT_UNREADABLE_REASON };
+  }
 
   deps.reviewContextGateway.setResult(
     job.localPath,

--- a/src/shared/foundation/executionGateway.base.ts
+++ b/src/shared/foundation/executionGateway.base.ts
@@ -1,8 +1,18 @@
+export type ExecutionOutcome =
+  | { type: string; status: 'succeeded' }
+  | { type: string; status: 'skipped' }
+  | { type: string; status: 'failed'; message: string };
+
 export interface ExecutionResult {
   total: number;
   succeeded: number;
   failed: number;
   skipped: number;
+  /**
+   * One entry per action, in execution order. Counts alone hide which verb failed and
+   * why, so a resolve that never ran used to be indistinguishable from one that did.
+   */
+  outcomes: ExecutionOutcome[];
 }
 
 export type CommandExecutor = (command: string, args: string[], cwd: string) => void;
@@ -12,7 +22,20 @@ export interface CommandInfo {
   args: string[];
 }
 
-export abstract class ExecutionGatewayBase<TAction, TContext extends { localPath: string }> {
+export function countSucceeded(result: ExecutionResult, actionType: string): number {
+  return result.outcomes.filter(
+    (outcome) => outcome.type === actionType && outcome.status === 'succeeded',
+  ).length;
+}
+
+export function emptyExecutionResult(): ExecutionResult {
+  return { total: 0, succeeded: 0, failed: 0, skipped: 0, outcomes: [] };
+}
+
+export abstract class ExecutionGatewayBase<
+  TAction extends { type: string },
+  TContext extends { localPath: string },
+> {
   constructor(protected readonly executor: CommandExecutor) {}
 
   protected abstract buildCommand(action: TAction, context: TContext): CommandInfo | null;
@@ -23,6 +46,7 @@ export abstract class ExecutionGatewayBase<TAction, TContext extends { localPath
       succeeded: 0,
       failed: 0,
       skipped: 0,
+      outcomes: [],
     };
 
     for (const action of actions) {
@@ -30,14 +54,21 @@ export abstract class ExecutionGatewayBase<TAction, TContext extends { localPath
 
       if (command === null) {
         result.skipped++;
+        result.outcomes.push({ type: action.type, status: 'skipped' });
         continue;
       }
 
       try {
         this.executor(command.command, command.args, context.localPath);
         result.succeeded++;
-      } catch {
+        result.outcomes.push({ type: action.type, status: 'succeeded' });
+      } catch (error) {
         result.failed++;
+        result.outcomes.push({
+          type: action.type,
+          status: 'failed',
+          message: error instanceof Error ? error.message : String(error),
+        });
       }
     }
 

--- a/src/tests/acceptance/196-least-privilege-platform-token.acceptance.test.ts
+++ b/src/tests/acceptance/196-least-privilege-platform-token.acceptance.test.ts
@@ -53,12 +53,26 @@ class RecordingCliExecutor {
 
 class RecordingPostGateway {
   readonly posts: Array<{ projectPath: string; mrNumber: number; body: string }> = [];
+  readonly threadReplies: Array<{
+    projectPath: string;
+    mrNumber: number;
+    threadId: string;
+    body: string;
+  }> = [];
   postComment = async (input: {
     projectPath: string;
     mrNumber: number;
     body: string;
   }): Promise<void> => {
     this.posts.push(input);
+  };
+  postThreadReply = async (input: {
+    projectPath: string;
+    mrNumber: number;
+    threadId: string;
+    body: string;
+  }): Promise<void> => {
+    this.threadReplies.push(input);
   };
 }
 

--- a/src/tests/acceptance/199-review-output-egress-scan.acceptance.test.ts
+++ b/src/tests/acceptance/199-review-output-egress-scan.acceptance.test.ts
@@ -80,6 +80,14 @@ const baseContext: ReviewContext = {
   progress: { phase: 'completed', currentStep: null },
 };
 
+/**
+ * One decorated gateway scans every public-output body; the destination still differs
+ * per verb — a reply goes into its thread, a comment into the MR notes.
+ */
+function sinkedBodies(sink: StubNoteCommentPostGateway): string[] {
+  return [...sink.calls, ...sink.threadReplies].map((call) => call.body);
+}
+
 const publicOutputVerbs: Array<{ name: string; action: ReviewAction }> = [
   { name: 'POST_COMMENT', action: { type: 'POST_COMMENT', body: `## Review\ntoken ${SECRET}` } },
   {
@@ -103,9 +111,10 @@ describe('SPEC-199 review output egress scan (acceptance — shared chokepoint a
           gateway,
         );
 
-        expect(sink.calls).toHaveLength(1);
-        expect(sink.calls[0].body).toContain('[REDACTED]');
-        expect(sink.calls[0].body).not.toContain(SECRET);
+        const bodies = sinkedBodies(sink);
+        expect(bodies).toHaveLength(1);
+        expect(bodies[0]).toContain('[REDACTED]');
+        expect(bodies[0]).not.toContain(SECRET);
         expect(executor.secretBearingArgs()).toHaveLength(0);
         expect(trace.traces).toHaveLength(1);
       });
@@ -124,9 +133,10 @@ describe('SPEC-199 review output egress scan (acceptance — shared chokepoint a
           gateway,
         );
 
-        expect(sink.calls).toHaveLength(1);
-        expect(sink.calls[0].body).toContain('[REDACTED]');
-        expect(sink.calls[0].body).not.toContain(SECRET);
+        const bodies = sinkedBodies(sink);
+        expect(bodies).toHaveLength(1);
+        expect(bodies[0]).toContain('[REDACTED]');
+        expect(bodies[0]).not.toContain(SECRET);
         expect(executor.secretBearingArgs()).toHaveLength(0);
         expect(trace.traces).toHaveLength(1);
       });

--- a/src/tests/acceptance/73-execute-review-usecase.acceptance.test.ts
+++ b/src/tests/acceptance/73-execute-review-usecase.acceptance.test.ts
@@ -5,6 +5,7 @@ import {
   type ExecuteReviewDependencies,
 } from '@/modules/review-execution/usecases/executeReview.usecase.js';
 import { RecordReviewCompletionUseCase } from '@/modules/tracking/usecases/tracking/recordReviewCompletion.usecase.js';
+import { emptyExecutionResult } from '@/shared/foundation/executionGateway.base.js';
 import { ReviewJobFactory } from '@/tests/factories/reviewJob.factory.js';
 import { ClaudeReviewInvokerStub } from '@/tests/stubs/claudeReviewInvoker.stub.js';
 import { createStubLogger } from '@/tests/stubs/logger.stub.js';
@@ -50,11 +51,20 @@ function buildDependencies(overrides?: Partial<ExecuteReviewDependencies>): {
       const threadsClosed = context.actions.filter(
         (action) => action.type === 'THREAD_RESOLVE',
       ).length;
-      return { result: { total: 1, succeeded: 1, failed: 0, skipped: 0 }, threadsClosed };
+      return {
+        result: {
+          total: 1,
+          succeeded: 1,
+          failed: 0,
+          skipped: 0,
+          outcomes: [{ type: 'THREAD_RESOLVE', status: 'succeeded' }],
+        },
+        threadsClosed,
+      };
     },
     executeFallbackActions: async () => {
       fallbackActionCalls.push(Date.now());
-      return { result: { total: 1, succeeded: 1, failed: 0, skipped: 0 }, threadsClosed: 0 };
+      return { result: emptyExecutionResult(), threadsClosed: 0 };
     },
     fetchDiffMetadata: () => ({ baseSha: 'a', headSha: 'b', startSha: 'c' }),
     logger: createStubLogger(),

--- a/src/tests/stubs/noteCommentPost.stub.ts
+++ b/src/tests/stubs/noteCommentPost.stub.ts
@@ -1,12 +1,18 @@
 import type {
   NoteCommentPostGateway,
   NoteCommentPostInput,
+  NoteCommentThreadReplyInput,
 } from '@/modules/platform-integration/entities/noteComment/noteCommentPost.gateway.js';
 
 export class StubNoteCommentPostGateway implements NoteCommentPostGateway {
   readonly calls: NoteCommentPostInput[] = [];
+  readonly threadReplies: NoteCommentThreadReplyInput[] = [];
 
   async postComment(input: NoteCommentPostInput): Promise<void> {
     this.calls.push(input);
+  }
+
+  async postThreadReply(input: NoteCommentThreadReplyInput): Promise<void> {
+    this.threadReplies.push(input);
   }
 }

--- a/src/tests/units/modules/platform-integration/interface-adapters/controllers/webhook/diffSizeGuard.helper.test.ts
+++ b/src/tests/units/modules/platform-integration/interface-adapters/controllers/webhook/diffSizeGuard.helper.test.ts
@@ -155,6 +155,9 @@ describe('applyDiffSizeGuard', () => {
       postComment: async () => {
         throw new Error('comment failed');
       },
+      postThreadReply: async () => {
+        throw new Error('reply failed');
+      },
     };
 
     const result = await applyDiffSizeGuard({

--- a/src/tests/units/modules/platform-integration/interface-adapters/gateways/cli/noteCommentPost.cli.shellSafety.test.ts
+++ b/src/tests/units/modules/platform-integration/interface-adapters/gateways/cli/noteCommentPost.cli.shellSafety.test.ts
@@ -45,4 +45,44 @@ describe('CLI note-comment post gateways — shell safety (issue #276)', () => {
 
     expect(parsesAsValidShell(captured)).toBe(true);
   });
+
+  it('GitLab: a thread reply targets the discussion notes endpoint and stays shell-valid', async () => {
+    let captured = '';
+    const gateway = new GitLabNoteCommentPostCliGateway((command: string): string => {
+      captured = command;
+      return '';
+    });
+
+    await gateway.postThreadReply({
+      projectPath: 'group/project',
+      mrNumber: 42,
+      threadId: 'abc123',
+      body: DANGEROUS_BODY,
+    });
+
+    expect(captured).toContain(
+      'projects/group%2Fproject/merge_requests/42/discussions/abc123/notes',
+    );
+    expect(parsesAsValidShell(captured)).toBe(true);
+  });
+
+  it('GitHub: a thread reply uses the review-thread reply mutation and stays shell-valid', async () => {
+    let captured = '';
+    const gateway = new GitHubNoteCommentPostCliGateway((command: string): string => {
+      captured = command;
+      return '';
+    });
+
+    await gateway.postThreadReply({
+      projectPath: 'owner/repo',
+      mrNumber: 7,
+      threadId: 'PRRT_kwDOabc',
+      body: DANGEROUS_BODY,
+    });
+
+    expect(captured).toContain('addPullRequestReviewThreadReply');
+    expect(captured).toContain("threadId='PRRT_kwDOabc'");
+    expect(captured).not.toContain('/issues/7/comments');
+    expect(parsesAsValidShell(captured)).toBe(true);
+  });
 });

--- a/src/tests/units/modules/review-execution/usecases/executeReview.usecase.test.ts
+++ b/src/tests/units/modules/review-execution/usecases/executeReview.usecase.test.ts
@@ -168,6 +168,13 @@ function appendContextActionsDuringInvoke(
   });
 }
 
+/** Reproduces a worktree cleaned up while Claude was running: the context file vanishes. */
+function dropContextDuringInvoke(harness: Harness, mergeRequestId: string): void {
+  harness.claudeInvoker.onInvoke((job) => {
+    harness.contextGateway.delete(job.localPath, mergeRequestId);
+  });
+}
+
 describe('executeReview', () => {
   let harness: Harness;
 
@@ -289,8 +296,49 @@ describe('executeReview', () => {
     });
   });
 
+  describe('unreadable review context', () => {
+    it('returns failed when the context file is gone after Claude ran', async () => {
+      const job = ReviewJobFactory.create({ jobType: 'followup' });
+      const mergeRequestId = `gitlab-${job.projectPath}-${job.mrNumber}`;
+      seedTrackedMr(harness, mergeRequestId);
+      dropContextDuringInvoke(harness, mergeRequestId);
+
+      const result = await executeReview(reviewInput({ job, isFollowup: true }), harness.deps);
+
+      expect(result.status).toBe('failed');
+      if (result.status === 'failed') {
+        expect(result.reason).toContain('review context');
+      }
+    });
+
+    it('notifies failure instead of completion', async () => {
+      const job = ReviewJobFactory.create({ jobType: 'followup' });
+      const mergeRequestId = `gitlab-${job.projectPath}-${job.mrNumber}`;
+      seedTrackedMr(harness, mergeRequestId);
+      dropContextDuringInvoke(harness, mergeRequestId);
+
+      await executeReview(reviewInput({ job, isFollowup: true }), harness.deps);
+
+      expect(harness.notifications.at(-1)?.title).toBe('Review followup échouée');
+    });
+
+    it('never silently falls back to stdout markers and records no stats', async () => {
+      const job = ReviewJobFactory.create({ jobType: 'followup' });
+      const mergeRequestId = `gitlab-${job.projectPath}-${job.mrNumber}`;
+      seedTrackedMr(harness, mergeRequestId);
+      dropContextDuringInvoke(harness, mergeRequestId);
+
+      await executeReview(reviewInput({ job, isFollowup: true }), harness.deps);
+
+      expect(harness.contextActionCalls).toBe(0);
+      expect(harness.fallbackActionCalls).toBe(0);
+      const stored = harness.trackingGateway.getById('/tmp/repos/test-project', mergeRequestId);
+      expect(stored?.reviews.length ?? 0).toBe(0);
+    });
+  });
+
   describe('best-effort context creation', () => {
-    it('still invokes Claude when thread resolution fails', async () => {
+    it('still invokes Claude when thread resolution fails, then reports the lost context', async () => {
       harness.setResolveThreadsError(new Error('thread fetch boom'));
       const job = ReviewJobFactory.create({ jobType: 'review' });
       const mergeRequestId = `gitlab-${job.projectPath}-${job.mrNumber}`;
@@ -298,8 +346,9 @@ describe('executeReview', () => {
 
       const result = await executeReview(reviewInput({ job }), harness.deps);
 
-      expect(result.status).toBe('completed');
       expect(harness.claudeInvoker.invocations).toHaveLength(1);
+      // No context file was ever written, so nothing Claude asked for could be published.
+      expect(result.status).toBe('failed');
     });
 
     it('still invokes Claude when diff metadata fetch fails', async () => {

--- a/src/tests/units/modules/review-execution/usecases/executeReview.usecase.test.ts
+++ b/src/tests/units/modules/review-execution/usecases/executeReview.usecase.test.ts
@@ -7,6 +7,7 @@ import {
   type ExecuteReviewInput,
 } from '@/modules/review-execution/usecases/executeReview.usecase.js';
 import { RecordReviewCompletionUseCase } from '@/modules/tracking/usecases/tracking/recordReviewCompletion.usecase.js';
+import type { ExecutionResult } from '@/shared/foundation/executionGateway.base.js';
 import { ReviewJobFactory } from '@/tests/factories/reviewJob.factory.js';
 import { TrackedMrFactory } from '@/tests/factories/trackedMr.factory.js';
 import { ClaudeReviewInvokerStub } from '@/tests/stubs/claudeReviewInvoker.stub.js';
@@ -17,6 +18,16 @@ import { StubReviewContextGateway } from '@/tests/stubs/reviewContextGateway.stu
 import { InMemoryReviewRequestTrackingGateway } from '@/tests/stubs/reviewRequestTracking.stub.js';
 
 const SUCCESS_STDOUT = '[REVIEW_STATS:blocking=1:warnings=2:suggestions=3:score=7.5]';
+
+function singleSucceededResult(): ExecutionResult {
+  return {
+    total: 1,
+    succeeded: 1,
+    failed: 0,
+    skipped: 0,
+    outcomes: [{ type: 'THREAD_RESOLVE', status: 'succeeded' }],
+  };
+}
 
 interface Harness {
   deps: ExecuteReviewDependencies;
@@ -79,14 +90,14 @@ function createHarness(): Harness {
     executeContextActions: async () => {
       state.contextActionCalls += 1;
       return {
-        result: { total: 1, succeeded: 1, failed: 0, skipped: 0 },
+        result: singleSucceededResult(),
         threadsClosed: state.contextThreadsClosed,
       };
     },
     executeFallbackActions: async () => {
       state.fallbackActionCalls += 1;
       return {
-        result: { total: 1, succeeded: 1, failed: 0, skipped: 0 },
+        result: singleSucceededResult(),
         threadsClosed: state.fallbackThreadsClosed,
       };
     },

--- a/src/tests/units/services/contextActionsExecutor.egress.test.ts
+++ b/src/tests/units/services/contextActionsExecutor.egress.test.ts
@@ -76,7 +76,7 @@ describe('executeActionsFromContext — egress routing (pentest amendment AC7/AC
     expect(rawSecretCalls).toHaveLength(0);
   });
 
-  it('routes a THREAD_REPLY body through the decorated sink, never the raw CLI primitive', async () => {
+  it('routes a THREAD_REPLY body through the decorated thread-reply sink, never the raw CLI primitive', async () => {
     const { sink, gateway } = buildDecoratedSink();
     const rawCalls: string[][] = [];
     const recordingExecutor: CommandExecutor = (_command, args) => {
@@ -96,8 +96,10 @@ describe('executeActionsFromContext — egress routing (pentest amendment AC7/AC
       gateway,
     );
 
-    expect(sink.calls).toHaveLength(1);
-    expect(sink.calls[0].body).not.toContain(SECRET);
+    expect(sink.calls).toHaveLength(0);
+    expect(sink.threadReplies).toHaveLength(1);
+    expect(sink.threadReplies[0].threadId).toBe('abc');
+    expect(sink.threadReplies[0].body).not.toContain(SECRET);
 
     const rawSecretCalls = rawCalls.filter((args) => args.some((arg) => arg.includes(SECRET)));
     expect(rawSecretCalls).toHaveLength(0);
@@ -128,9 +130,10 @@ describe('executeActionsFromContext — egress routing (pentest amendment AC7/AC
       gateway,
     );
 
-    expect(sink.calls).toHaveLength(2);
-    for (const call of sink.calls) {
-      expect(call.body).not.toContain(SECRET);
+    const sinkedBodies = [...sink.calls, ...sink.threadReplies].map((call) => call.body);
+    expect(sinkedBodies).toHaveLength(2);
+    for (const body of sinkedBodies) {
+      expect(body).not.toContain(SECRET);
     }
     const rawSecretCalls = rawCalls.filter((args) => args.some((arg) => arg.includes(SECRET)));
     expect(rawSecretCalls).toHaveLength(0);

--- a/src/tests/units/services/contextActionsExecutor.test.ts
+++ b/src/tests/units/services/contextActionsExecutor.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import type { ReviewContext } from '@/modules/review-execution/entities/reviewContext/reviewContext.js';
 import { executeActionsFromContext } from '@/modules/review-execution/services/contextActionsExecutor.js';
+import { countSucceeded } from '@/shared/foundation/executionGateway.base.js';
 
 // AC6/AC7: the context auto-path executor is bounded to read + postComment.
 // THREAD_RESOLVE / ADD_LABEL are dropped (no-op, logged), POST_COMMENT executes.
@@ -238,5 +239,68 @@ describe('executeActionsFromContext (auto path, capability-bounded)', () => {
     expect(result.total).toBe(2);
     expect(result.failed).toBe(1);
     expect(result.succeeded).toBe(1);
+  });
+
+  describe('a failed command is reported, never counted as done', () => {
+    const contextWithAuthenticatedResolve: ReviewContext = {
+      ...baseContext,
+      threads: [
+        {
+          id: 'PRRT_kwDONxxx',
+          file: 'src/app.ts',
+          line: 3,
+          status: 'open',
+          body: 'blocking finding',
+        },
+      ],
+      actions: [{ type: 'THREAD_RESOLVE', threadId: 'PRRT_kwDONxxx' }],
+    };
+
+    it('logs the command error with the action type', async () => {
+      mockExecutor.mockImplementationOnce(() => {
+        throw new Error('gh: Could not resolve to a node with the global id');
+      });
+
+      await executeActionsFromContext(
+        contextWithAuthenticatedResolve,
+        '/tmp/repo',
+        mockLogger,
+        mockExecutor,
+      );
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        {
+          actionType: 'THREAD_RESOLVE',
+          error: 'gh: Could not resolve to a node with the global id',
+        },
+        'Review action command failed',
+      );
+    });
+
+    it('leaves the failed resolve out of the succeeded count', async () => {
+      mockExecutor.mockImplementationOnce(() => {
+        throw new Error('gh: Could not resolve to a node with the global id');
+      });
+
+      const result = await executeActionsFromContext(
+        contextWithAuthenticatedResolve,
+        '/tmp/repo',
+        mockLogger,
+        mockExecutor,
+      );
+
+      expect(countSucceeded(result, 'THREAD_RESOLVE')).toBe(0);
+    });
+
+    it('counts a resolve that the platform accepted', async () => {
+      const result = await executeActionsFromContext(
+        contextWithAuthenticatedResolve,
+        '/tmp/repo',
+        mockLogger,
+        mockExecutor,
+      );
+
+      expect(countSucceeded(result, 'THREAD_RESOLVE')).toBe(1);
+    });
   });
 });

--- a/src/tests/units/services/publicOutputExecutor.test.ts
+++ b/src/tests/units/services/publicOutputExecutor.test.ts
@@ -27,6 +27,14 @@ function buildDecoratedGateway() {
 
 const context = { projectPath: 'group/project', mrNumber: 42 };
 
+/**
+ * The invariant is one decorated gateway for every public-output body, not one method:
+ * a reply reaches the thread it answers, a comment reaches the MR notes.
+ */
+function bodiesSentThrough(sink: StubNoteCommentPostGateway): string[] {
+  return [...sink.calls, ...sink.threadReplies].map((call) => call.body);
+}
+
 describe('executePublicOutput', () => {
   describe('AC7 — THREAD_REPLY egress is scanned', () => {
     it('routes a THREAD_REPLY body through the decorated sink with redaction', async () => {
@@ -37,9 +45,9 @@ describe('executePublicOutput', () => {
 
       await executePublicOutput(actions, context, gateway);
 
-      expect(sink.calls).toHaveLength(1);
-      expect(sink.calls[0].body).toContain('[REDACTED]');
-      expect(sink.calls[0].body).not.toContain(SECRET);
+      expect(sink.threadReplies).toHaveLength(1);
+      expect(sink.threadReplies[0].body).toContain('[REDACTED]');
+      expect(sink.threadReplies[0].body).not.toContain(SECRET);
     });
   });
 
@@ -57,9 +65,10 @@ describe('executePublicOutput', () => {
 
       await executePublicOutput([action], context, gateway);
 
-      expect(sink.calls).toHaveLength(1);
-      expect(sink.calls[0].body).not.toContain(SECRET);
-      expect(sink.calls[0].body).toContain('[REDACTED]');
+      const bodies = bodiesSentThrough(sink);
+      expect(bodies).toHaveLength(1);
+      expect(bodies[0]).not.toContain(SECRET);
+      expect(bodies[0]).toContain('[REDACTED]');
     });
 
     it('every auto-path public-output verb resolves to one shared decorated sink', async () => {
@@ -71,10 +80,11 @@ describe('executePublicOutput', () => {
 
       await executePublicOutput(actions, context, gateway);
 
-      expect(sink.calls).toHaveLength(2);
-      for (const call of sink.calls) {
-        expect(call.body).not.toContain(SECRET);
-        expect(call.body).toContain('[REDACTED]');
+      const bodies = bodiesSentThrough(sink);
+      expect(bodies).toHaveLength(2);
+      for (const body of bodies) {
+        expect(body).not.toContain(SECRET);
+        expect(body).toContain('[REDACTED]');
       }
     });
 
@@ -87,7 +97,7 @@ describe('executePublicOutput', () => {
 
       await executePublicOutput(actions, context, gateway);
 
-      expect(sink.calls).toHaveLength(0);
+      expect(bodiesSentThrough(sink)).toHaveLength(0);
     });
   });
 });

--- a/src/tests/units/services/publicOutputExecutor.threadReply.test.ts
+++ b/src/tests/units/services/publicOutputExecutor.threadReply.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+
+import { createEgressScanner } from '@/modules/platform-integration/entities/egressScan/egressScan.scanner.js';
+import type { EgressScanConfig } from '@/modules/platform-integration/entities/egressScan/egressScan.scanner.js';
+import { EgressScannedNoteCommentPostGateway } from '@/modules/platform-integration/interface-adapters/gateways/egressScanned.noteCommentPost.gateway.js';
+import { executePublicOutput } from '@/modules/review-execution/services/publicOutputExecutor.js';
+import type { PublicOutputAction } from '@/modules/review-execution/services/publicOutputExecutor.js';
+import { StubEgressTraceGateway } from '@/tests/stubs/egressScan.stub.js';
+import { StubNoteCommentPostGateway } from '@/tests/stubs/noteCommentPost.stub.js';
+
+const SECRET = 'glpat-abcdefghij1234567890';
+
+const redactConfig: EgressScanConfig = {
+  secretShapeMode: 'redact',
+  lengthMode: 'redact',
+  outOfScopeMode: 'redact',
+  maxBodyLength: 10000,
+  redactionMarker: '[REDACTED]',
+  truncationMarker: '…[TRUNCATED]',
+};
+
+function buildDecoratedGateway() {
+  const sink = new StubNoteCommentPostGateway();
+  const trace = new StubEgressTraceGateway();
+  const scanner = createEgressScanner(redactConfig);
+  const gateway = new EgressScannedNoteCommentPostGateway(sink, scanner, trace);
+  return { sink, trace, gateway };
+}
+
+const context = { projectPath: 'owner/repo', mrNumber: 42 };
+
+describe('executePublicOutput — THREAD_REPLY lands in its thread', () => {
+  it('routes a THREAD_REPLY to the thread-reply sink carrying its threadId', async () => {
+    const { sink, gateway } = buildDecoratedGateway();
+    const actions: PublicOutputAction[] = [
+      { type: 'THREAD_REPLY', threadId: 'PRRT_kwDOabc', message: 'Still open — code unchanged.' },
+    ];
+
+    await executePublicOutput(actions, context, gateway);
+
+    expect(sink.calls).toHaveLength(0);
+    expect(sink.threadReplies).toEqual([
+      {
+        projectPath: 'owner/repo',
+        mrNumber: 42,
+        threadId: 'PRRT_kwDOabc',
+        body: 'Still open — code unchanged.',
+      },
+    ]);
+  });
+
+  it('still scans the reply body before it leaves the system', async () => {
+    const { sink, trace, gateway } = buildDecoratedGateway();
+    const actions: PublicOutputAction[] = [
+      { type: 'THREAD_REPLY', threadId: 'PRRT_kwDOabc', message: `fixed, token ${SECRET}` },
+    ];
+
+    await executePublicOutput(actions, context, gateway);
+
+    expect(sink.threadReplies[0].body).toContain('[REDACTED]');
+    expect(sink.threadReplies[0].body).not.toContain(SECRET);
+    expect(trace.traces.map((entry) => entry.channel)).toContain('THREAD_REPLY');
+  });
+
+  it('keeps POST_COMMENT on the top-level note sink', async () => {
+    const { sink, gateway } = buildDecoratedGateway();
+    const actions: PublicOutputAction[] = [{ type: 'POST_COMMENT', body: 'followup report' }];
+
+    await executePublicOutput(actions, context, gateway);
+
+    expect(sink.threadReplies).toHaveLength(0);
+    expect(sink.calls).toHaveLength(1);
+  });
+});

--- a/src/tests/units/services/threadActionsExecutor.egress.test.ts
+++ b/src/tests/units/services/threadActionsExecutor.egress.test.ts
@@ -46,7 +46,7 @@ const gitlabContext: ExecutionContext = {
 };
 
 describe('executeThreadActions — egress routing (pentest amendment AC7/AC9)', () => {
-  it('routes a THREAD_REPLY body through the decorated sink, never the raw CLI primitive', async () => {
+  it('routes a THREAD_REPLY body through the decorated thread-reply sink, never the raw CLI primitive', async () => {
     const { sink, gateway } = buildDecoratedSink();
     const rawCalls: string[][] = [];
     const recordingExecutor: CommandExecutor = (_command, args) => {
@@ -58,9 +58,11 @@ describe('executeThreadActions — egress routing (pentest amendment AC7/AC9)', 
 
     await executeThreadActions(actions, gitlabContext, silentLogger, recordingExecutor, gateway);
 
-    expect(sink.calls).toHaveLength(1);
-    expect(sink.calls[0].body).toContain('[REDACTED]');
-    expect(sink.calls[0].body).not.toContain(SECRET);
+    expect(sink.calls).toHaveLength(0);
+    expect(sink.threadReplies).toHaveLength(1);
+    expect(sink.threadReplies[0].threadId).toBe('abc');
+    expect(sink.threadReplies[0].body).toContain('[REDACTED]');
+    expect(sink.threadReplies[0].body).not.toContain(SECRET);
 
     const reachedRawNotePrimitive = rawCalls.some((args) =>
       args.some((arg) => arg.includes(SECRET) || arg.includes('/notes')),
@@ -133,9 +135,10 @@ describe('executeThreadActions — egress routing (pentest amendment AC7/AC9)', 
 
     await executeThreadActions(actions, gitlabContext, silentLogger, recordingExecutor, gateway);
 
-    expect(sink.calls).toHaveLength(2);
-    for (const call of sink.calls) {
-      expect(call.body).not.toContain(SECRET);
+    const sinkedBodies = [...sink.calls, ...sink.threadReplies].map((call) => call.body);
+    expect(sinkedBodies).toHaveLength(2);
+    for (const body of sinkedBodies) {
+      expect(body).not.toContain(SECRET);
     }
     const rawSecretCalls = rawCalls.filter((args) => args.some((arg) => arg.includes(SECRET)));
     expect(rawSecretCalls).toHaveLength(0);

--- a/src/tests/units/services/threadActionsExecutor.test.ts
+++ b/src/tests/units/services/threadActionsExecutor.test.ts
@@ -186,7 +186,7 @@ describe('executeThreadActions (auto path, capability-bounded)', () => {
 
       const result = await executeThreadActions([], context, mockLogger, mockExecutor);
 
-      expect(result).toEqual({ total: 0, succeeded: 0, failed: 0, skipped: 0 });
+      expect(result).toEqual({ total: 0, succeeded: 0, failed: 0, skipped: 0, outcomes: [] });
       expect(mockExecutor).not.toHaveBeenCalled();
     });
   });

--- a/src/tests/units/shared/foundation/executionGateway.base.test.ts
+++ b/src/tests/units/shared/foundation/executionGateway.base.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  ExecutionGatewayBase,
+  type CommandInfo,
+} from '@/shared/foundation/executionGateway.base.js';
+
+type StubAction = { type: string; skip?: boolean };
+
+class StubExecutionGateway extends ExecutionGatewayBase<StubAction, { localPath: string }> {
+  protected buildCommand(action: StubAction): CommandInfo | null {
+    if (action.skip) {
+      return null;
+    }
+    return { command: 'stub', args: [action.type] };
+  }
+}
+
+describe('ExecutionGatewayBase', () => {
+  it('reports the failing action type and the command error message', async () => {
+    const gateway = new StubExecutionGateway(() => {
+      throw new Error('gh: Could not resolve to a node with the global id');
+    });
+
+    const result = await gateway.execute([{ type: 'THREAD_RESOLVE' }], { localPath: '/tmp/repo' });
+
+    expect(result.failed).toBe(1);
+    expect(result.outcomes).toEqual([
+      {
+        type: 'THREAD_RESOLVE',
+        status: 'failed',
+        message: 'gh: Could not resolve to a node with the global id',
+      },
+    ]);
+  });
+
+  it('records one outcome per action, succeeded and skipped included', async () => {
+    const gateway = new StubExecutionGateway(() => {});
+
+    const result = await gateway.execute(
+      [{ type: 'THREAD_RESOLVE' }, { type: 'POST_INLINE_COMMENT', skip: true }],
+      { localPath: '/tmp/repo' },
+    );
+
+    expect(result.outcomes).toEqual([
+      { type: 'THREAD_RESOLVE', status: 'succeeded' },
+      { type: 'POST_INLINE_COMMENT', status: 'skipped' },
+    ]);
+    expect(result.outcomes).toHaveLength(result.total);
+  });
+});


### PR DESCRIPTION
## Symptom

On a GitHub follow-up review: threads verified as fixed were not closed, and unresolved threads got no reply.

Diagnosed against production logs (`~/.claude-review/logs/mcp-server.log`, `daemon-stdout.log`) and the live thread state via `gh api graphql`.

## What was actually broken

### 1. A reply never reached its thread

`publicOutputBody()` returns a body for `THREAD_REPLY`, so `isPublicOutputAction` was true and the action went to `NoteCommentPostGateway.postComment` — which posts a **top-level PR note**. The `threadId` was dropped. The `addPullRequestReviewThreadReply` mutation added in 44ca36e was dead code on the webhook path, which always wires the scanned post sink.

Evidence — one `THREAD_REPLY` emitted per thread, thread still holds a single comment:

| PR | thread | replies emitted | comments on thread |
|---|---|---|---|
| 1393 | `PRRT_kwDOKCEckc6VBJi0` | 1 | 1 |
| 1395 | `PRRT_kwDOKCEckc6U1txh` | 1 | 1 |
| 1386 | `PRRT_kwDOKCEckc6UewnD` | 1 | 1 |

Counter-proof: the **manual** follow-up path (`mrTrackingAdvanced.routes.ts`) passes no `postGateway`, so it reached the CLI gateway — PR 1390's five replies landed in-thread on 2026-07-29.

The destination was wrong, not the scan. `postThreadReply` keeps the single scanned egress chokepoint and teaches it the thread destination.

### 2. An unreadable context file failed silently

Claude reaches the platform only through the review context file (MCP `add_action`); the prompt forbids stdout markers. When the file was gone, `executePostReviewActions` took the marker fallback, found nothing to parse, and reported "terminée" — no thread resolved, no reply, no report, no error. Observed on PR 1394: `get_threads` and every `add_action` returned an error to Claude, and the run still completed.

### 3. Failures were counted as successes

`ExecutionGatewayBase` swallowed command errors in a bare `catch {}`, and `threadsClosed` was computed from the actions *requested* before execution — so stats reported closed threads for commands that had failed or been dropped by the capability filter.

## Out of scope, found on the way

- `mrTrackingAdvanced.routes.ts:295,312` — the manual follow-up path passes no `postGateway`, so `POST_COMMENT` and `THREAD_REPLY` bypass the SPEC-199 egress scan entirely.
- `executeReviewWiring.ts` hardcodes `resolveProvenance(null)`, so the stdout-marker fallback can never resolve or reply.
- The follow-up templates claim the server runs context actions **and** stdout markers; it runs one or the other.

## Verification

`yarn verify` — 4260 tests, 0 lint/type error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)