### PR TITLE
fix: stop the test suite from destroying the running daemon's pid file

### DIFF
--- a/src/modules/cli-configuration/interface-adapters/gateways/selfUpdate.cli.gateway.ts
+++ b/src/modules/cli-configuration/interface-adapters/gateways/selfUpdate.cli.gateway.ts
@@ -14,6 +14,11 @@ export interface SelfUpdateCliDependencies {
   execFileAsync: (command: string, args: string[]) => Promise<{ stdout: string; stderr: string }>;
   killProcess: (pid: number, signal: string) => void;
   spawnDaemonDelayed: (port: number | undefined, delaySec: number) => void;
+  /**
+   * Injectable so a test never reads or deletes the machine's live pid file —
+   * doing so orphaned the running daemon and left `reviewflow stop` unable to find it.
+   */
+  pidFilePath: string;
 }
 
 function defaultSpawnDaemonDelayed(port: number | undefined, delaySec: number): void {
@@ -36,6 +41,7 @@ function createDefaultDependencies(): SelfUpdateCliDependencies {
     execFileAsync: defaultExecFileAsync,
     killProcess: (pid, signal) => process.kill(pid, signal),
     spawnDaemonDelayed: defaultSpawnDaemonDelayed,
+    pidFilePath: PID_FILE_PATH,
   };
 }
 
@@ -62,11 +68,12 @@ export class SelfUpdateCliGateway implements SelfUpdateCommandPort {
   }
 
   async restartDaemon(serverPort?: number): Promise<void> {
-    const pidFileContent = readPidFile(PID_FILE_PATH);
+    const { pidFilePath } = this.dependencies;
+    const pidFileContent = readPidFile(pidFilePath);
     const port = pidFileContent?.port ?? serverPort;
     const targetPid = pidFileContent?.pid ?? process.pid;
 
-    removePidFile(PID_FILE_PATH);
+    removePidFile(pidFilePath);
 
     this.dependencies.spawnDaemonDelayed(port, RESTART_DELAY_SECONDS);
 

--- a/src/tests/units/cli/cli.integration.test.ts
+++ b/src/tests/units/cli/cli.integration.test.ts
@@ -1,8 +1,10 @@
 import { execSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 
 // Run integration tests against the TypeScript source via tsx — avoids the
 // requirement of a prior `yarn build`, keeping the tests stable in fresh
@@ -16,11 +18,27 @@ const cliCommand = `${tsxBin} ${cliSrc}`;
 // Cold-start tsx spawns can exceed the 5s default under load; allow headroom.
 const TEST_TIMEOUT_MS = 15000;
 
+// The pid file lives under the home directory, so these tests used to read the one
+// belonging to the developer's own daemon: `status` answered "running" and the
+// stopped-server expectations failed. A throwaway HOME gives the spawned CLI an
+// empty config dir, making "stopped" a fact of the fixture rather than of the machine.
+let fakeHome: string;
+let cliEnvironment: NodeJS.ProcessEnv;
+
+beforeAll(() => {
+  fakeHome = mkdtempSync(join(tmpdir(), 'reviewflow-cli-home-'));
+  cliEnvironment = { ...process.env, HOME: fakeHome, USERPROFILE: fakeHome, NO_COLOR: '1' };
+});
+
+afterAll(() => {
+  rmSync(fakeHome, { recursive: true, force: true });
+});
+
 describe('CLI integration', () => {
   it(
     'should print version when called with --version',
     () => {
-      const output = execSync(`${cliCommand} --version`).toString().trim();
+      const output = execSync(`${cliCommand} --version`, { env: cliEnvironment }).toString().trim();
       expect(output).toMatch(/^\d+\.\d+\.\d+$/);
     },
     TEST_TIMEOUT_MS,
@@ -29,7 +47,7 @@ describe('CLI integration', () => {
   it(
     'should print help when called with --help',
     () => {
-      const output = execSync(`${cliCommand} --help`).toString();
+      const output = execSync(`${cliCommand} --help`, { env: cliEnvironment }).toString();
       expect(output).toContain('reviewflow');
       expect(output).toContain('start');
       expect(output).toContain('stop');
@@ -47,7 +65,7 @@ describe('CLI integration', () => {
     'should exit with code 1 when status is checked and server is not running',
     () => {
       try {
-        execSync(`${cliCommand} status`, { env: { ...process.env, NO_COLOR: '1' } });
+        execSync(`${cliCommand} status`, { env: cliEnvironment });
         expect.unreachable('should have thrown');
       } catch (error) {
         const execError = error as { status: number; stdout: Buffer };
@@ -62,7 +80,7 @@ describe('CLI integration', () => {
     'should output JSON for status --json when stopped',
     () => {
       try {
-        execSync(`${cliCommand} status --json`);
+        execSync(`${cliCommand} status --json`, { env: cliEnvironment });
         expect.unreachable('should have thrown');
       } catch (error) {
         const execError = error as { status: number; stdout: Buffer };

--- a/src/tests/units/interface-adapters/gateways/selfUpdate.cli.gateway.test.ts
+++ b/src/tests/units/interface-adapters/gateways/selfUpdate.cli.gateway.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import {
   SelfUpdateCliGateway,
@@ -7,6 +11,11 @@ import {
 import { PID_FILE_PATH } from '@/shared/services/daemonPaths.js';
 import { writePidFile, removePidFile } from '@/shared/services/pidFileManager.js';
 
+// A throwaway pid file per test. Pointing these at PID_FILE_PATH used to delete the
+// pid file of whatever daemon the developer had running, orphaning the process.
+let sandboxDir: string;
+let pidFilePath: string;
+
 function createFakeDependencies(
   overrides?: Partial<SelfUpdateCliDependencies>,
 ): SelfUpdateCliDependencies {
@@ -14,13 +23,27 @@ function createFakeDependencies(
     execFileAsync: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
     killProcess: vi.fn(),
     spawnDaemonDelayed: vi.fn(),
+    pidFilePath,
     ...overrides,
   };
 }
 
 describe('SelfUpdateCliGateway', () => {
   beforeEach(() => {
-    removePidFile(PID_FILE_PATH);
+    sandboxDir = mkdtempSync(join(tmpdir(), 'reviewflow-selfupdate-'));
+    pidFilePath = join(sandboxDir, 'reviewflow.pid');
+    removePidFile(pidFilePath);
+  });
+
+  afterEach(() => {
+    rmSync(sandboxDir, { recursive: true, force: true });
+  });
+
+  it('never reaches for the real daemon pid file', () => {
+    const deps = createFakeDependencies();
+
+    expect(deps.pidFilePath).not.toBe(PID_FILE_PATH);
+    expect(deps.pidFilePath.startsWith(tmpdir())).toBe(true);
   });
 
   describe('runGlobalUpdate', () => {
@@ -73,7 +96,7 @@ describe('SelfUpdateCliGateway', () => {
     });
 
     it('should use pid file port over server port when pid file exists', async () => {
-      writePidFile(PID_FILE_PATH, { pid: 9999, startedAt: new Date().toISOString(), port: 4000 });
+      writePidFile(pidFilePath, { pid: 9999, startedAt: new Date().toISOString(), port: 4000 });
       const deps = createFakeDependencies();
       const gateway = new SelfUpdateCliGateway(deps);
 
@@ -83,7 +106,7 @@ describe('SelfUpdateCliGateway', () => {
     });
 
     it('should kill process from pid file when it exists', async () => {
-      writePidFile(PID_FILE_PATH, { pid: 9999, startedAt: new Date().toISOString(), port: 4000 });
+      writePidFile(pidFilePath, { pid: 9999, startedAt: new Date().toISOString(), port: 4000 });
       const deps = createFakeDependencies();
       const gateway = new SelfUpdateCliGateway(deps);
 
@@ -130,14 +153,14 @@ describe('SelfUpdateCliGateway', () => {
     });
 
     it('should remove pid file before spawning', async () => {
-      writePidFile(PID_FILE_PATH, { pid: 9999, startedAt: new Date().toISOString(), port: 4000 });
+      writePidFile(pidFilePath, { pid: 9999, startedAt: new Date().toISOString(), port: 4000 });
       const deps = createFakeDependencies();
       const gateway = new SelfUpdateCliGateway(deps);
 
       await gateway.restartDaemon(3847);
 
       const { readPidFile } = await import('@/shared/services/pidFileManager.js');
-      expect(readPidFile(PID_FILE_PATH)).toBeNull();
+      expect(readPidFile(pidFilePath)).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## The bug

`src/tests/units/interface-adapters/gateways/selfUpdate.cli.gateway.test.ts` operated on the **real** `PID_FILE_PATH` (`~/.config/reviewflow/reviewflow.pid`):

```ts
beforeEach(() => {
  removePidFile(PID_FILE_PATH);   // deletes the live daemon's pid file
});
// ...
writePidFile(PID_FILE_PATH, { pid: 9999, ... });   // and overwrites it
```

So **every `yarn test:ci` orphaned whatever daemon the developer had running**: the process survived and kept serving webhooks, but its pid file was gone, so `reviewflow stop` answered `Server is not running` and the process could only be killed by hand.

Found in the wild on a daemon that had been in that state for two days.

## The knock-on effect

The same global file made `cli.integration.test.ts` non-deterministic. It shells out to the real CLI and asserts `status` reports a stopped server:

| vitest ran first | `status` says | test |
|---|---|---|
| `selfUpdate` suite (pid file already deleted) | not running | green **by accident** |
| `cli.integration` (pid file still there) | running | red |

Its green was never a property of the code. Fixing the pid-file leak turned this into a deterministic failure, which is why both changes land together — the suite cannot be green with only one of them.

## Changes

- `SelfUpdateCliDependencies` takes `pidFilePath`, defaulting to `PID_FILE_PATH`. The gateway no longer hardcodes the machine's live path.
- The selfUpdate tests write to a per-test `mkdtemp` sandbox, plus a guard case asserting the fixture never points at `PID_FILE_PATH` — so a future edit cannot silently reintroduce this.
- `cli.integration.test.ts` spawns the CLI under a throwaway `HOME`, so "stopped" is a property of the fixture rather than of the developer's machine.

## Verification

`yarn verify` — 4264 tests, 0 lint/type error, run **with a live daemon**. Its pid file is intact afterwards and `reviewflow status` still reports the correct PID. Before this branch, the same run deleted it.

## Noted, not fixed

`daemonPaths.ts` builds `~/.config/reviewflow` directly from `homedir()`, while `getConfigDir()` returns `~/Library/Application Support/reviewflow` on macOS and honours `XDG_CONFIG_HOME`. Two different config dirs coexist. Out of scope here, but the daemon paths probably want to go through `getConfigDir()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)