### PR TITLE
fix: scan manual follow-up output before it leaves the machine

### DIFF
--- a/src/main/routes.ts
+++ b/src/main/routes.ts
@@ -375,6 +375,24 @@ export async function registerRoutes(app: FastifyInstance, deps: Dependencies): 
     platform === 'github'
       ? new GitHubThreadFetchGateway(defaultGitHubExecutor)
       : new GitLabThreadFetchGateway(defaultGitLabExecutor);
+
+  // The single scanned egress sink per platform (SPEC-199). Built here because the
+  // manual-followup routes registered just below need it as much as the webhook path.
+  const egressScanner = createEgressScanner(defaultEgressScanConfig);
+  const egressTraceGateway = new LoggerEgressTraceGateway(deps.logger);
+  const gitLabNoteCommentPostGateway = new EgressScannedNoteCommentPostGateway(
+    new GitLabNoteCommentPostCliGateway(defaultGitLabExecutor),
+    egressScanner,
+    egressTraceGateway,
+  );
+  const gitHubNoteCommentPostGateway = new EgressScannedNoteCommentPostGateway(
+    new GitHubNoteCommentPostCliGateway(defaultGitHubExecutor),
+    egressScanner,
+    egressTraceGateway,
+  );
+  const noteCommentPostGatewayFactory = (platform: 'gitlab' | 'github') =>
+    platform === 'github' ? gitHubNoteCommentPostGateway : gitLabNoteCommentPostGateway;
+
   await app.register(mrTrackingAdvancedRoutes, {
     getRepositories: () => deps.config.repositories,
     reviewRequestTrackingGateway: deps.reviewRequestTrackingGateway,
@@ -396,6 +414,7 @@ export async function registerRoutes(app: FastifyInstance, deps: Dependencies): 
     recordReviewCompletion: new RecordReviewCompletionUseCase(deps.reviewRequestTrackingGateway),
     enforceBudget,
     broadcastBudgetExceeded,
+    noteCommentPostGatewayFactory,
     claudeInvokerDeps,
     gateClaudeInvocation,
     logger: deps.logger,
@@ -447,9 +466,6 @@ export async function registerRoutes(app: FastifyInstance, deps: Dependencies): 
   const trackingGw = deps.reviewRequestTrackingGateway;
   const threadFetchGw = new GitLabThreadFetchGateway(defaultGitLabExecutor);
 
-  const egressScanner = createEgressScanner(defaultEgressScanConfig);
-  const egressTraceGateway = new LoggerEgressTraceGateway(deps.logger);
-
   // Confirming a parked review rebuilds the real review processor from a code-side
   // registry: the builders close over framework gateways re-created at boot, so a
   // confirmation survives a server restart and is driven only by the persisted
@@ -459,16 +475,6 @@ export async function registerRoutes(app: FastifyInstance, deps: Dependencies): 
 
   const gitLabThreadFetchGatewayForReview = new GitLabThreadFetchGateway(defaultGitLabExecutor);
   const gitHubThreadFetchGatewayForReview = new GitHubThreadFetchGateway(defaultGitHubExecutor);
-  const gitLabNoteCommentPostGateway = new EgressScannedNoteCommentPostGateway(
-    new GitLabNoteCommentPostCliGateway(defaultGitLabExecutor),
-    egressScanner,
-    egressTraceGateway,
-  );
-  const gitHubNoteCommentPostGateway = new EgressScannedNoteCommentPostGateway(
-    new GitHubNoteCommentPostCliGateway(defaultGitHubExecutor),
-    egressScanner,
-    egressTraceGateway,
-  );
 
   const gitLabExecuteReview = buildExecuteReview({
     platform: 'gitlab',

--- a/src/modules/tracking/interface-adapters/controllers/http/mrTrackingAdvanced.routes.ts
+++ b/src/modules/tracking/interface-adapters/controllers/http/mrTrackingAdvanced.routes.ts
@@ -9,6 +9,7 @@ import { logInfo, logError } from '@/frameworks/logging/logBuffer.js';
 import { enqueueReview, createJobId, updateJobProgress } from '@/frameworks/queue/pQueueAdapter.js';
 import { startWatchingReviewContext, stopWatchingReviewContext } from '@/main/websocket.js';
 import type { BudgetExceededPayload } from '@/main/websocket.js';
+import type { NoteCommentPostGateway } from '@/modules/platform-integration/entities/noteComment/noteCommentPost.gateway.js';
 import type { GitHubDiffMetadataFetchGateway } from '@/modules/platform-integration/interface-adapters/gateways/diffMetadataFetch.github.gateway.js';
 import type { GitLabDiffMetadataFetchGateway } from '@/modules/platform-integration/interface-adapters/gateways/diffMetadataFetch.gitlab.gateway.js';
 import type { GitHubThreadFetchGateway } from '@/modules/platform-integration/interface-adapters/gateways/threadFetch.github.gateway.js';
@@ -32,6 +33,7 @@ import type { ReviewRequestTrackingGateway } from '@/modules/tracking/entities/t
 import type { TrackedMr } from '@/modules/tracking/entities/tracking/trackedMr.js';
 import type { RecordReviewCompletionUseCase } from '@/modules/tracking/usecases/tracking/recordReviewCompletion.usecase.js';
 import type { SyncThreadsUseCase } from '@/modules/tracking/usecases/tracking/syncThreads.usecase.js';
+import type { CommandExecutor } from '@/shared/foundation/executionGateway.base.js';
 
 type Platform = 'gitlab' | 'github';
 
@@ -52,6 +54,13 @@ export interface MrTrackingAdvancedRoutesOptions {
   recordReviewCompletion: RecordReviewCompletionUseCase;
   enforceBudget: Pick<EnforceBudgetUseCase, 'execute'>;
   broadcastBudgetExceeded: (payload: BudgetExceededPayload) => void;
+  /**
+   * The scanned egress sink every public-output body must travel through (SPEC-199).
+   * Manual follow-ups used to reach the raw CLI note primitive directly, so a report
+   * or a reply left the machine unscanned.
+   */
+  noteCommentPostGatewayFactory: (platform: Platform) => NoteCommentPostGateway;
+  commandExecutor?: CommandExecutor;
   claudeInvokerDeps?: ClaudeInvokerDependencies;
   gateClaudeInvocation?: GateClaudeInvocationUseCase;
   logger: Logger;
@@ -87,6 +96,8 @@ export const mrTrackingAdvancedRoutes: FastifyPluginAsync<MrTrackingAdvancedRout
     recordReviewCompletion,
     enforceBudget,
     broadcastBudgetExceeded,
+    noteCommentPostGatewayFactory,
+    commandExecutor = defaultCommandExecutor,
     claudeInvokerDeps,
     gateClaudeInvocation,
     logger,
@@ -296,7 +307,9 @@ export const mrTrackingAdvancedRoutes: FastifyPluginAsync<MrTrackingAdvancedRout
               reviewContext,
               job.localPath,
               logger,
-              defaultCommandExecutor,
+              commandExecutor,
+              null,
+              noteCommentPostGatewayFactory(job.platform),
             );
             logger.info(
               { ...actionResult, threadResolveCount, mrNumber: job.mrNumber },
@@ -319,7 +332,8 @@ export const mrTrackingAdvancedRoutes: FastifyPluginAsync<MrTrackingAdvancedRout
                 diffMetadata: reviewContext?.diffMetadata,
               },
               logger,
-              defaultCommandExecutor,
+              commandExecutor,
+              noteCommentPostGatewayFactory(job.platform),
             );
             logger.info(
               { ...actionResult, threadResolveCount, mrNumber: job.mrNumber },

--- a/src/tests/units/modules/tracking/interface-adapters/controllers/http/mrTrackingAdvanced.egress.test.ts
+++ b/src/tests/units/modules/tracking/interface-adapters/controllers/http/mrTrackingAdvanced.egress.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/frameworks/queue/pQueueAdapter.js', () => ({
+  enqueueReview: vi.fn(async () => true),
+  createJobId: vi.fn(() => 'gitlab-followup-test-org/test-project-42'),
+  updateJobProgress: vi.fn(),
+}));
+
+vi.mock('@/config/projectConfig.js', () => ({
+  loadProjectConfig: vi.fn(() => null),
+  getFollowupAgents: vi.fn(() => null),
+}));
+
+vi.mock('@/claude/invoker.js', () => ({
+  invokeClaudeReview: vi.fn(),
+  sendNotification: vi.fn(),
+}));
+
+vi.mock('@/main/websocket.js', () => ({
+  startWatchingReviewContext: vi.fn(),
+  stopWatchingReviewContext: vi.fn(),
+}));
+
+vi.mock('@/frameworks/logging/logBuffer.js', () => ({
+  logInfo: vi.fn(),
+  logError: vi.fn(),
+}));
+
+import Fastify from 'fastify';
+
+import { invokeClaudeReview } from '@/claude/invoker.js';
+import { enqueueReview } from '@/frameworks/queue/pQueueAdapter.js';
+import { createEgressScanner } from '@/modules/platform-integration/entities/egressScan/egressScan.scanner.js';
+import type { EgressScanConfig } from '@/modules/platform-integration/entities/egressScan/egressScan.scanner.js';
+import { EgressScannedNoteCommentPostGateway } from '@/modules/platform-integration/interface-adapters/gateways/egressScanned.noteCommentPost.gateway.js';
+import type { ReviewJob } from '@/modules/review-execution/entities/job/reviewJob.js';
+import type { ReviewContext } from '@/modules/review-execution/entities/reviewContext/reviewContext.js';
+import { mrTrackingAdvancedRoutes } from '@/modules/tracking/interface-adapters/controllers/http/mrTrackingAdvanced.routes.js';
+import { TrackedMrFactory } from '@/tests/factories/trackedMr.factory.js';
+import { StubEgressTraceGateway } from '@/tests/stubs/egressScan.stub.js';
+import { createStubLogger } from '@/tests/stubs/logger.stub.js';
+import { StubNoteCommentPostGateway } from '@/tests/stubs/noteCommentPost.stub.js';
+
+const SECRET = 'glpat-abcdefghij1234567890';
+const MR_ID = 'gitlab-test-org/test-project-42';
+const LOCAL_PATH = '/home/user/projects/test';
+
+const redactConfig: EgressScanConfig = {
+  secretShapeMode: 'redact',
+  lengthMode: 'redact',
+  outOfScopeMode: 'redact',
+  maxBodyLength: 10000,
+  redactionMarker: '[REDACTED]',
+  truncationMarker: '…[TRUNCATED]',
+};
+
+const DEFAULT_REPO = {
+  name: 'test',
+  platform: 'gitlab' as const,
+  localPath: LOCAL_PATH,
+  remoteUrl: 'https://gitlab.com/test-org/test-project.git',
+  skill: 'review',
+  enabled: true,
+};
+
+function contextWithPublicOutput(): ReviewContext {
+  return {
+    version: '1.0',
+    mergeRequestId: MR_ID,
+    platform: 'gitlab',
+    projectPath: 'test-org/test-project',
+    mergeRequestNumber: 42,
+    createdAt: '2026-07-30T10:00:00Z',
+    threads: [
+      { id: 'thread-1', file: 'src/app.ts', line: 3, status: 'open', body: 'blocking finding' },
+    ],
+    actions: [
+      { type: 'THREAD_REPLY', threadId: 'thread-1', message: `still open, token ${SECRET}` },
+      { type: 'POST_COMMENT', body: `## Follow-up\ntoken ${SECRET}` },
+    ],
+    progress: { phase: 'completed', currentStep: null },
+  };
+}
+
+/**
+ * Drives the real manual-followup processor: the production mock of enqueueReview
+ * throws the processor away, which is exactly why this path went unscanned unnoticed.
+ */
+async function runManualFollowup(): Promise<{
+  sink: StubNoteCommentPostGateway;
+  rawCommands: string[];
+}> {
+  const sink = new StubNoteCommentPostGateway();
+  const scannedGateway = new EgressScannedNoteCommentPostGateway(
+    sink,
+    createEgressScanner(redactConfig),
+    new StubEgressTraceGateway(),
+  );
+  const rawCommands: string[] = [];
+
+  vi.mocked(invokeClaudeReview).mockResolvedValue({
+    success: true,
+    cancelled: false,
+    exitCode: 0,
+    stdout: '[REVIEW_STATS:blocking=0:warnings=0:suggestions=0:score=10]',
+    stderr: '',
+    durationMs: 10,
+  } as never);
+
+  const capturedProcessors: Array<(job: ReviewJob, signal: AbortSignal) => Promise<void>> = [];
+  vi.mocked(enqueueReview).mockImplementation(async (_job, processor) => {
+    capturedProcessors.push(processor);
+    return true;
+  });
+
+  const app = Fastify();
+  await app.register(mrTrackingAdvancedRoutes, {
+    getRepositories: () => [DEFAULT_REPO],
+    reviewRequestTrackingGateway: {
+      getById: vi.fn(() => null),
+      getByNumber: vi.fn(() =>
+        TrackedMrFactory.create({
+          id: MR_ID,
+          mrNumber: 42,
+          project: 'test-org/test-project',
+          sourceBranch: 'feature/refresh',
+          targetBranch: 'main',
+        }),
+      ),
+      create: vi.fn(),
+      update: vi.fn(),
+      getByState: vi.fn(() => []),
+      getActiveMrs: vi.fn(() => []),
+      remove: vi.fn(() => true),
+      archive: vi.fn(() => true),
+      recordReviewEvent: vi.fn(),
+      recordPush: vi.fn(() => null),
+      loadTracking: vi.fn(() => null),
+      saveTracking: vi.fn(),
+    } as never,
+    reviewContextGateway: {
+      create: vi.fn(),
+      read: vi.fn(() => contextWithPublicOutput()),
+      updateProgress: vi.fn(),
+    } as never,
+    threadFetchGatewayFactory: () => ({ fetchThreads: vi.fn(() => []) }) as never,
+    diffMetadataFetchGatewayFactory: () => ({ fetchDiffMetadata: vi.fn(() => undefined) }) as never,
+    diffStatsFetchGatewayFactory: () => ({ fetchDiffStats: vi.fn(() => null) }) as never,
+    createSyncThreadsUseCase: () => ({ execute: vi.fn() }) as never,
+    recordReviewCompletion: { execute: vi.fn() } as never,
+    enforceBudget: {
+      execute: vi.fn(async () => ({
+        accepted: true,
+        status: {
+          limitUsd: 200,
+          consumedUsd: 0,
+          remainingUsd: 200,
+          percentUsed: 0,
+          exceeded: false,
+          periodStart: '2026-07-01T00:00:00.000Z',
+        },
+      })),
+    } as never,
+    broadcastBudgetExceeded: vi.fn(),
+    noteCommentPostGatewayFactory: () => scannedGateway,
+    commandExecutor: (command: string, args: string[]) => {
+      rawCommands.push([command, ...args].join(' '));
+    },
+    logger: createStubLogger(),
+  } as never);
+
+  await app.inject({
+    method: 'POST',
+    url: '/api/mr-tracking/followup',
+    payload: { mrId: MR_ID, projectPath: LOCAL_PATH },
+  });
+
+  const processor = capturedProcessors[0];
+  if (!processor) {
+    throw new Error('the followup was never enqueued with a processor');
+  }
+  await processor(
+    {
+      id: 'gitlab-followup-test-org/test-project-42',
+      platform: 'gitlab',
+      projectPath: 'test-org/test-project',
+      localPath: LOCAL_PATH,
+      mrNumber: 42,
+      skill: 'review-followup',
+      jobType: 'followup',
+    } as ReviewJob,
+    new AbortController().signal,
+  );
+
+  await app.close();
+  return { sink, rawCommands };
+}
+
+describe('manual followup — public output goes through the scanned sink (SPEC-199)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redacts the follow-up report before it leaves the system', async () => {
+    const { sink } = await runManualFollowup();
+
+    expect(sink.calls).toHaveLength(1);
+    expect(sink.calls[0].body).toContain('[REDACTED]');
+    expect(sink.calls[0].body).not.toContain(SECRET);
+  });
+
+  it('redacts the thread reply and keeps it addressed to its thread', async () => {
+    const { sink } = await runManualFollowup();
+
+    expect(sink.threadReplies).toHaveLength(1);
+    expect(sink.threadReplies[0].threadId).toBe('thread-1');
+    expect(sink.threadReplies[0].body).toContain('[REDACTED]');
+    expect(sink.threadReplies[0].body).not.toContain(SECRET);
+  });
+
+  it('never hands a secret to the raw CLI primitive', async () => {
+    const { rawCommands } = await runManualFollowup();
+
+    expect(rawCommands.filter((command) => command.includes(SECRET))).toHaveLength(0);
+  });
+});

--- a/src/tests/units/modules/tracking/interface-adapters/controllers/http/mrTrackingAdvanced.routes.test.ts
+++ b/src/tests/units/modules/tracking/interface-adapters/controllers/http/mrTrackingAdvanced.routes.test.ts
@@ -33,6 +33,7 @@ import type { TrackedMr } from '@/modules/tracking/entities/tracking/trackedMr.j
 import { mrTrackingAdvancedRoutes } from '@/modules/tracking/interface-adapters/controllers/http/mrTrackingAdvanced.routes.js';
 import { TrackedMrFactory, MrTrackingDataFactory } from '@/tests/factories/trackedMr.factory.js';
 import { createStubLogger } from '@/tests/stubs/logger.stub.js';
+import { StubNoteCommentPostGateway } from '@/tests/stubs/noteCommentPost.stub.js';
 
 interface RepoStub {
   name: string;
@@ -139,6 +140,7 @@ async function buildApp(options: BuildAppOptions): Promise<AppBundle> {
     recordReviewCompletion: { execute: vi.fn() } as never,
     enforceBudget: { execute: enforceBudgetExecute } as never,
     broadcastBudgetExceeded,
+    noteCommentPostGatewayFactory: () => new StubNoteCommentPostGateway(),
     gateClaudeInvocation:
       options.gateResult == null ? undefined : ({ execute: gateExecute } as never),
     logger: createStubLogger(),


### PR DESCRIPTION
## The gap

SPEC-199 makes `EgressScannedNoteCommentPostGateway` the single chokepoint every public-output body must pass through. The manual follow-up route (`POST /api/mr-tracking/followup`) executed its actions with **no** `postGateway`:

```ts
await executeActionsFromContext(reviewContext, job.localPath, logger, defaultCommandExecutor);
//                                                     no baseUrl, no postGateway ^
```

With `postGateway === null`, `POST_COMMENT` and `THREAD_REPLY` fall through to the raw `glab`/`gh` note primitive. A secret in a review body was redacted on the webhook path and published verbatim on this one.

Same for the stdout-marker branch a few lines below.

## Why it went unnoticed

The route's tests mock `enqueueReview` as `vi.fn(async () => true)` — the processor closure is captured and thrown away, so the code that actually executes actions was never run by any test. The new test mocks `enqueueReview` to *invoke* the processor, which is what exercises the fixed line.

## Changes

- `MrTrackingAdvancedRoutesOptions` takes `noteCommentPostGatewayFactory`; both execution paths now receive the scanned sink for the job's platform.
- `commandExecutor` is injectable (defaults to `defaultCommandExecutor`) so the test can assert no secret reaches the CLI primitive, rather than shelling out to a real `glab`/`gh`.
- `routes.ts` builds the two per-platform sinks before registering these routes and reuses the same instances the webhook path already used — one scanner, one trace gateway, no duplicate instance.

## Verification

`yarn verify` — 4263 tests, 0 lint/type error.

Three new tests cover: report redacted, reply redacted **and** still addressed to its thread, and no secret in any CLI command.

## Note

`src/tests/units/cli/cli.integration.test.ts` flaked once during a full-suite run (it shells out to the real `reviewflow status`). It passes isolated, passes on a clean re-run, and fails/passes identically without this branch's changes. Worth hardening separately — it depends on the machine's daemon state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)