### PR TITLE
feat(review): implement spec-224 follow-up review labels

### DIFF
--- a/docs/feature-tracker.md
+++ b/docs/feature-tracker.md
@@ -86,3 +86,4 @@
 | Signal an in-progress review with a platform label | [221-review-in-progress-label](specs/221-review-in-progress-label.md) — [plan](plans/221-review-in-progress-label.plan.md) — [report](reports/221-review-in-progress-label.report.md) | implemented | 2026-08-04 |
 | Signal a finished review with a platform label | [222-review-done-label](specs/222-review-done-label.md) — [report](reports/222-review-done-label.report.md) | implemented | 2026-08-04 |
 | Update a source-checkout install from the dashboard | [223-source-checkout-self-update](specs/223-source-checkout-self-update.md) — [plan](plans/223-source-checkout-self-update.plan.md) — [report](reports/223-source-checkout-self-update.report.md) | implemented | 2026-08-05 |
+| Apply the review labels on follow-up reviews too | [224-followup-review-labels](specs/224-followup-review-labels.md) — [report](reports/224-followup-review-labels.report.md) | implemented | 2026-08-06 |

--- a/docs/reports/224-followup-review-labels.report.md
+++ b/docs/reports/224-followup-review-labels.report.md
@@ -1,0 +1,47 @@
+# Report — 224 Apply the review labels on follow-up reviews too
+
+Spec: [docs/specs/224-followup-review-labels.md](../specs/224-followup-review-labels.md)
+
+## Outcome
+
+A follow-up review now runs the exact same platform-label lifecycle as an initial review: stale
+`review-done` removed, `review-in-progress` applied before Claude is invoked, `review-done` applied
+on completion, `review-in-progress` cleared on every terminal state.
+
+Before this change a follow-up kept `review-done` visible for its whole duration and showed no
+in-flight signal — the blind spot spec 221 was written to close, still open on the path where the
+author is actively waiting.
+
+## What changed
+
+- **Use case (modified)**: `src/modules/review-execution/usecases/executeReview.usecase.ts` — the
+  `if (input.isFollowup) return runAndMarkDone(...)` early return was removed, so both paths go
+  through `markReviewInProgress` → `try/finally` → `clearReviewInProgress`. Doc comment updated.
+- **Acceptance test (new)**: `src/tests/acceptance/224-followup-review-labels.acceptance.test.ts` —
+  7 tests covering both platforms, the three terminal states, and the best-effort guarantee.
+- **Acceptance test (modified)**: `221-review-in-progress-label.acceptance.test.ts` — the
+  "follow-up reviews are untouched" block now asserts the shared lifecycle.
+- **Acceptance test (modified)**: `222-review-done-label.acceptance.test.ts` — the follow-up test
+  asserts the full 6-command sequence instead of the done-only pair.
+- **Unit test (modified)**: `executeReview.usecase.test.ts` — two follow-up label expectations
+  flipped to the new behavior.
+- **Specs (modified)**: 221 and 222 carry strike-through notes on the rules superseded here.
+
+No gateway, no use case, no label, and no wiring was added — `MarkReviewInProgressUseCase` already
+handled the stale-`review-done` removal, so the follow-up path inherited the full invariant for free.
+
+## Decisions
+
+- Deleting the branch rather than adding a flag: after the change both paths are byte-identical, so a
+  parameter would only re-encode a distinction the product no longer makes.
+- The follow-up path reuses `MarkReviewInProgressUseCase` unchanged, which means it also removes a
+  stale `review-done` first. That is required, not incidental: without it the merge request would
+  carry both labels for the duration of the run.
+- `isFollowup` stays in `runReviewPipeline` — it still drives notifications, `syncThreads`, and
+  `threadsOpened`. Only the label gate was dropped.
+
+## Verification
+
+- `yarn verify` — typecheck, lint, and the full test suite.
+- Label command sequences are asserted at the CLI-string level for both `gh` and `glab`; they were
+  not exercised against a live platform (same caveat as spec 221).

--- a/docs/specs/221-review-in-progress-label.md
+++ b/docs/specs/221-review-in-progress-label.md
@@ -21,6 +21,9 @@ instructions.
 
 Scope is limited to the **initial review** (`isFollowup === false`). Follow-up runs are untouched.
 
+> **Superseded in part by [224-followup-review-labels](224-followup-review-labels.md)**: follow-up
+> runs now share the same in-progress lifecycle. Every rule below still holds for the initial review.
+
 ## Rules
 
 - the label name is the domain constant `review-in-progress` — not configurable in this iteration
@@ -36,7 +39,8 @@ Scope is limited to the **initial review** (`isFollowup === false`). Follow-up r
   `completed` even if its label could not be applied or removed
 - if applying the label failed, the removal attempt still runs (it is a no-op on the platform side)
   and its own failure is likewise swallowed
-- follow-up reviews (`isFollowup === true`) neither apply nor remove the label
+- ~~follow-up reviews (`isFollowup === true`) neither apply nor remove the label~~ — superseded by
+  spec 224: a follow-up runs the same lifecycle
 - both platforms are supported through one gateway contract with a GitLab CLI implementation
   (`glab`) and a GitHub CLI implementation (`gh`)
 
@@ -57,15 +61,14 @@ Scope is limited to the **initial review** (`isFollowup === false`). Follow-up r
 - apply fails: {initial review, ensure or add throws} → warning logged, Claude still invoked, review
   outcome identical to a run without the feature
 - remove fails: {initial review completes, remove throws} → warning logged, result still `completed`
-- follow-up review: {follow-up job} → no label applied, no label removed, behavior identical to
-  before this feature
+- ~~follow-up review: {follow-up job} → no label applied, no label removed~~ — superseded by spec 224
 
 ## Out of Scope
 
 - Making the label name configurable per project (`.reviewflow.json`)
 - Label colour / description management beyond what is needed to create a missing label
 - A distinct label per outcome (`review-passed`, `review-blocked`) — only the in-progress signal
-- Applying the label on follow-up reviews
+- ~~Applying the label on follow-up reviews~~ — delivered by spec 224
 - Exposing the label state on the dashboard
 - Reconciling labels left over from a daemon crash mid-review (no startup sweep)
 - Replacing or removing the existing Claude-driven `ADD_LABEL` review action

--- a/docs/specs/222-review-done-label.md
+++ b/docs/specs/222-review-done-label.md
@@ -30,9 +30,11 @@ statement that a review happened.
   signal
 - when an initial review starts, `review-done` is removed before `review-in-progress` is applied —
   a merge request must never carry both labels at once
-- a follow-up review does not remove `review-done` at start (it does not set `review-in-progress`
-  either, so the two labels cannot collide); re-applying `review-done` on a merge request that
-  already carries it is a harmless no-op
+- ~~a follow-up review does not remove `review-done` at start (it does not set `review-in-progress`
+  either, so the two labels cannot collide)~~ — superseded by
+  [224-followup-review-labels](224-followup-review-labels.md): a follow-up removes the stale
+  `review-done` and sets `review-in-progress` like an initial review. Re-applying `review-done` on a
+  merge request that already carries it stays a harmless no-op
 - label operations stay best-effort: any failure is logged as a warning and **never** changes the
   `ExecuteReviewResult` — a review that completes still reports `completed` even if its label could
   not be applied
@@ -43,8 +45,8 @@ statement that a review happened.
 
 - initial review completes: {initial review, Claude succeeds, actions executed} → `review-done`
   ensured then applied, `review-in-progress` removed, result `completed` with unchanged stats
-- follow-up completes: {follow-up review, Claude succeeds} → `review-done` ensured then applied, no
-  `review-in-progress` touched, result `completed`
+- follow-up completes: {follow-up review, Claude succeeds} → `review-done` ensured then applied,
+  result `completed` (since spec 224 the follow-up also carries `review-in-progress` while it runs)
 - blocking issues found: {initial review completes, `blocking: 3`} → `review-done` applied all the
   same (the label is neutral), stats unchanged
 - cancelled: {initial review aborted} → no `review-done` applied, `review-in-progress` still removed,

--- a/docs/specs/224-followup-review-labels.md
+++ b/docs/specs/224-followup-review-labels.md
@@ -1,0 +1,103 @@
+# Apply the review labels on follow-up reviews too
+
+## Status: implemented
+
+## Context
+
+Spec [221-review-in-progress-label](221-review-in-progress-label.md) added `review-in-progress`,
+applied before Claude runs and cleared on every terminal state, and deliberately scoped it to the
+**initial** review. Spec [222-review-done-label](222-review-done-label.md) added the neutral
+`review-done` label and did extend it to follow-ups.
+
+The result is asymmetric: a follow-up run leaves the merge request carrying `review-done` for its
+whole duration. Anyone looking at the MR/PR while corrections are being re-reviewed sees a stale
+"reviewed" signal and no sign that a run is in flight — exactly the blind spot spec 221 was written
+to close, reintroduced on the path where it matters most (the author has just pushed and is waiting).
+
+This feature drops the `isFollowup` gate: a follow-up run goes through the same label lifecycle as an
+initial review. It supersedes the "follow-up reviews neither apply nor remove the label" rule of spec
+221 and the "a follow-up review does not remove `review-done` at start" rule of spec 222.
+
+No new gateway, no new use case, no new label: only the branch in `executeReview` that skips the
+in-progress lifecycle for follow-ups is removed.
+
+## Rules
+
+- a follow-up review applies `review-in-progress` before Claude is invoked, exactly as an initial
+  review does — ensure the label exists on the project, then add it to the merge request
+- a follow-up review removes a stale `review-done` before applying `review-in-progress`, so the two
+  labels are never both present (same invariant as spec 222, now enforced on both paths)
+- a follow-up review removes `review-in-progress` when it reaches any terminal state — `completed`,
+  `cancelled`, or `failed` — including on an unexpected throw
+- a follow-up review that reaches `completed` still applies `review-done`, unchanged from spec 222
+- a cancelled or failed follow-up applies no `review-done`, unchanged from spec 222
+- label operations stay best-effort on the follow-up path: any failure is logged as a warning and
+  **never** changes the `ExecuteReviewResult`
+- the initial-review label lifecycle is unchanged in every respect
+
+## Scenarios
+
+- follow-up starts: {follow-up job, GitLab} → stale `review-done` removed, `review-in-progress`
+  ensured then applied, all before `claudeInvoker.invoke` is called
+- follow-up starts: {follow-up job, GitHub} → same, via `gh`
+- follow-up completes: {follow-up job, Claude succeeds} → `review-done` ensured then applied, then
+  `review-in-progress` removed, result `completed` with unchanged stats
+- follow-up cancelled: {follow-up job, run aborted} → `review-in-progress` removed, no `review-done`
+  applied, result `cancelled`
+- follow-up fails on invocation: {follow-up job, Claude exits non-zero} → `review-in-progress`
+  removed, no `review-done` applied, result `failed` with the same reason as today
+- follow-up fails on unreadable context: {follow-up job, context file unreadable after the run} →
+  `review-in-progress` removed, no `review-done` applied, result `failed` with
+  `CONTEXT_UNREADABLE_REASON`
+- apply fails on a follow-up: {follow-up job, ensure or add throws} → warning logged, Claude still
+  invoked, review outcome identical to a run without the feature
+- initial review unchanged: {initial review job} → same command sequence as spec 222 records today
+
+## Out of Scope
+
+- Making either label name configurable per project
+- A verdict-bearing label (`review-passed` / `review-blocked`)
+- A `review-failed` label for broken runs
+- Removing `review-done` when the merge request is merged or closed
+- Reconciling labels left over from a daemon crash mid-review (no startup sweep, same as spec 221)
+- Exposing label state on the dashboard
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| follow-up review | The run triggered by a push on a merge request that already carries an initial review with open threads (`isFollowup === true`) |
+| label lifecycle | Remove stale `review-done` → apply `review-in-progress` → apply `review-done` on completion → remove `review-in-progress` |
+
+## INVEST Evaluation
+
+| Criterion | Status | Note |
+|-----------|--------|------|
+| Independent | OK | Touches one branch in `executeReview`; no gateway, use case, or label added |
+| Negotiable | OK | Nothing left open — the initial-review lifecycle is the reference |
+| Valuable | OK | Removes the stale "reviewed" signal while a follow-up is in flight |
+| Estimable | OK | 1 modified use case, 1 acceptance test, updates to specs 221/222 tests |
+| Small | OK | ~5 files including tests |
+| Testable | OK | Each rule maps to a scenario; assertions are CLI-command sequences |
+
+## Definition of Done
+
+See `.claude/skills/product-manager/rules/dod.md`.
+
+## Implementation
+
+### Artefacts
+
+- **Use case (modified)**: `executeReview.usecase.ts` — the `isFollowup` early return was removed, so
+  both paths run `markReviewInProgress` → `try/finally` → `clearReviewInProgress`.
+- **Tests**: new acceptance suite for this spec; the follow-up expectations of the spec 221 and 222
+  suites and of `executeReview.usecase.test.ts` were flipped to the shared lifecycle.
+
+### Decisions
+
+- Deleting the branch rather than gating it behind a flag: both paths are now identical, so a
+  parameter would re-encode a distinction the product no longer makes.
+- The follow-up path reuses `MarkReviewInProgressUseCase` unchanged, so it also drops a stale
+  `review-done` first — required to keep the never-both-labels invariant on this path.
+
+Full report: [docs/reports/224-followup-review-labels.report.md](../reports/224-followup-review-labels.report.md).

--- a/src/modules/review-execution/usecases/executeReview.usecase.ts
+++ b/src/modules/review-execution/usecases/executeReview.usecase.ts
@@ -348,19 +348,16 @@ async function runAndMarkDone(
 /**
  * Wraps the pipeline with the platform labels: `review-in-progress` is applied before
  * Claude runs and cleared on every terminal state — the `finally` also covers an
- * unexpected throw — while `review-done` lands on completion (spec 221 and 222). Every
- * label use case is non-throwing, so the review outcome is never altered. Follow-up runs
- * skip the in-progress label but still earn the done label.
+ * unexpected throw — while `review-done` lands on completion (spec 221 and 222).
+ * Follow-up runs share that lifecycle since spec 224, so a re-review never leaves a stale
+ * `review-done` standing while it runs. Every label use case is non-throwing, so the
+ * review outcome is never altered.
  */
 export async function executeReview(
   input: ExecuteReviewInput,
   deps: ExecuteReviewDependencies,
 ): Promise<ExecuteReviewResult> {
   const target = { projectPath: input.job.projectPath, mrNumber: input.job.mrNumber };
-
-  if (input.isFollowup) {
-    return runAndMarkDone(input, deps, target);
-  }
 
   await deps.markReviewInProgress.execute(target);
   try {

--- a/src/tests/acceptance/222-review-done-label.acceptance.test.ts
+++ b/src/tests/acceptance/222-review-done-label.acceptance.test.ts
@@ -166,16 +166,21 @@ describe('SPEC-222 review-done label (acceptance)', () => {
       });
     });
 
-    it('follow-up completes: applies review-done without touching review-in-progress', async () => {
+    /** Spec 224 gave the follow-up the full lifecycle; the done label still lands on it. */
+    it('follow-up completes: applies review-done inside the in-progress lifecycle', async () => {
       const harness = createHarness({ platform: 'github' });
       const job = ReviewJobFactory.createGitHub({ jobType: 'followup' });
 
       const result = await executeReview(gitHubInput({ job, isFollowup: true }), harness.deps);
 
-      expect(harness.commands).toEqual([GITHUB_ENSURE_DONE, GITHUB_ADD_DONE]);
-      expect(harness.commands).not.toContain(GITHUB_ENSURE_IN_PROGRESS);
-      expect(harness.commands).not.toContain(GITHUB_ADD_IN_PROGRESS);
-      expect(harness.commands).not.toContain(GITHUB_REMOVE_IN_PROGRESS);
+      expect(harness.commands).toEqual([
+        GITHUB_REMOVE_DONE,
+        GITHUB_ENSURE_IN_PROGRESS,
+        GITHUB_ADD_IN_PROGRESS,
+        GITHUB_ENSURE_DONE,
+        GITHUB_ADD_DONE,
+        GITHUB_REMOVE_IN_PROGRESS,
+      ]);
       expect(result.status).toBe('completed');
     });
 

--- a/src/tests/acceptance/224-followup-review-labels.acceptance.test.ts
+++ b/src/tests/acceptance/224-followup-review-labels.acceptance.test.ts
@@ -27,17 +27,18 @@ import { InMemoryReviewRequestTrackingGateway } from '@/tests/stubs/reviewReques
 
 const SUCCESS_STDOUT = '[REVIEW_STATS:blocking=1:warnings=2:suggestions=3:score=7.5]';
 
-const GITHUB_ENSURE = `gh label create '${REVIEW_IN_PROGRESS_LABEL}' --force -R 'test-owner/test-repo'`;
-const GITHUB_ADD = `gh api --method POST 'repos/test-owner/test-repo/issues/123/labels' --field 'labels[]=${REVIEW_IN_PROGRESS_LABEL}'`;
-const GITHUB_REMOVE = `gh api --method DELETE 'repos/test-owner/test-repo/issues/123/labels/${REVIEW_IN_PROGRESS_LABEL}'`;
+const GITHUB_ADD_DONE = `gh api --method POST 'repos/test-owner/test-repo/issues/123/labels' --field 'labels[]=${REVIEW_DONE_LABEL}'`;
+const GITHUB_REMOVE_DONE = `gh api --method DELETE 'repos/test-owner/test-repo/issues/123/labels/${REVIEW_DONE_LABEL}'`;
+const GITHUB_ENSURE_IN_PROGRESS = `gh label create '${REVIEW_IN_PROGRESS_LABEL}' --force -R 'test-owner/test-repo'`;
+const GITHUB_ADD_IN_PROGRESS = `gh api --method POST 'repos/test-owner/test-repo/issues/123/labels' --field 'labels[]=${REVIEW_IN_PROGRESS_LABEL}'`;
+const GITHUB_REMOVE_IN_PROGRESS = `gh api --method DELETE 'repos/test-owner/test-repo/issues/123/labels/${REVIEW_IN_PROGRESS_LABEL}'`;
 
-/** Spec 222 drops a stale done label before the in-progress one is applied. */
-const GITHUB_REMOVE_STALE_DONE = `gh api --method DELETE 'repos/test-owner/test-repo/issues/123/labels/${REVIEW_DONE_LABEL}'`;
-const GITLAB_REMOVE_STALE_DONE = `glab api --method PUT 'projects/test-org%2Ftest-project/merge_requests/42' --field 'remove_labels=${REVIEW_DONE_LABEL}'`;
-
-const GITLAB_ENSURE = `glab api --method POST 'projects/test-org%2Ftest-project/labels' --field 'name=${REVIEW_IN_PROGRESS_LABEL}' --field 'color=#1f77b4'`;
-const GITLAB_ADD = `glab api --method PUT 'projects/test-org%2Ftest-project/merge_requests/42' --field 'add_labels=${REVIEW_IN_PROGRESS_LABEL}'`;
-const GITLAB_REMOVE = `glab api --method PUT 'projects/test-org%2Ftest-project/merge_requests/42' --field 'remove_labels=${REVIEW_IN_PROGRESS_LABEL}'`;
+const GITLAB_ENSURE_DONE = `glab api --method POST 'projects/test-org%2Ftest-project/labels' --field 'name=${REVIEW_DONE_LABEL}' --field 'color=#1f77b4'`;
+const GITLAB_ADD_DONE = `glab api --method PUT 'projects/test-org%2Ftest-project/merge_requests/42' --field 'add_labels=${REVIEW_DONE_LABEL}'`;
+const GITLAB_REMOVE_DONE = `glab api --method PUT 'projects/test-org%2Ftest-project/merge_requests/42' --field 'remove_labels=${REVIEW_DONE_LABEL}'`;
+const GITLAB_ENSURE_IN_PROGRESS = `glab api --method POST 'projects/test-org%2Ftest-project/labels' --field 'name=${REVIEW_IN_PROGRESS_LABEL}' --field 'color=#1f77b4'`;
+const GITLAB_ADD_IN_PROGRESS = `glab api --method PUT 'projects/test-org%2Ftest-project/merge_requests/42' --field 'add_labels=${REVIEW_IN_PROGRESS_LABEL}'`;
+const GITLAB_REMOVE_IN_PROGRESS = `glab api --method PUT 'projects/test-org%2Ftest-project/merge_requests/42' --field 'remove_labels=${REVIEW_IN_PROGRESS_LABEL}'`;
 
 interface HarnessOptions {
   platform: Platform;
@@ -109,12 +110,12 @@ function createHarness(options: HarnessOptions): Harness {
   return { deps, commands, commandsBeforeInvoke, claudeInvoker, contextGateway, warnMessages };
 }
 
-function gitLabInput(overrides?: Partial<ExecuteReviewInput>): ExecuteReviewInput {
+function gitLabFollowupInput(overrides?: Partial<ExecuteReviewInput>): ExecuteReviewInput {
   return {
-    job: ReviewJobFactory.create({ jobType: 'review' }),
+    job: ReviewJobFactory.createFollowup(),
     signal: new AbortController().signal,
     platform: 'gitlab',
-    isFollowup: false,
+    isFollowup: true,
     agents: [],
     baseUrl: 'https://gitlab.com',
     notificationPrefix: 'MR !',
@@ -123,10 +124,10 @@ function gitLabInput(overrides?: Partial<ExecuteReviewInput>): ExecuteReviewInpu
   };
 }
 
-function gitHubInput(overrides?: Partial<ExecuteReviewInput>): ExecuteReviewInput {
+function gitHubFollowupInput(overrides?: Partial<ExecuteReviewInput>): ExecuteReviewInput {
   return {
-    ...gitLabInput(),
-    job: ReviewJobFactory.createGitHub({ jobType: 'review' }),
+    ...gitLabFollowupInput(),
+    job: ReviewJobFactory.createGitHub({ jobType: 'followup' }),
     platform: 'github',
     baseUrl: null,
     notificationPrefix: 'PR #',
@@ -134,52 +135,45 @@ function gitHubInput(overrides?: Partial<ExecuteReviewInput>): ExecuteReviewInpu
   };
 }
 
-describe('SPEC-221 review-in-progress label (acceptance)', () => {
-  describe('an initial review ensures then applies the label before Claude is invoked', () => {
-    it('GitHub: ensures the label on the repository then applies it to the pull request', async () => {
+describe('SPEC-224 follow-up reviews carry the same labels (acceptance)', () => {
+  describe('a follow-up signals itself as in progress', () => {
+    it('follow-up starts: drops the stale done label then applies review-in-progress before Claude runs', async () => {
+      const harness = createHarness({ platform: 'gitlab' });
+
+      await executeReview(gitLabFollowupInput(), harness.deps);
+
+      expect(harness.commandsBeforeInvoke).toEqual([
+        GITLAB_REMOVE_DONE,
+        GITLAB_ENSURE_IN_PROGRESS,
+        GITLAB_ADD_IN_PROGRESS,
+      ]);
+    });
+
+    it('follow-up starts on GitHub: same lifecycle through gh', async () => {
       const harness = createHarness({ platform: 'github' });
 
-      await executeReview(gitHubInput(), harness.deps);
+      await executeReview(gitHubFollowupInput(), harness.deps);
 
       expect(harness.commandsBeforeInvoke).toEqual([
-        GITHUB_REMOVE_STALE_DONE,
-        GITHUB_ENSURE,
-        GITHUB_ADD,
+        GITHUB_REMOVE_DONE,
+        GITHUB_ENSURE_IN_PROGRESS,
+        GITHUB_ADD_IN_PROGRESS,
       ]);
     });
 
-    it('GitLab: ensures the label on the project then applies it to the merge request', async () => {
+    it('follow-up completes: applies review-done then removes review-in-progress', async () => {
       const harness = createHarness({ platform: 'gitlab' });
 
-      await executeReview(gitLabInput(), harness.deps);
+      const result = await executeReview(gitLabFollowupInput(), harness.deps);
 
-      expect(harness.commandsBeforeInvoke).toEqual([
-        GITLAB_REMOVE_STALE_DONE,
-        GITLAB_ENSURE,
-        GITLAB_ADD,
+      expect(harness.commands).toEqual([
+        GITLAB_REMOVE_DONE,
+        GITLAB_ENSURE_IN_PROGRESS,
+        GITLAB_ADD_IN_PROGRESS,
+        GITLAB_ENSURE_DONE,
+        GITLAB_ADD_DONE,
+        GITLAB_REMOVE_IN_PROGRESS,
       ]);
-    });
-  });
-
-  describe('ensuring the label is idempotent', () => {
-    it('applies the label without surfacing an error when the label already exists', async () => {
-      const harness = createHarness({ platform: 'gitlab', failOn: /labels$/ });
-
-      const result = await executeReview(gitLabInput(), harness.deps);
-
-      expect(harness.commands).toContain(GITLAB_ADD);
-      expect(result.status).toBe('completed');
-      expect(harness.warnMessages).toEqual([]);
-    });
-  });
-
-  describe('the label is removed on every terminal state', () => {
-    it('removes the label when the review completes, with unchanged stats', async () => {
-      const harness = createHarness({ platform: 'gitlab' });
-
-      const result = await executeReview(gitLabInput(), harness.deps);
-
-      expect(harness.commands.at(-1)).toBe(GITLAB_REMOVE);
       expect(result).toEqual({
         status: 'completed',
         stats: {
@@ -187,14 +181,16 @@ describe('SPEC-221 review-in-progress label (acceptance)', () => {
           blocking: 1,
           warnings: 2,
           suggestions: 3,
-          threadsOpened: 1,
+          threadsOpened: 0,
           threadsClosed: 0,
           durationMs: 1000,
         },
       });
     });
+  });
 
-    it('removes the label when the review is cancelled', async () => {
+  describe('every terminal state clears the in-progress label', () => {
+    it('follow-up cancelled: removes review-in-progress and applies no review-done', async () => {
       const harness = createHarness({ platform: 'github' });
       harness.claudeInvoker.setResult({
         success: false,
@@ -205,13 +201,14 @@ describe('SPEC-221 review-in-progress label (acceptance)', () => {
         durationMs: 0,
       });
 
-      const result = await executeReview(gitHubInput(), harness.deps);
+      const result = await executeReview(gitHubFollowupInput(), harness.deps);
 
-      expect(harness.commands.at(-1)).toBe(GITHUB_REMOVE);
+      expect(harness.commands.at(-1)).toBe(GITHUB_REMOVE_IN_PROGRESS);
+      expect(harness.commands).not.toContain(GITHUB_ADD_DONE);
       expect(result.status).toBe('cancelled');
     });
 
-    it('removes the label when Claude exits non-zero', async () => {
+    it('follow-up fails on invocation: removes review-in-progress and applies no review-done', async () => {
       const harness = createHarness({ platform: 'gitlab' });
       harness.claudeInvoker.setResult({
         success: false,
@@ -222,14 +219,15 @@ describe('SPEC-221 review-in-progress label (acceptance)', () => {
         durationMs: 500,
       });
 
-      const result = await executeReview(gitLabInput(), harness.deps);
+      const result = await executeReview(gitLabFollowupInput(), harness.deps);
 
-      expect(harness.commands.at(-1)).toBe(GITLAB_REMOVE);
+      expect(harness.commands.at(-1)).toBe(GITLAB_REMOVE_IN_PROGRESS);
+      expect(harness.commands).not.toContain(GITLAB_ADD_DONE);
       expect(result).toEqual({ status: 'failed', reason: 'exploded' });
     });
 
-    it('removes the label when the review context is unreadable after the run', async () => {
-      const job = ReviewJobFactory.create({ jobType: 'review' });
+    it('follow-up fails on an unreadable context: removes review-in-progress and applies no review-done', async () => {
+      const job = ReviewJobFactory.createFollowup();
       const mergeRequestId = `gitlab-${job.projectPath}-${job.mrNumber}`;
       const harness = createHarness({
         platform: 'gitlab',
@@ -238,9 +236,10 @@ describe('SPEC-221 review-in-progress label (acceptance)', () => {
         },
       });
 
-      const result = await executeReview(gitLabInput({ job }), harness.deps);
+      const result = await executeReview(gitLabFollowupInput({ job }), harness.deps);
 
-      expect(harness.commands.at(-1)).toBe(GITLAB_REMOVE);
+      expect(harness.commands.at(-1)).toBe(GITLAB_REMOVE_IN_PROGRESS);
+      expect(harness.commands).not.toContain(GITLAB_ADD_DONE);
       expect(result.status).toBe('failed');
       if (result.status === 'failed') {
         expect(result.reason).toContain('review context is unreadable');
@@ -248,48 +247,18 @@ describe('SPEC-221 review-in-progress label (acceptance)', () => {
     });
   });
 
-  describe('label operations never change the review outcome', () => {
-    it('still invokes Claude and completes when applying the label fails', async () => {
+  describe('label operations never change the follow-up outcome', () => {
+    it('still invokes Claude and completes when applying the in-progress label fails', async () => {
       const harness = createHarness({
         platform: 'github',
         failOn: new RegExp(`labels\\[\\]=${REVIEW_IN_PROGRESS_LABEL}`),
       });
 
-      const result = await executeReview(gitHubInput(), harness.deps);
+      const result = await executeReview(gitHubFollowupInput(), harness.deps);
 
       expect(harness.claudeInvoker.invocations).toHaveLength(1);
       expect(result.status).toBe('completed');
       expect(harness.warnMessages).toHaveLength(1);
-    });
-
-    it('still completes when removing the label fails', async () => {
-      const harness = createHarness({
-        platform: 'github',
-        failOn: new RegExp(`labels/${REVIEW_IN_PROGRESS_LABEL}`),
-      });
-
-      const result = await executeReview(gitHubInput(), harness.deps);
-
-      expect(result.status).toBe('completed');
-      expect(harness.warnMessages).toHaveLength(1);
-    });
-  });
-
-  describe('follow-up reviews share the lifecycle', () => {
-    /**
-     * Spec 224 superseded this spec's initial-only rule: a follow-up now runs the same
-     * in-progress lifecycle. Full coverage lives in the spec 224 acceptance test.
-     */
-    it('applies then removes the in-progress label', async () => {
-      const harness = createHarness({ platform: 'gitlab' });
-      const job = ReviewJobFactory.createFollowup();
-
-      const result = await executeReview(gitLabInput({ job, isFollowup: true }), harness.deps);
-
-      expect(harness.commandsBeforeInvoke).toContain(GITLAB_ENSURE);
-      expect(harness.commandsBeforeInvoke).toContain(GITLAB_ADD);
-      expect(harness.commands.at(-1)).toBe(GITLAB_REMOVE);
-      expect(result.status).toBe('completed');
     });
   });
 });

--- a/src/tests/units/modules/review-execution/usecases/executeReview.usecase.test.ts
+++ b/src/tests/units/modules/review-execution/usecases/executeReview.usecase.test.ts
@@ -496,7 +496,7 @@ describe('executeReview', () => {
       expect(result.status).toBe('completed');
     });
 
-    it('leaves follow-up reviews untouched', async () => {
+    it('applies the label on follow-up reviews too', async () => {
       const job = ReviewJobFactory.createFollowup();
       const mergeRequestId = `gitlab-${job.projectPath}-${job.mrNumber}`;
       appendContextActionsDuringInvoke(harness, mergeRequestId, ['t-1']);
@@ -504,10 +504,12 @@ describe('executeReview', () => {
       const result = await executeReview(reviewInput({ job, isFollowup: true }), harness.deps);
 
       expect(result.status).toBe('completed');
-      expect(harness.reviewLabelGateway.added.map((entry) => entry.label)).not.toContain(
+      expect(harness.reviewLabelGateway.added.map((entry) => entry.label)).toContain(
         REVIEW_IN_PROGRESS_LABEL,
       );
-      expect(harness.reviewLabelGateway.removed).toEqual([]);
+      expect(harness.reviewLabelGateway.removed.map((entry) => entry.label)).toContain(
+        REVIEW_IN_PROGRESS_LABEL,
+      );
     });
   });
 
@@ -531,6 +533,7 @@ describe('executeReview', () => {
 
       expect(result.status).toBe('completed');
       expect(harness.reviewLabelGateway.added.map((entry) => entry.label)).toEqual([
+        REVIEW_IN_PROGRESS_LABEL,
         REVIEW_DONE_LABEL,
       ]);
     });


### PR DESCRIPTION
## Summary

Follow-up reviews now run the same platform-label lifecycle as initial reviews:

1. the stale `review-done` is removed
2. `review-in-progress` is ensured then applied — before Claude is invoked
3. `review-done` is applied on completion
4. `review-in-progress` is cleared on every terminal state (`completed`, `cancelled`, `failed`, and an unexpected throw)

Before this, spec 221 scoped the in-progress label to initial reviews only, so a follow-up kept `review-done` visible for its whole duration with no in-flight signal — the blind spot spec 221 was written to close, still open on the path where the author has just pushed and is waiting.

## Implementation

The `if (input.isFollowup) return runAndMarkDone(...)` early return in `executeReview.usecase.ts` was removed, so both paths go through `markReviewInProgress` → `try/finally` → `clearReviewInProgress`. No gateway, use case, label, or wiring was added — `MarkReviewInProgressUseCase` already dropped the stale `review-done`, so the follow-up path inherited the never-both-labels invariant for free.

Specs 221 and 222 carry strike-through notes on the rules superseded here.

## Spec

- [docs/specs/224-followup-review-labels.md](https://github.com/DGouron/review-flow/blob/feat/224-followup-review-labels/docs/specs/224-followup-review-labels.md)
- [docs/reports/224-followup-review-labels.report.md](https://github.com/DGouron/review-flow/blob/feat/224-followup-review-labels/docs/reports/224-followup-review-labels.report.md)

## Test plan

- New acceptance suite `224-followup-review-labels.acceptance.test.ts` — 7 tests: both platforms at start, the completed sequence, the three terminal states, and the best-effort guarantee.
- Follow-up expectations of the spec 221 / 222 acceptance suites and of `executeReview.usecase.test.ts` flipped to the shared lifecycle.
- `yarn verify` green: typecheck, lint, format, 4413 tests / 522 files.

Label command sequences are asserted at the CLI-string level for both `gh` and `glab`; they were not exercised against a live platform (same caveat as spec 221).

🤖 Generated with [Claude Code](https://claude.com/claude-code)