### PR TITLE
fix: keep the daemon alive and stop requiring unused platform CLIs

### DIFF
--- a/src/main/commands/start.command.ts
+++ b/src/main/commands/start.command.ts
@@ -88,25 +88,27 @@ export function executeStart(
   startForeground();
 }
 
+function loadStartupInfo(): { enabledPlatforms: Array<'gitlab' | 'github'>; defaultPort: number } {
+  try {
+    const config = loadConfig();
+    const enabledPlatforms: Array<'gitlab' | 'github'> = [
+      ...new Set(config.repositories.filter((r) => r.enabled).map((r) => r.platform)),
+    ];
+    return { enabledPlatforms, defaultPort: config.server.port };
+  } catch {
+    return { enabledPlatforms: [], defaultPort: 3000 };
+  }
+}
+
 export function createStartDependencies(pidDeps: PidFileDeps): StartDependencies {
   return {
-    validateDependencies,
+    validateDependencies: () => validateDependencies(loadStartupInfo().enabledPlatforms),
     startServer: (port) => startServer({ portOverride: port }),
     exit: process.exit,
     error: console.error,
     log: console.log,
     startDaemonDeps: { ...pidDeps, spawnDaemon },
-    loadStartupInfo: () => {
-      try {
-        const config = loadConfig();
-        const enabledPlatforms: Array<'gitlab' | 'github'> = [
-          ...new Set(config.repositories.filter((r) => r.enabled).map((r) => r.platform)),
-        ];
-        return { enabledPlatforms, defaultPort: config.server.port };
-      } catch {
-        return { enabledPlatforms: [], defaultPort: 3000 };
-      }
-    },
+    loadStartupInfo,
     openInBrowser,
   };
 }

--- a/src/modules/supervisor-management/interface-adapters/gateways/supervisor.cli.gateway.ts
+++ b/src/modules/supervisor-management/interface-adapters/gateways/supervisor.cli.gateway.ts
@@ -56,14 +56,33 @@ export function createDefaultSupervisorProbe(): SupervisorProcessProbe {
     });
 }
 
-export function createDefaultSupervisorSpawner(): SupervisorProcessSpawner {
+export interface SupervisorChildProcess {
+  pid?: number | undefined;
+  unref: () => void;
+  on: (event: 'error', listener: (error: Error) => void) => unknown;
+}
+
+export type SupervisorProcessLauncher = () => SupervisorChildProcess;
+
+const launchSupervisorProcess: SupervisorProcessLauncher = () =>
+  spawn('claude', ['agents'], {
+    detached: true,
+    stdio: 'ignore',
+    cwd: process.env.HOME ?? '/',
+  });
+
+/**
+ * `spawn` reports a missing binary through an asynchronous 'error' event, not a throw, and an
+ * unhandled 'error' event takes the whole daemon down. The supervisor is optional: a failed
+ * launch must be reported through the returned result, never kill the review server.
+ */
+export function createDefaultSupervisorSpawner(
+  launch: SupervisorProcessLauncher = launchSupervisorProcess,
+): SupervisorProcessSpawner {
   return () => {
     try {
-      const child = spawn('claude', ['agents'], {
-        detached: true,
-        stdio: 'ignore',
-        cwd: process.env.HOME ?? '/',
-      });
+      const child = launch();
+      child.on('error', () => {});
       child.unref();
       return { pid: child.pid ?? null, error: null };
     } catch (error) {

--- a/src/shared/services/dependencyChecker.ts
+++ b/src/shared/services/dependencyChecker.ts
@@ -8,23 +8,38 @@ interface DependencyInfo {
 
 type CommandExecutor = (command: string, options?: object) => Buffer | string;
 
-const REQUIRED_DEPENDENCIES: DependencyInfo[] = [
-  {
-    name: 'Claude Code CLI',
-    command: 'claude --version',
-    installUrl: 'https://docs.anthropic.com/en/docs/claude-code/overview',
-  },
-  {
+type Platform = 'gitlab' | 'github';
+
+const CLAUDE_DEPENDENCY: DependencyInfo = {
+  name: 'Claude Code CLI',
+  command: 'claude --version',
+  installUrl: 'https://docs.anthropic.com/en/docs/claude-code/overview',
+};
+
+const PLATFORM_DEPENDENCIES: Record<Platform, DependencyInfo> = {
+  gitlab: {
     name: 'GitLab CLI (glab)',
     command: 'glab version',
     installUrl: 'https://gitlab.com/gitlab-org/cli#installation',
   },
-  {
+  github: {
     name: 'GitHub CLI (gh)',
     command: 'gh --version',
     installUrl: 'https://cli.github.com/',
   },
-];
+};
+
+function requiredDependencies(platforms: Platform[]): DependencyInfo[] {
+  const required = [CLAUDE_DEPENDENCY];
+
+  for (const platform of ['gitlab', 'github'] as const) {
+    if (platforms.includes(platform)) {
+      required.push(PLATFORM_DEPENDENCIES[platform]);
+    }
+  }
+
+  return required;
+}
 
 export function checkDependency(
   dep: { name: string; command: string },
@@ -38,9 +53,16 @@ export function checkDependency(
   }
 }
 
-export function validateDependencies(executor: CommandExecutor = execSync): DependencyInfo[] {
+/**
+ * A GitHub-only install must never be blocked by a missing `glab`, nor a GitLab-only install
+ * by a missing `gh`: only the CLIs of the platforms actually configured are required.
+ */
+export function validateDependencies(
+  platforms: Platform[],
+  executor: CommandExecutor = execSync,
+): DependencyInfo[] {
   const missing: DependencyInfo[] = [];
-  for (const dep of REQUIRED_DEPENDENCIES) {
+  for (const dep of requiredDependencies(platforms)) {
     if (!checkDependency(dep, executor)) {
       missing.push(dep);
     }

--- a/src/tests/units/modules/supervisor-management/gateways/supervisor.cli.gateway.test.ts
+++ b/src/tests/units/modules/supervisor-management/gateways/supervisor.cli.gateway.test.ts
@@ -1,6 +1,11 @@
+import { EventEmitter } from 'node:events';
+
 import { describe, it, expect } from 'vitest';
 
-import { SupervisorCliGateway } from '@/modules/supervisor-management/interface-adapters/gateways/supervisor.cli.gateway.js';
+import {
+  SupervisorCliGateway,
+  createDefaultSupervisorSpawner,
+} from '@/modules/supervisor-management/interface-adapters/gateways/supervisor.cli.gateway.js';
 import type {
   SupervisorProcessProbe,
   SupervisorProcessSpawner,
@@ -118,5 +123,40 @@ describe('SupervisorCliGateway.spawnDetached', () => {
 
     expect(result.state).toBe('failed');
     expect(result.reason).toMatch(/pid/i);
+  });
+});
+
+describe('createDefaultSupervisorSpawner', () => {
+  function fakeChild(pid: number | undefined): EventEmitter & {
+    pid: number | undefined;
+    unref: () => void;
+  } {
+    const child = Object.assign(new EventEmitter(), { pid, unref: () => {} });
+    return child;
+  }
+
+  it('reports the pid of the spawned supervisor', () => {
+    const child = fakeChild(4242);
+    const spawner = createDefaultSupervisorSpawner(() => child);
+
+    expect(spawner()).toEqual({ pid: 4242, error: null });
+  });
+
+  it('survives an asynchronous spawn error instead of crashing the daemon', () => {
+    const child = fakeChild(undefined);
+    const spawner = createDefaultSupervisorSpawner(() => child);
+
+    const result = spawner();
+
+    expect(result.pid).toBeNull();
+    expect(() => child.emit('error', new Error('spawn claude ENOENT'))).not.toThrow();
+  });
+
+  it('reports a synchronous spawn failure as an error', () => {
+    const spawner = createDefaultSupervisorSpawner(() => {
+      throw new Error('boom');
+    });
+
+    expect(spawner()).toEqual({ pid: null, error: 'boom' });
   });
 });

--- a/src/tests/units/shared/services/dependencyChecker.test.ts
+++ b/src/tests/units/shared/services/dependencyChecker.test.ts
@@ -5,6 +5,15 @@ import {
   validateDependencies,
 } from '../../../../shared/services/dependencyChecker.js';
 
+function executorMissing(...absentCommands: string[]) {
+  return (command: string) => {
+    if (absentCommands.some((absent) => command.startsWith(absent))) {
+      throw new Error('command not found');
+    }
+    return Buffer.from('1.0.0');
+  };
+}
+
 describe('dependencyChecker', () => {
   describe('checkDependency', () => {
     it('should return true when command succeeds', () => {
@@ -27,22 +36,59 @@ describe('dependencyChecker', () => {
   });
 
   describe('validateDependencies', () => {
-    it('should return missing dependencies when commands fail', () => {
-      const fakeExecutor = () => {
-        throw new Error('not found');
-      };
+    it('should not require glab when only github repositories are configured', () => {
+      const result = validateDependencies(['github'], executorMissing('glab'));
 
-      const result = validateDependencies(fakeExecutor);
+      expect(result).toEqual([]);
+    });
 
-      expect(result.length).toBeGreaterThan(0);
-      expect(result[0]).toHaveProperty('name');
+    it('should not require gh when only gitlab repositories are configured', () => {
+      const result = validateDependencies(['gitlab'], executorMissing('gh '));
+
+      expect(result).toEqual([]);
+    });
+
+    it('should require gh when a github repository is configured', () => {
+      const result = validateDependencies(['github'], executorMissing('gh '));
+
+      expect(result.map((dependency) => dependency.name)).toEqual(['GitHub CLI (gh)']);
+    });
+
+    it('should require glab when a gitlab repository is configured', () => {
+      const result = validateDependencies(['gitlab'], executorMissing('glab'));
+
+      expect(result.map((dependency) => dependency.name)).toEqual(['GitLab CLI (glab)']);
+    });
+
+    it('should require both platform CLIs when both platforms are configured', () => {
+      const result = validateDependencies(['github', 'gitlab'], executorMissing('gh ', 'glab'));
+
+      expect(result.map((dependency) => dependency.name)).toEqual([
+        'GitLab CLI (glab)',
+        'GitHub CLI (gh)',
+      ]);
+    });
+
+    it('should always require the Claude Code CLI, whatever the platforms', () => {
+      const result = validateDependencies([], executorMissing('claude'));
+
+      expect(result.map((dependency) => dependency.name)).toEqual(['Claude Code CLI']);
+    });
+
+    it('should require no platform CLI when no repository is configured', () => {
+      const result = validateDependencies([], executorMissing('glab', 'gh '));
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return the install url of each missing dependency', () => {
+      const result = validateDependencies(['github'], executorMissing('gh '));
+
       expect(result[0]).toHaveProperty('installUrl');
     });
 
-    it('should return empty array when all dependencies found', () => {
-      const fakeExecutor = () => Buffer.from('1.0.0');
-
-      const result = validateDependencies(fakeExecutor);
+    it('should return empty array when all required dependencies are found', () => {
+      const result = validateDependencies(['github', 'gitlab'], () => Buffer.from('1.0.0'));
 
       expect(result).toEqual([]);
     });


### PR DESCRIPTION
Closes #383, closes #384.

Both surfaced from the same incident this morning: the webhook endpoint answered `502 Bad Gateway` because the daemon was dead and could not be restarted.

## #383 — the daemon died

While the `claude` binary was being replaced by an update, the supervisor probe failed and the respawn hit `ENOENT`:

```
{"reason":"claude agents --json exited with code -1","msg":"Claude agents supervisor went down — attempting respawn"}
{"reason":"spawned process returned no pid","msg":"Failed to spawn Claude agents supervisor"}
node:events:487  throw er; // Unhandled 'error' event
Error: spawn claude ENOENT  { syscall: 'spawn claude', path: 'claude', spawnargs: ['agents'] }
```

`spawn` reports a missing binary through an **asynchronous** `'error'` event, so the surrounding `try/catch` never fired, and an `'error'` event with no listener makes Node throw — killing the whole process. `createDefaultSupervisorProbe` already attached `child.on('error', …)`; the spawner did not.

The supervisor is optional and its failure is already modelled in the return value. The launcher is now injectable (`SupervisorProcessLauncher`) and the spawner attaches the listener before `unref()`, so a failed launch returns `{ pid: null }` and the review server keeps serving webhooks.

## #384 — and could not be restarted

`reviewflow start` then refused to boot:

```
Missing dependencies:
  - GitLab CLI (glab)
```

on a configuration whose only repository is on GitHub. `validateDependencies` required the three CLIs unconditionally, while `createStartDependencies` already computes `enabledPlatforms` from the config and `configLoader.ts:144` resolves each repository's platform at load time.

`validateDependencies(platforms, executor?)` now requires the Claude Code CLI always, `glab` only when a GitLab repository is enabled, and `gh` only when a GitHub one is. A GitHub profile is never blocked by GitLab, and the reverse holds.

## Tests

- `supervisor.cli.gateway.test.ts`: the spawner reports the pid, survives an asynchronous spawn error instead of crashing, and still reports a synchronous failure.
- `dependencyChecker.test.ts`: rewritten around the platform axis — GitHub-only without `glab` is fine, GitLab-only without `gh` is fine, each platform requires its own CLI, the Claude CLI is required whatever the platforms, and an empty configuration requires no platform CLI.

`yarn verify`: 4446 tests pass, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
